### PR TITLE
Us002a remove survey database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>surveysvc-api</artifactId>
-      <version>10.49.1</version>
+      <version>10.49.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,13 +24,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>collectionexercisesvc-api</artifactId>
-      <version>10.49.3-SNAPSHOT</version>
+      <version>10.49.3</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>surveysvc-api</artifactId>
-      <version>10.49.3-SNAPSHOT</version>
+      <version>10.49.2</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.collection.exercise.client;
 
+import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 
@@ -17,6 +18,6 @@ public interface SampleSvcClient {
    *          units.
    * @return the total number of sample units in the collection exercise.
    */
-  SampleUnitsRequestDTO requestSampleUnits(CollectionExercise exercise);
+  SampleUnitsRequestDTO requestSampleUnits(CollectionExercise exercise) throws CTPException;
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SurveySvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SurveySvcClient.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.springframework.web.client.RestClientException;
 
+import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
 import uk.gov.ons.response.survey.representation.SurveyClassifierDTO;
 import uk.gov.ons.response.survey.representation.SurveyClassifierTypeDTO;
 
@@ -12,7 +13,7 @@ import uk.gov.ons.response.survey.representation.SurveyClassifierTypeDTO;
  * Service responsible for making client calls to the Survey service
  *
  */
-public interface SurveySvcClient {
+public interface SurveySvcClient extends SurveyService {
 
   /**
    * Get classifier type selectors for Survey by UUID.

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
@@ -19,8 +19,10 @@ import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkRepository;
+import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
 import uk.gov.ons.ctp.response.sample.representation.CollectionExerciseJobCreationRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,6 +53,9 @@ public class SampleSvcRestClientImpl implements SampleSvcClient {
   @Autowired
   private ObjectMapper objectMapper;
 
+  @Autowired
+  private SurveyService surveyService;
+
   @Retryable(value = {RestClientException.class}, maxAttemptsExpression = "#{${retries.maxAttempts}}",
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
@@ -65,9 +70,11 @@ public class SampleSvcRestClientImpl implements SampleSvcClient {
       sampleSummaryUUIDList.add(samplelink.getSampleSummaryId());
     }
 
+    SurveyDTO surveyDto = this.surveyService.findSurvey(exercise.getSurveyUuid());
+
     CollectionExerciseJobCreationRequestDTO requestDTO = new CollectionExerciseJobCreationRequestDTO();
     requestDTO.setCollectionExerciseId(exercise.getId());
-    requestDTO.setSurveyRef(exercise.getSurvey().getSurveyRef());
+    requestDTO.setSurveyRef(surveyDto.getSurveyRef());
     requestDTO.setExerciseDateTime(exercise.getScheduledStartDateTime());
     requestDTO.setSampleSummaryUUIDList(sampleSummaryUUIDList);
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +33,8 @@ import java.util.UUID;
  */
 @Component
 @Slf4j
+@Qualifier("restClient")
+@Primary
 public class SurveySvcRestClientImpl implements SurveySvcClient {
 
   @Autowired

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
@@ -17,8 +17,10 @@ import org.springframework.web.util.UriComponents;
 import uk.gov.ons.ctp.common.rest.RestUtility;
 import uk.gov.ons.ctp.response.collection.exercise.client.SurveySvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Survey;
 import uk.gov.ons.response.survey.representation.SurveyClassifierDTO;
 import uk.gov.ons.response.survey.representation.SurveyClassifierTypeDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 import java.io.IOException;
 import java.util.List;
@@ -100,4 +102,29 @@ public class SurveySvcRestClientImpl implements SurveySvcClient {
     }
     return result;
   }
+
+  @Override
+  public SurveyDTO findSurvey(UUID surveyId) {
+    UriComponents uriComponents = restUtility.createUriComponents(
+            appConfig.getSurveySvc().getSurveyDetailPath(), null, surveyId);
+
+    HttpEntity<?> httpEntity = restUtility.createHttpEntity(null);
+
+    log.debug("about to get to the Survey SVC with surveyId {}", surveyId);
+    ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
+            String.class);
+
+    SurveyDTO result = null;
+    if (responseEntity != null && responseEntity.getStatusCode().is2xxSuccessful()) {
+      String responseBody = responseEntity.getBody();
+      try {
+        result = objectMapper.readValue(responseBody, SurveyDTO.class);
+      } catch (IOException e) {
+        String msg = String.format("cause = %s - message = %s", e.getCause(), e.getMessage());
+        log.error(msg);
+      }
+    }
+    return result;
+  }
+
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
+import org.springframework.security.access.method.P;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -113,21 +114,25 @@ public class SurveySvcRestClientImpl implements SurveySvcClient {
 
     HttpEntity<?> httpEntity = restUtility.createHttpEntity(null);
 
-    log.debug("about to get to the Survey SVC with surveyId {}", surveyId);
-    ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
-            String.class);
+    try {
+      log.debug("about to get to the Survey SVC with surveyId {}", surveyId);
+      ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
+              String.class);
 
-    SurveyDTO result = null;
-    if (responseEntity != null && responseEntity.getStatusCode().is2xxSuccessful()) {
-      String responseBody = responseEntity.getBody();
-      try {
-        result = objectMapper.readValue(responseBody, SurveyDTO.class);
-      } catch (IOException e) {
-        String msg = String.format("cause = %s - message = %s", e.getCause(), e.getMessage());
-        log.error(msg);
+      SurveyDTO result = null;
+      if (responseEntity != null && responseEntity.getStatusCode().is2xxSuccessful()) {
+        String responseBody = responseEntity.getBody();
+        try {
+          result = objectMapper.readValue(responseBody, SurveyDTO.class);
+        } catch (IOException e) {
+          String msg = String.format("cause = %s - message = %s", e.getCause(), e.getMessage());
+          log.error(msg);
+        }
       }
+      return result;
+    } catch(RestClientException e){
+      return null;
     }
-    return result;
   }
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SurveySvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SurveySvc.java
@@ -16,4 +16,5 @@ public class SurveySvc {
   private String requestClassifierTypesListPath;
   private String requestClassifierTypesPath;
   private String surveyDetailPath;
+  private String surveyRefPath;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SurveySvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SurveySvc.java
@@ -15,4 +15,5 @@ public class SurveySvc {
   private RestUtilityConfig connectionConfig;
   private String requestClassifierTypesListPath;
   private String requestClassifierTypesPath;
+  private String surveyDetailPath;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributor.java
@@ -148,7 +148,7 @@ public class SampleUnitDistributor {
         parent.setCollectionInstrumentId(sampleUnit.getCollectionInstrumentId().toString());
         actionPlanId = collectionExerciseRepo
             .getActiveActionPlanId(exercise.getExercisePK(), sampleUnit.getSampleUnitType().name(),
-                exercise.getSurvey().getSurveyPK());
+                exercise.getSurveyUuid());
       } else {
         SampleUnitChild child = new SampleUnitChild();
         child.setSampleUnitRef(sampleUnit.getSampleUnitRef());
@@ -158,7 +158,7 @@ public class SampleUnitDistributor {
         child.setActionPlanId(
             collectionExerciseRepo
                 .getActiveActionPlanId(exercise.getExercisePK(), sampleUnit.getSampleUnitType().name(),
-                    exercise.getSurvey().getSurveyPK()));
+                    exercise.getSurveyUuid()));
         children.add(child);
       }
     }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CaseTypeDefault.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CaseTypeDefault.java
@@ -27,25 +27,17 @@ public class CaseTypeDefault implements CaseType {
   @Column(name = "casetypedefaultpk")
   private Integer caseTypeDefaultPK;
 
-  @JoinColumn(name = "surveyfk", referencedColumnName = "surveypk")
-  @Column(name = "surveyfk")
-  private Integer surveyFK;
+//  @JoinColumn(name = "surveyfk", referencedColumnName = "surveypk")
+//  @Column(name = "surveyfk")
+//  private Integer surveyFK;
+
+  @Column(name="survey_uuid")
+  private UUID surveyId;
 
   @Column(name = "actionplanid")
   private UUID actionPlanId;
 
   @Column(name = "sampleunittypefk")
   private String sampleUnitTypeFK;
-
-  @Override
-  public String toString() {
-    return "CaseTypeDefault{"
-            + "sampleUnitTypeFK='" + sampleUnitTypeFK + '\''
-            + ", actionPlanId=" + actionPlanId
-            + ", caseTypeDefaultPK=" + caseTypeDefaultPK
-            + ", surveyFK=" + surveyFK
-            + '}';
-  }
-
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CaseTypeDefault.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CaseTypeDefault.java
@@ -27,10 +27,6 @@ public class CaseTypeDefault implements CaseType {
   @Column(name = "casetypedefaultpk")
   private Integer caseTypeDefaultPK;
 
-//  @JoinColumn(name = "surveyfk", referencedColumnName = "surveypk")
-//  @Column(name = "surveyfk")
-//  private Integer surveyFK;
-
   @Column(name="survey_uuid")
   private UUID surveyId;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CollectionExercise.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CollectionExercise.java
@@ -96,4 +96,7 @@ public class CollectionExercise {
 
   @Column(name = "deleted")
   private Boolean deleted;
+
+  @Column(name="survey_uuid")
+  private UUID surveyUuid;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CollectionExercise.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CollectionExercise.java
@@ -42,9 +42,9 @@ public class CollectionExercise {
   @Column(name = "exercisepk")
   private Integer exercisePK;
 
-  @ManyToOne
-  @JoinColumn(name = "surveyfk", referencedColumnName = "surveypk")
-  private Survey survey;
+//  @ManyToOne
+//  @JoinColumn(name = "surveyfk", referencedColumnName = "surveypk")
+//  private Survey survey;
 
   private String name;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CollectionExercise.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CollectionExercise.java
@@ -42,10 +42,6 @@ public class CollectionExercise {
   @Column(name = "exercisepk")
   private Integer exercisePK;
 
-//  @ManyToOne
-//  @JoinColumn(name = "surveyfk", referencedColumnName = "surveypk")
-//  private Survey survey;
-
   private String name;
 
   @Column(name = "actualexecutiondatetime")

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -171,7 +171,7 @@ public class CollectionExerciseEndpoint {
    * @param cv a constraint violation
    * @return a human readable message
    */
-  private static String getMessageForConstraintViolation(ConstraintViolation<?> cv) {
+  private static String getMessageForConstraintViolation(final ConstraintViolation<?> cv) {
     return cv.getPropertyPath() + " " + cv.getMessage();
   }
 
@@ -182,7 +182,7 @@ public class CollectionExerciseEndpoint {
    * @param collexDto The collection exercise data to validate
    * @throws CTPException thrown if constraint violation
    */
-  private void validateConstraints(CollectionExerciseDTO collexDto) throws CTPException {
+  private void validateConstraints(final CollectionExerciseDTO collexDto) throws CTPException {
     javax.validation.Validator validator = VALIDATOR_FACTORY.getValidator();
     Set<ConstraintViolation<CollectionExerciseDTO>> result = validator.validate(collexDto,
             CollectionExerciseDTO.PatchValidation.class);
@@ -205,7 +205,7 @@ public class CollectionExerciseEndpoint {
    * @return 200 if all is ok, 400 for bad request, 409 for conflict
    * @throws CTPException thrown if constraint violation etc
    */
-  private ResponseEntity<?> patchCollectionExercise(UUID id, CollectionExerciseDTO collexDto) throws CTPException {
+  private ResponseEntity<?> patchCollectionExercise(final UUID id, final CollectionExerciseDTO collexDto) throws CTPException {
     validateConstraints(collexDto);
 
     this.collectionExerciseService.patchCollectionExercise(id, collexDto);
@@ -272,6 +272,7 @@ public class CollectionExerciseEndpoint {
   /**
    * PUT request to update a collection exercise userDescription
    * @param id Collection exercise Id to update
+   * @param surveyId The new survey to associate with this collection exercise
    * @throws CTPException on resource not found
    * @return 200 if all is ok, 400 for bad request, 409 for conflict
    */
@@ -345,6 +346,7 @@ public class CollectionExerciseEndpoint {
    * DELETE request to delete a collection exercise
    * @param id Collection exercise Id to delete
    * @throws CTPException on resource not found
+   * @return the collection exercise that was to be deleted
    */
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
   public ResponseEntity<CollectionExercise> deleteCollectionExercise(@PathVariable("id") final UUID id)

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -42,6 +42,7 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSumm
 import uk.gov.ons.ctp.response.collection.exercise.representation.LinkedSampleSummariesDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 import static java.util.stream.Collectors.joining;
 
@@ -83,7 +84,7 @@ public class CollectionExerciseEndpoint {
   public ResponseEntity<List<CollectionExerciseSummaryDTO>> getCollectionExercisesForSurvey(
       @PathVariable("id") final UUID id) throws CTPException {
 
-    Survey survey = surveyService.findSurvey(id);
+    SurveyDTO survey = surveyService.findSurvey(id);
 
     List<CollectionExerciseSummaryDTO> collectionExerciseSummaryDTOList;
 
@@ -308,7 +309,7 @@ public class CollectionExerciseEndpoint {
     if (StringUtils.isBlank(surveyId)) {
       throw new CTPException(CTPException.Fault.BAD_REQUEST, "No survey specified");
     } else {
-      Survey survey = this.surveyService.findSurvey(UUID.fromString(collex.getSurveyId()));
+      SurveyDTO survey = this.surveyService.findSurvey(UUID.fromString(collex.getSurveyId()));
 
       if (survey == null) {
           throw new CTPException(CTPException.Fault.BAD_REQUEST, "Invalid survey: " + surveyId);
@@ -444,11 +445,11 @@ public class CollectionExerciseEndpoint {
     Collection<CaseType> caseTypeList = collectionExerciseService.getCaseTypesList(collectionExercise);
    List<CaseTypeDTO> caseTypeDTOList = mapperFacade.mapAsList(caseTypeList, CaseTypeDTO.class);
 
-    Survey survey = surveyService.findSurveyByFK(collectionExercise.getSurvey().getSurveyPK());
+    SurveyDTO survey = surveyService.findSurvey(collectionExercise.getSurveyUuid());
 
     CollectionExerciseDTO collectionExerciseDTO = mapperFacade.map(collectionExercise, CollectionExerciseDTO.class);
     collectionExerciseDTO.setCaseTypes(caseTypeDTOList);
-    collectionExerciseDTO.setSurveyId(survey.getId().toString());
+    collectionExerciseDTO.setSurveyId(survey.getId());
     return collectionExerciseDTO;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -443,13 +443,14 @@ public class CollectionExerciseEndpoint {
    */
   private CollectionExerciseDTO addCaseTypesandSurveyId(CollectionExercise collectionExercise) {
     Collection<CaseType> caseTypeList = collectionExerciseService.getCaseTypesList(collectionExercise);
-   List<CaseTypeDTO> caseTypeDTOList = mapperFacade.mapAsList(caseTypeList, CaseTypeDTO.class);
-
-    SurveyDTO survey = surveyService.findSurvey(collectionExercise.getSurveyUuid());
+    List<CaseTypeDTO> caseTypeDTOList = mapperFacade.mapAsList(caseTypeList, CaseTypeDTO.class);
 
     CollectionExerciseDTO collectionExerciseDTO = mapperFacade.map(collectionExercise, CollectionExerciseDTO.class);
     collectionExerciseDTO.setCaseTypes(caseTypeDTOList);
-    collectionExerciseDTO.setSurveyId(survey.getId());
+    // NOTE: this method used to fail (NPE) if the survey did not exist in the local database.  Now the survey id
+    // is not validated and passed on verbatim
+    collectionExerciseDTO.setSurveyId(collectionExercise.getSurveyUuid().toString());
+
     return collectionExerciseDTO;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CaseTypeDefaultRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CaseTypeDefaultRepository.java
@@ -13,12 +13,12 @@ import java.util.UUID;
 public interface CaseTypeDefaultRepository extends JpaRepository<CaseTypeDefault, UUID> {
 
   /**
-   * Query repository for case type defaults associated to survey pk.
+   * Query repository for case type defaults associated to survey uuid.
    *
-   * @param surveyPK survey pk to which the Case Type Default is associated.
+   * @param surveyUuid survey uuid to which the Case Type Default is associated.
    * @return list of associated casetypes.
    */
-  List<CaseTypeDefault> findBySurveyFK(Integer surveyPK);
+  List<CaseTypeDefault> findBySurveyUuid(UUID surveyUuid);
 
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CaseTypeDefaultRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CaseTypeDefaultRepository.java
@@ -18,7 +18,7 @@ public interface CaseTypeDefaultRepository extends JpaRepository<CaseTypeDefault
    * @param surveyUuid survey uuid to which the Case Type Default is associated.
    * @return list of associated casetypes.
    */
-  List<CaseTypeDefault> findBySurveyUuid(UUID surveyUuid);
+  List<CaseTypeDefault> findBySurveyId(UUID surveyUuid);
 
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
@@ -24,30 +24,15 @@ public interface CollectionExerciseRepository extends JpaRepository<CollectionEx
   CollectionExercise findOneById(UUID id);
 
   /**
-   * Query repository for list of collection exercises associated to surveyfk.
-   *
-   * @param surveyfk surveyfk to which collection exercises are associated.
-   * @return List of collection exercises.
-   */
-  List<CollectionExercise> findBySurveySurveyPK(Integer surveyfk);
-
-  /**
    * Query repository for collection exercise with given period and survey
    *
    * @param exerciseRef collection exercise period
-   * @param surveyfk surveyfk to which collection exercises are associated.
+   * @param surveyUuid surveyfk to which collection exercises are associated.
    * @return List of collection exercises.
    */
-  List<CollectionExercise> findByExerciseRefAndSurveySurveyPK(String exerciseRef, Integer surveyfk);
+  List<CollectionExercise> findByExerciseRefAndSurveyUuid(String exerciseRef, UUID surveyUuid);
 
-  /**
-   * Query repository for collection exercise with given period and survey uuid
-   *
-   * @param exerciseRef collection exercise period
-   * @param surveyUuid uuid to which collection exercises are associated.
-   * @return List of collection exercises.
-   */
-  List<CollectionExercise> findByExerciseRefAndSurveyId(String exerciseRef, UUID surveyUuid);
+  List<CollectionExercise> findBySurveyUuid(UUID surveyUuid);
 
   /**
    * Query repository for list of collection exercises associated with a certain

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
@@ -49,7 +49,7 @@ public interface CollectionExerciseRepository extends JpaRepository<CollectionEx
    *
    * @param exercisefk of CollectionExercise.
    * @param sampleunittypefk of SampleUnitType.
-   * @param surveyfk of Survey.
+   * @param surveyUuid uuid of Survey.
    * @return ActiveActionPlanId
    */
   @Query(value = "SELECT CASE WHEN r.actionplanid IS NULL THEN CAST(df.actionplanid AS VARCHAR) ELSE "
@@ -59,5 +59,5 @@ public interface CollectionExerciseRepository extends JpaRepository<CollectionEx
           + "AND d.sampleunittypefk = :p_sampleunittypefk) df ON r.sampleunittypeFK = df.sampleunittypeFK;",
           nativeQuery = true)
   String getActiveActionPlanId(@Param("p_exercisefk") Integer exercisefk,
-      @Param("p_sampleunittypefk") String sampleunittypefk, @Param("p_surveyfk") Integer surveyfk);
+      @Param("p_sampleunittypefk") String sampleunittypefk, @Param("p_surveyUuid") UUID surveyUuid);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
@@ -49,15 +49,15 @@ public interface CollectionExerciseRepository extends JpaRepository<CollectionEx
    *
    * @param exercisefk of CollectionExercise.
    * @param sampleunittypefk of SampleUnitType.
-   * @param surveyUuid uuid of Survey.
+   * @param surveyuuid uuid of Survey.
    * @return ActiveActionPlanId
    */
   @Query(value = "SELECT CASE WHEN r.actionplanid IS NULL THEN CAST(df.actionplanid AS VARCHAR) ELSE "
           + "CAST(r.actionplanid AS VARCHAR) END as to_use FROM (SELECT o.* FROM collectionexercise.casetypeoverride o "
           + "WHERE o.exercisefk = :p_exercisefk AND o.sampleunittypefk = :p_sampleunittypefk) r "
-          + "RIGHT OUTER JOIN (SELECT d.* FROM collectionexercise.casetypedefault d WHERE d.surveyfk = :p_surveyfk "
+          + "RIGHT OUTER JOIN (SELECT d.* FROM collectionexercise.casetypedefault d WHERE d.survey_uuid = :p_surveyuuid "
           + "AND d.sampleunittypefk = :p_sampleunittypefk) df ON r.sampleunittypeFK = df.sampleunittypeFK;",
           nativeQuery = true)
   String getActiveActionPlanId(@Param("p_exercisefk") Integer exercisefk,
-      @Param("p_sampleunittypefk") String sampleunittypefk, @Param("p_surveyUuid") UUID surveyUuid);
+      @Param("p_sampleunittypefk") String sampleunittypefk, @Param("p_surveyuuid") UUID surveyuuid);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SurveyRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SurveyRepository.java
@@ -19,4 +19,11 @@ public interface SurveyRepository extends JpaRepository<Survey, Integer> {
      */
     Survey findById(UUID id);
 
+    /**
+     * Query reporitory for survey by survey ref
+     * @param surveyRef survey ref to find
+     * @return Survey object
+     */
+    Survey findBySurveyRef(String surveyRef);
+
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
@@ -100,6 +100,7 @@ public interface CollectionExerciseService {
   /**
    * Update a collection exercise
    * @param collex the updated collection exercise
+   * @param id the id of the collection exercise to update
    * @return the updated CollectionExercise object
    */
   CollectionExercise updateCollectionExercise(UUID id, CollectionExerciseDTO collex) throws CTPException;
@@ -109,6 +110,7 @@ public interface CollectionExerciseService {
    * @param id the id of the collection exercise to patch
    * @param collex the patch data
    * @return the patched CollectionExercise object
+   * @throws CTPException thrown if error occurs
    */
   CollectionExercise patchCollectionExercise(UUID id, CollectionExerciseDTO collex) throws CTPException;
 
@@ -116,6 +118,7 @@ public interface CollectionExerciseService {
    * Delete a collection exercise
    * @param id the id of the collection exercise to delete
    * @return the updated CollectionExercise object
+   * @throws CTPException thrown if error occurs
    */
   CollectionExercise deleteCollectionExercise(UUID id) throws CTPException;
 
@@ -123,6 +126,7 @@ public interface CollectionExerciseService {
    * Undelete a collection exercise
    * @param id the id of the collection exercise to delete
    * @return the updated CollectionExercise object
+   * @throws CTPException thrown if error occurs
    */
   CollectionExercise undeleteCollectionExercise(UUID id) throws CTPException;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
@@ -10,6 +10,7 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Survey;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /**
  * Service responsible for dealing with collection exercises
@@ -24,7 +25,7 @@ public interface CollectionExerciseService {
    * @param survey the survey for which to find collection exercises
    * @return the associated surveys.
    */
-  List<CollectionExercise> findCollectionExercisesForSurvey(Survey survey);
+  List<CollectionExercise> findCollectionExercisesForSurvey(SurveyDTO survey);
 
   /**
    * Find a collection exercise associated to a collection exercise Id from the
@@ -86,7 +87,7 @@ public interface CollectionExerciseService {
    * @param survey the survey the collection exercise is associated with
    * @return the collection exercise if it exists, null otherwise
    */
-  CollectionExercise  findCollectionExercise(String exerciseRef, Survey survey);
+  CollectionExercise  findCollectionExercise(String exerciseRef, SurveyDTO survey);
 
   /**
    * Gets collection exercise with given exerciseRef and survey uuid (should be no more than 1)

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SurveyService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SurveyService.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.service;
 
 import uk.gov.ons.ctp.response.collection.exercise.domain.Survey;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 import java.util.UUID;
 
@@ -16,14 +17,6 @@ public interface SurveyService {
    * @param id the survey Id for which to request survey.
    * @return the survey object
    */
-  Survey findSurvey(UUID id);
-
-  /**
-   * Request the delivery of survey from the Survey Service.
-   *
-   * @param surveyFK the survey FK for which to request survey.
-   * @return the survey object
-   */
-  Survey findSurveyByFK(int surveyFK);
+  SurveyDTO findSurvey(UUID id);
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SurveyService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SurveyService.java
@@ -19,4 +19,11 @@ public interface SurveyService {
    */
   SurveyDTO findSurvey(UUID id);
 
+  /**
+   * Request a survey by reference (the id the business use, e.g. 221 for BRES)
+   * @param surveyRef
+   * @return
+   */
+  SurveyDTO findSurveyByRef(String surveyRef);
+
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -22,7 +22,6 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeDefault;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
-import uk.gov.ons.ctp.response.collection.exercise.domain.Survey;
 import uk.gov.ons.ctp.response.collection.exercise.repository.CaseTypeDefaultRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.CaseTypeOverrideRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
@@ -79,7 +78,7 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
   @Override
   public Collection<CaseType> getCaseTypesList(CollectionExercise collectionExercise) {
 
-    List<CaseTypeDefault> caseTypeDefaultList = caseTypeDefaultRepo.findBySurveyUuid(collectionExercise.getSurveyUuid());
+    List<CaseTypeDefault> caseTypeDefaultList = caseTypeDefaultRepo.findBySurveyId(collectionExercise.getSurveyUuid());
 
     List<CaseTypeOverride> caseTypeOverrideList = caseTypeOverrideRepo
         .findByExerciseFK(collectionExercise.getExercisePK());

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -190,7 +190,7 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
           // If period/survey not supplied in patchData then this call will trivially return
           validateUniqueness(collex, proposedPeriod, proposedSurvey);
 
-          if (StringUtils.isBlank(patchData.getSurveyId()) == false) {
+          if (!StringUtils.isBlank(patchData.getSurveyId())) {
               UUID surveyId = UUID.fromString(patchData.getSurveyId());
 
               SurveyDTO survey = this.surveyService.findSurvey(surveyId);
@@ -203,13 +203,13 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
               }
           }
 
-          if (StringUtils.isBlank(patchData.getExerciseRef()) == false) {
+          if (!StringUtils.isBlank(patchData.getExerciseRef())) {
               collex.setExerciseRef(patchData.getExerciseRef());
           }
-          if (StringUtils.isBlank(patchData.getName()) == false) {
+          if (!StringUtils.isBlank(patchData.getName())) {
               collex.setName(patchData.getName());
           }
-          if (StringUtils.isBlank(patchData.getUserDescription()) == false) {
+          if (!StringUtils.isBlank(patchData.getUserDescription())) {
               collex.setUserDescription(patchData.getUserDescription());
           }
 
@@ -230,11 +230,11 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
      */
    private void validateUniqueness(CollectionExercise existing, String candidatePeriod, UUID candidateSurvey)
            throws CTPException {
-       if (existing.getSurveyUuid().equals(candidateSurvey) == false
-               || existing.getExerciseRef().equals(candidatePeriod) == false) {
+       if (!existing.getSurveyUuid().equals(candidateSurvey)
+               || !existing.getExerciseRef().equals(candidatePeriod)) {
            CollectionExercise otherExisting = findCollectionExercise(candidatePeriod, candidateSurvey);
 
-           if (otherExisting != null && otherExisting.getId().equals(existing.getId()) == false) {
+           if (otherExisting != null && !otherExisting.getId().equals(existing.getId())) {
                throw new CTPException(
                        CTPException.Fault.RESOURCE_VERSION_CONFLICT,
                        String.format("A collection exercise with period %s and id %s already exists.",

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -30,6 +30,7 @@ import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkReposito
 import uk.gov.ons.ctp.response.collection.exercise.repository.SurveyRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /**
  * The implementation of the SampleService
@@ -55,9 +56,8 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
   private SampleLinkRepository sampleLinkRepository;
 
   @Override
-  public List<CollectionExercise> findCollectionExercisesForSurvey(Survey survey) {
-
-    return collectRepo.findBySurveySurveyPK(survey.getSurveyPK());
+  public List<CollectionExercise> findCollectionExercisesForSurvey(SurveyDTO survey) {
+    return this.collectRepo.findBySurveyUuid(UUID.fromString(survey.getId()));
   }
 
   @Override
@@ -151,10 +151,10 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
   }
 
   @Override
-  public CollectionExercise findCollectionExercise(String exerciseRef, Survey survey) {
-      List<CollectionExercise> existing = this.collectRepo.findByExerciseRefAndSurveySurveyPK(
+  public CollectionExercise findCollectionExercise(String exerciseRef, SurveyDTO survey) {
+      List<CollectionExercise> existing = this.collectRepo.findByExerciseRefAndSurveyUuid(
               exerciseRef,
-              survey.getSurveyPK());
+              UUID.fromString(survey.getId()));
 
       switch (existing.size()) {
         case 0:
@@ -166,7 +166,7 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
 
    @Override
    public CollectionExercise findCollectionExercise(String exerciseRef, UUID surveyId) {
-      List<CollectionExercise> existing = this.collectRepo.findByExerciseRefAndSurveyId(exerciseRef, surveyId);
+      List<CollectionExercise> existing = this.collectRepo.findByExerciseRefAndSurveyUuid(exerciseRef, surveyId);
 
        switch (existing.size()) {
            case 0:

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -193,13 +193,14 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
           if (StringUtils.isBlank(patchData.getSurveyId()) == false) {
               UUID surveyId = UUID.fromString(patchData.getSurveyId());
 
-              // MATTTODO do we need to implement a new check to see if the survey exists here?
-//              if (survey == null) {
-//                  throw new CTPException(CTPException.Fault.BAD_REQUEST,
-//                          String.format("Survey %s does not exist", surveyId));
-//              } else {
+              SurveyDTO survey = this.surveyService.findSurvey(surveyId);
+
+              if (survey == null) {
+                  throw new CTPException(CTPException.Fault.BAD_REQUEST,
+                          String.format("Survey %s does not exist", surveyId));
+              } else {
                   collex.setSurveyUuid(surveyId);
-//              }
+              }
           }
 
           if (StringUtils.isBlank(patchData.getExerciseRef()) == false) {
@@ -258,7 +259,6 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
         // This will throw exception if period & surveyUuid are not unique
         validateUniqueness(existing, period, surveyUuid);
 
-        // MATTTODO do we need to implement a new check to see if the survey exists here?
         SurveyDTO survey = this.surveyService.findSurvey(surveyUuid);
 
         if (survey == null) {

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SurveyServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SurveyServiceImpl.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import uk.gov.ons.ctp.response.collection.exercise.domain.Survey;
@@ -15,6 +16,7 @@ import uk.gov.ons.response.survey.representation.SurveyDTO;
  *
  */
 @Service
+@Qualifier("database")
 public class SurveyServiceImpl implements SurveyService {
 
   @Autowired

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SurveyServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SurveyServiceImpl.java
@@ -24,12 +24,30 @@ public class SurveyServiceImpl implements SurveyService {
 
   @Override
   public SurveyDTO findSurvey(UUID id) {
+    SurveyDTO result = null;
     Survey survey = surveyRepo.findById(id);
 
-    SurveyDTO result = new SurveyDTO();
+    if (survey != null) {
+      result = new SurveyDTO();
 
-    result.setId(survey.getId().toString());
-    result.setSurveyRef(survey.getSurveyRef());
+      result.setId(survey.getId().toString());
+      result.setSurveyRef(survey.getSurveyRef());
+    }
+
+    return result;
+  }
+
+  @Override
+  public SurveyDTO findSurveyByRef(String surveyRef) {
+    SurveyDTO result = null;
+    Survey survey = surveyRepo.findBySurveyRef(surveyRef);
+
+    if (survey != null) {
+      result = new SurveyDTO();
+
+      result.setId(survey.getId().toString());
+      result.setSurveyRef(survey.getSurveyRef());
+    }
 
     return result;
   }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SurveyServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SurveyServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Survey;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SurveyRepository;
 import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /**
  * The implementation of the SampleService
@@ -20,12 +21,15 @@ public class SurveyServiceImpl implements SurveyService {
   private SurveyRepository surveyRepo;
 
   @Override
-  public Survey findSurvey(UUID id) {
-    return surveyRepo.findById(id);
+  public SurveyDTO findSurvey(UUID id) {
+    Survey survey = surveyRepo.findById(id);
+
+    SurveyDTO result = new SurveyDTO();
+
+    result.setId(survey.getId().toString());
+    result.setSurveyRef(survey.getSurveyRef());
+
+    return result;
   }
 
-  @Override
-  public Survey findSurveyByFK(int surveyFK) {
-    return surveyRepo.findOne(surveyFK);
-  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java
@@ -119,7 +119,7 @@ public class ValidateSampleUnits {
         collections.forEach((exercise, groups) -> {
           if (!validateSampleUnits(exercise, groups)) {
             log.error("Exited without validating Collection Exercise: {}, Survey: {}", exercise.getId(),
-                exercise.getSurvey().getId());
+                exercise.getSurveyUuid());
             return; // Exit collection forEach for exercise as no
                     // classifierTypes, fatal error.
           }
@@ -158,7 +158,7 @@ public class ValidateSampleUnits {
       return false;
     }
 
-    String surveyId = exercise.getSurvey().getId().toString();
+    String surveyId = exercise.getSurveyUuid().toString();
     List<ExerciseSampleUnit> updatedSampleUnitsForGroup = new ArrayList<>();
 
     for (ExerciseSampleUnitGroup sampleUnitGroup : sampleUnitGroups) {
@@ -350,21 +350,21 @@ public class ValidateSampleUnits {
     // Get Classifier types for Collection Instruments
     try {
       List<SurveyClassifierDTO> classifierTypeSelectors = surveySvcClient
-          .requestClassifierTypeSelectors(exercise.getSurvey().getId());
+          .requestClassifierTypeSelectors(exercise.getSurveyUuid());
       SurveyClassifierDTO chosenSelector = classifierTypeSelectors.stream()
           .filter(claz -> CASE_TYPE_SELECTOR.equals(claz.getName())).findAny().orElse(null);
       if (chosenSelector != null) {
         classifierTypeSelector = surveySvcClient
-            .requestClassifierTypeSelector(exercise.getSurvey().getId(), UUID.fromString(chosenSelector.getId()));
+            .requestClassifierTypeSelector(exercise.getSurveyUuid(), UUID.fromString(chosenSelector.getId()));
         if (classifierTypeSelector != null) {
           classifierTypes = classifierTypeSelector.getClassifierTypes();
         } else {
           log.error("Error requesting Survey Classifier Types for SurveyId: {},  caseTypeSelectorId: {}",
-              exercise.getSurvey().getId(), chosenSelector.getId());
+              exercise.getSurveyUuid(), chosenSelector.getId());
         }
       } else {
         log.error("Error requesting Survey Classifier Types for SurveyId: {}",
-            exercise.getSurvey().getId());
+            exercise.getSurveyUuid());
       }
     } catch (RestClientException ex) {
       log.error("Error requesting Survey service for classifierTypes: {}", ex.getMessage());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,6 +96,7 @@ sample-svc:
 survey-svc:
   request-classifier-types-list-path: /surveys/{surveyId}/classifiertypeselectors
   request-classifier-types-path: /surveys/{surveyId}/classifiertypeselectors/{selectorId}
+  survey-detail-path: /surveys/{surveyId}
   connection-config:
     scheme: http
     host: localhost

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,6 +97,7 @@ survey-svc:
   request-classifier-types-list-path: /surveys/{surveyId}/classifiertypeselectors
   request-classifier-types-path: /surveys/{surveyId}/classifiertypeselectors/{selectorId}
   survey-detail-path: /surveys/{surveyId}
+  survey-ref-path: /surveys/ref/{surveyRef}
   connection-config:
     scheme: http
     host: localhost

--- a/src/main/resources/database/changes/release-10.49.2/changelog.yml
+++ b/src/main/resources/database/changes/release-10.49.2/changelog.yml
@@ -8,3 +8,12 @@ databaseChangeLog:
             comment: US002a - add necessary fields to collectionexercise table
             path: us002a-add-columns-to-collection-exercise.sql
             relativeToChangelogFile: true
+
+  - changeSet:
+      id: 10.49.2-2
+      author: Matt Innes
+      changes:
+        - sqlFile:
+            comment: US002a - change survey reference to be uuid not fk to cache table
+            path: us002a-survey-ref-to-uuid.sql
+            relativeToChangelogFile: true

--- a/src/main/resources/database/changes/release-10.49.2/changelog.yml
+++ b/src/main/resources/database/changes/release-10.49.2/changelog.yml
@@ -17,3 +17,12 @@ databaseChangeLog:
             comment: US002a - change survey reference to be uuid not fk to cache table
             path: us002a-survey-ref-to-uuid.sql
             relativeToChangelogFile: true
+
+  - changeSet:
+      id: 10.49.2-3
+      author: Matt Innes
+      changes:
+        - sqlFile:
+            comment: US002a - convert the survey fk to a survey uuid
+            path: us002a-survey-pk-to-uuid.sql
+            relativeToChangelogFile: true

--- a/src/main/resources/database/changes/release-10.49.2/us002a-survey-pk-to-uuid.sql
+++ b/src/main/resources/database/changes/release-10.49.2/us002a-survey-pk-to-uuid.sql
@@ -1,0 +1,12 @@
+
+ALTER TABLE collectionexercise.casetypedefault ADD COLUMN survey_uuid UUID;
+
+UPDATE collectionexercise.casetypedefault AS ce
+SET survey_uuid = subquery.id
+FROM (
+    SELECT surveypk, id
+    FROM collectionexercise.survey
+) AS subquery
+WHERE ce.surveyfk = subquery.surveypk;
+
+ALTER TABLE collectionexercise.casetypedefault DROP COLUMN surveyfk;

--- a/src/main/resources/database/changes/release-10.49.2/us002a-survey-ref-to-uuid.sql
+++ b/src/main/resources/database/changes/release-10.49.2/us002a-survey-ref-to-uuid.sql
@@ -1,0 +1,12 @@
+
+ALTER TABLE collectionexercise.collectionexercise ADD COLUMN survey_uuid UUID;
+
+UPDATE collectionexercise.collectionexercise AS ce
+SET survey_uuid = subquery.id
+FROM (
+    SELECT surveypk, id
+    FROM collectionexercise.survey
+) AS subquery
+WHERE ce.surveyfk = subquery.surveypk;
+
+ALTER TABLE collectionexercise.collectionexercise DROP COLUMN surveyfk;

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.java
@@ -144,11 +144,11 @@ public class SampleUnitDistributorTest {
     when(sampleUnitRepo.findBySampleUnitGroup(any())).thenReturn(sampleUnitParentOnly);
 
     when(collectionExerciseRepo.getActiveActionPlanId(collectionExercise.getExercisePK(), "B",
-        collectionExercise.getSurvey().getSurveyPK()))
+        collectionExercise.getSurveyUuid()))
             .thenReturn(ACTION_PLAN_ID_PARENT);
 
     when(collectionExerciseRepo.getActiveActionPlanId(collectionExercise.getExercisePK(), "BI",
-        collectionExercise.getSurvey().getSurveyPK()))
+        collectionExercise.getSurveyUuid()))
             .thenReturn(ACTION_PLAN_ID_CHILD);
     when(
         sampleUnitGroupRepo.countByStateFKAndCollectionExercise(
@@ -298,7 +298,7 @@ public class SampleUnitDistributorTest {
 
     // Override happy path scenario so no ActionPlanId is returned.
     when(collectionExerciseRepo.getActiveActionPlanId(collectionExercise.getExercisePK(), "B",
-        collectionExercise.getSurvey().getSurveyPK()))
+        collectionExercise.getSurveyUuid()))
             .thenReturn(null);
 
     // Count of SampleUnitGroups would not match as didn't publish the

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -75,7 +75,8 @@ import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAd
 @Slf4j
 public class CollectionExerciseEndpointUnitTests {
   private static final String LINK_SAMPLE_SUMMARY_JSON = "{\"sampleSummaryIds\": [\"87043936-4d38-4696-952a-fcd55a51be96\", \"cf23b621-c613-424c-9d0d-53a9cfa82f3a\"]}";
-  private static final UUID SURVEY_ID = UUID.fromString("31ec898e-f370-429a-bca4-eab1045aff4e");
+  private static final UUID SURVEY_ID_1 = UUID.fromString("31ec898e-f370-429a-bca4-eab1045aff4e");
+  private static final UUID SURVEY_ID_2 = UUID.fromString("32ec898e-f370-429a-bca4-eab1045aff4e");
   private static final int SURVEY_FK = 1;
   private static final UUID COLLECTIONEXERCISE_ID1 = UUID.fromString("3ec82e0e-18ff-4886-8703-5b83442041ba");
   private static final UUID COLLECTIONEXERCISE_ID2 = UUID.fromString("e653d1ce-551b-4b41-b05c-eec02f71891e");
@@ -160,11 +161,11 @@ public class CollectionExerciseEndpointUnitTests {
    */
   @Test
   public void findCollectionExercisesForSurvey() throws Exception {
-    when(surveyService.findSurvey(SURVEY_ID)).thenReturn(surveyDtoResults.get(0));
+    when(surveyService.findSurvey(SURVEY_ID_1)).thenReturn(surveyDtoResults.get(0));
     when(collectionExerciseService.findCollectionExercisesForSurvey(surveyDtoResults.get(0)))
         .thenReturn(collectionExerciseResults);
 
-    ResultActions actions = mockCollectionExerciseMvc.perform(getJson(String.format("/collectionexercises/survey/%s", SURVEY_ID)));
+    ResultActions actions = mockCollectionExerciseMvc.perform(getJson(String.format("/collectionexercises/survey/%s", SURVEY_ID_1)));
 
     actions.andExpect(status().isOk())
         .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
@@ -222,7 +223,7 @@ public class CollectionExerciseEndpointUnitTests {
         .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
         .andExpect(handler().methodName("getCollectionExercise"))
         .andExpect(jsonPath("$.id", is(COLLECTIONEXERCISE_ID1.toString())))
-        .andExpect(jsonPath("$.surveyId", is(SURVEY_ID.toString())))
+        .andExpect(jsonPath("$.surveyId", is(SURVEY_ID_1.toString())))
         .andExpect(jsonPath("$.name", is(COLLECTIONEXERCISE_NAME)))
         .andExpect(jsonPath("$.state", is(COLLECTIONEXERCISE_STATE)))
         .andExpect(jsonPath("$.caseTypes[*]", hasSize(1)))
@@ -259,9 +260,8 @@ public class CollectionExerciseEndpointUnitTests {
         .thenReturn(collectionExerciseResults.get(0));
     when(collectionExerciseService.getCaseTypesList(collectionExerciseResults.get(0)))
         .thenReturn(caseTypeDefaultResults);
-// MATTTODO fix this
-    when(surveyService.findSurvey(UUID.fromString("31ec898e-f370-429a-bca4-eab1045aff4e"))).thenReturn(surveyDtoResults.get(0));
-    when(surveyService.findSurvey(UUID.fromString("32ec898e-f370-429a-bca4-eab1045aff4e"))).thenReturn(surveyDtoResults.get(0));
+    when(surveyService.findSurvey(SURVEY_ID_1)).thenReturn(surveyDtoResults.get(0));
+    when(surveyService.findSurvey(SURVEY_ID_2)).thenReturn(surveyDtoResults.get(1));
 
     ResultActions actions = mockCollectionExerciseMvc.perform(getJson(String.format("/collectionexercises/")));
 
@@ -269,12 +269,12 @@ public class CollectionExerciseEndpointUnitTests {
         .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
         .andExpect(handler().methodName("getAllCollectionExercises"))
         .andExpect(jsonPath("$[0].id", is(COLLECTIONEXERCISE_ID1.toString())))
-        .andExpect(jsonPath("$[0].surveyId", is(SURVEY_ID.toString())))
+        .andExpect(jsonPath("$[0].surveyId", is(SURVEY_ID_1.toString())))
         .andExpect(jsonPath("$[0].name", is(COLLECTIONEXERCISE_NAME)))
         .andExpect(jsonPath("$[0].state", is(COLLECTIONEXERCISE_STATE)))
         .andExpect(jsonPath("$[0].exerciseRef", is("2017")))
         .andExpect(jsonPath("$[1].id", is(COLLECTIONEXERCISE_ID2.toString())))
-        .andExpect(jsonPath("$[1].surveyId", is(SURVEY_ID.toString())))
+        .andExpect(jsonPath("$[1].surveyId", is(SURVEY_ID_2.toString())))
         .andExpect(jsonPath("$[1].name", is(COLLECTIONEXERCISE_NAME)))
         .andExpect(jsonPath("$[1].state", is(COLLECTIONEXERCISE_STATE)))
         .andExpect(jsonPath("$[1].exerciseRef", is("2017")));
@@ -354,7 +354,7 @@ public class CollectionExerciseEndpointUnitTests {
   @Test
   public void testCreateCollectionExercise() throws Exception {
     CollectionExercise created = FixtureHelper.loadClassFixtures(CollectionExercise[].class, "post").get(0);
-    when(surveyService.findSurvey(SURVEY_ID)).thenReturn(surveyDtoResults.get(0));
+    when(surveyService.findSurvey(SURVEY_ID_1)).thenReturn(surveyDtoResults.get(0));
     when(collectionExerciseService.createCollectionExercise(any())).thenReturn(created);
 
     String json = getResourceAsString("CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post.json");
@@ -368,7 +368,7 @@ public class CollectionExerciseEndpointUnitTests {
   @Test
   public void testCreateCollectionExerciseAlreadyExists() throws Exception {
     CollectionExercise created = FixtureHelper.loadClassFixtures(CollectionExercise[].class, "post").get(0);
-    when(surveyService.findSurvey(SURVEY_ID)).thenReturn(surveyDtoResults.get(0));
+    when(surveyService.findSurvey(SURVEY_ID_1)).thenReturn(surveyDtoResults.get(0));
     when(collectionExerciseService.createCollectionExercise(any())).thenReturn(created);
     when(this.collectionExerciseService.findCollectionExercise("202103", surveyDtoResults.get(0))).thenReturn(created);
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -77,6 +77,7 @@ public class CollectionExerciseEndpointUnitTests {
   private static final String LINK_SAMPLE_SUMMARY_JSON = "{\"sampleSummaryIds\": [\"87043936-4d38-4696-952a-fcd55a51be96\", \"cf23b621-c613-424c-9d0d-53a9cfa82f3a\"]}";
   private static final UUID SURVEY_ID_1 = UUID.fromString("31ec898e-f370-429a-bca4-eab1045aff4e");
   private static final UUID SURVEY_ID_2 = UUID.fromString("32ec898e-f370-429a-bca4-eab1045aff4e");
+  private static final String SURVEY_REF_1 = "221";
   private static final int SURVEY_FK = 1;
   private static final UUID COLLECTIONEXERCISE_ID1 = UUID.fromString("3ec82e0e-18ff-4886-8703-5b83442041ba");
   private static final UUID COLLECTIONEXERCISE_ID2 = UUID.fromString("e653d1ce-551b-4b41-b05c-eec02f71891e");
@@ -358,6 +359,20 @@ public class CollectionExerciseEndpointUnitTests {
     when(collectionExerciseService.createCollectionExercise(any())).thenReturn(created);
 
     String json = getResourceAsString("CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post.json");
+    ResultActions actions = mockCollectionExerciseMvc.perform(postJson("/collectionexercises", json));
+
+    actions
+            .andExpect(status().isCreated())
+            .andExpect(header().string("location", "http://localhost/collectionexercises/3ec82e0e-18ff-4886-8703-5b83442041ba"));
+  }
+
+  @Test
+  public void testCreateCollectionExerciseBySurveyRef() throws Exception {
+    CollectionExercise created = FixtureHelper.loadClassFixtures(CollectionExercise[].class, "post").get(0);
+    when(surveyService.findSurveyByRef(SURVEY_REF_1)).thenReturn(surveyDtoResults.get(0));
+    when(collectionExerciseService.createCollectionExercise(any())).thenReturn(created);
+
+    String json = getResourceAsString("CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post-survey-ref.json");
     ResultActions actions = mockCollectionExerciseMvc.perform(postJson("/collectionexercises", json));
 
     actions

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -115,7 +115,6 @@ public class CollectionExerciseEndpointUnitTests {
   private MockMvc textPlainMock;
   private List<Survey> surveyResults;
   private List<SurveyDTO> surveyDtoResults;
-  private List<CollectionExerciseDTO> collectionExerciseDTOResults;
   private List<CollectionExercise> collectionExerciseResults;
   private List<SampleUnitsRequestDTO> sampleUnitsRequestDTOResults;
   private Collection<CaseType> caseTypeDefaultResults;

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -51,6 +51,7 @@ import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
 import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
 import uk.gov.ons.ctp.response.party.representation.SampleLinkDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -111,6 +112,7 @@ public class CollectionExerciseEndpointUnitTests {
   private MockMvc mockCollectionExerciseMvc;
   private MockMvc textPlainMock;
   private List<Survey> surveyResults;
+  private List<SurveyDTO> surveyDtoResults;
   private List<CollectionExerciseDTO> collectionExerciseDTOResults;
   private List<CollectionExercise> collectionExerciseResults;
   private List<SampleUnitsRequestDTO> sampleUnitsRequestDTOResults;
@@ -139,6 +141,7 @@ public class CollectionExerciseEndpointUnitTests {
             .build();
 
     this.surveyResults = FixtureHelper.loadClassFixtures(Survey[].class);
+    this.surveyDtoResults = FixtureHelper.loadClassFixtures(SurveyDTO[].class);
     this.collectionExerciseResults = FixtureHelper.loadClassFixtures(CollectionExercise[].class);
     this.sampleUnitsRequestDTOResults = FixtureHelper.loadClassFixtures(SampleUnitsRequestDTO[].class);
     this.linkedSampleSummaries = FixtureHelper.loadClassFixtures(LinkedSampleSummariesDTO[].class);
@@ -157,8 +160,8 @@ public class CollectionExerciseEndpointUnitTests {
    */
   @Test
   public void findCollectionExercisesForSurvey() throws Exception {
-    when(surveyService.findSurvey(SURVEY_ID)).thenReturn(surveyResults.get(0));
-    when(collectionExerciseService.findCollectionExercisesForSurvey(surveyResults.get(0)))
+    when(surveyService.findSurvey(SURVEY_ID)).thenReturn(surveyDtoResults.get(0));
+    when(collectionExerciseService.findCollectionExercisesForSurvey(surveyDtoResults.get(0)))
         .thenReturn(collectionExerciseResults);
 
     ResultActions actions = mockCollectionExerciseMvc.perform(getJson(String.format("/collectionexercises/survey/%s", SURVEY_ID)));
@@ -205,7 +208,7 @@ public class CollectionExerciseEndpointUnitTests {
         .thenReturn(collectionExerciseResults.get(0));
     when(collectionExerciseService.getCaseTypesList(collectionExerciseResults.get(0)))
         .thenReturn(caseTypeDefaultResults);
-    when(surveyService.findSurveyByFK(SURVEY_FK)).thenReturn(surveyResults.get(0));
+    when(surveyService.findSurvey(UUID.fromString("31ec898e-f370-429a-bca4-eab1045aff4e"))).thenReturn(surveyDtoResults.get(0));
 
     MockHttpServletRequestBuilder json = getJson(String.format("/collectionexercises/%s", COLLECTIONEXERCISE_ID1));
 
@@ -256,7 +259,9 @@ public class CollectionExerciseEndpointUnitTests {
         .thenReturn(collectionExerciseResults.get(0));
     when(collectionExerciseService.getCaseTypesList(collectionExerciseResults.get(0)))
         .thenReturn(caseTypeDefaultResults);
-    when(surveyService.findSurveyByFK(SURVEY_FK)).thenReturn(surveyResults.get(0));
+// MATTTODO fix this
+    when(surveyService.findSurvey(UUID.fromString("31ec898e-f370-429a-bca4-eab1045aff4e"))).thenReturn(surveyDtoResults.get(0));
+    when(surveyService.findSurvey(UUID.fromString("32ec898e-f370-429a-bca4-eab1045aff4e"))).thenReturn(surveyDtoResults.get(0));
 
     ResultActions actions = mockCollectionExerciseMvc.perform(getJson(String.format("/collectionexercises/")));
 
@@ -349,7 +354,7 @@ public class CollectionExerciseEndpointUnitTests {
   @Test
   public void testCreateCollectionExercise() throws Exception {
     CollectionExercise created = FixtureHelper.loadClassFixtures(CollectionExercise[].class, "post").get(0);
-    when(surveyService.findSurvey(SURVEY_ID)).thenReturn(surveyResults.get(0));
+    when(surveyService.findSurvey(SURVEY_ID)).thenReturn(surveyDtoResults.get(0));
     when(collectionExerciseService.createCollectionExercise(any())).thenReturn(created);
 
     String json = getResourceAsString("CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post.json");
@@ -363,9 +368,9 @@ public class CollectionExerciseEndpointUnitTests {
   @Test
   public void testCreateCollectionExerciseAlreadyExists() throws Exception {
     CollectionExercise created = FixtureHelper.loadClassFixtures(CollectionExercise[].class, "post").get(0);
-    when(surveyService.findSurvey(SURVEY_ID)).thenReturn(surveyResults.get(0));
+    when(surveyService.findSurvey(SURVEY_ID)).thenReturn(surveyDtoResults.get(0));
     when(collectionExerciseService.createCollectionExercise(any())).thenReturn(created);
-    when(this.collectionExerciseService.findCollectionExercise("202103", surveyResults.get(0))).thenReturn(created);
+    when(this.collectionExerciseService.findCollectionExercise("202103", surveyDtoResults.get(0))).thenReturn(created);
 
     String json = getResourceAsString("CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post.json");
     ResultActions actions = mockCollectionExerciseMvc.perform(postJson("/collectionexercises", json));

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
@@ -15,6 +15,8 @@ import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExercise
 import uk.gov.ons.ctp.response.collection.exercise.repository.SurveyRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
+import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 import java.util.*;
 
@@ -40,7 +42,7 @@ public class CollectionExerciseServiceImplTest {
   private CollectionExerciseRepository collexRepo;
 
   @Mock
-  private SurveyRepository surveyRepo;
+  private SurveyService surveyService;
 
   @InjectMocks
   private CollectionExerciseServiceImpl collectionExerciseServiceImpl;
@@ -152,7 +154,7 @@ public class CollectionExerciseServiceImplTest {
    * @return CaseTypeDefault
    */
   private CaseTypeDefault createCaseTypeDefault(UUID actionPlanId, String sampleUnitTypeFK) {
-    CaseTypeDefault.builder().caseTypeDefaultPK(1).surveyFK(1);
+    CaseTypeDefault.builder().caseTypeDefaultPK(1).surveyId(UUID.randomUUID());
     return CaseTypeDefault.builder().actionPlanId(actionPlanId).sampleUnitTypeFK(sampleUnitTypeFK).build();
   }
 
@@ -171,8 +173,8 @@ public class CollectionExerciseServiceImplTest {
   @Test
   public void testCreateCollectionExercise() throws Exception {
       CollectionExerciseDTO toCreate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
-      Survey survey = FixtureHelper.loadClassFixtures(Survey[].class).get(0);
-      when(this.surveyRepo.findById(UUID.fromString(toCreate.getSurveyId()))).thenReturn(survey);
+      SurveyDTO survey = FixtureHelper.loadClassFixtures(SurveyDTO[].class).get(0);
+      when(this.surveyService.findSurvey(UUID.fromString(toCreate.getSurveyId()))).thenReturn(survey);
 
       this.collectionExerciseServiceImpl.createCollectionExercise(toCreate);
 
@@ -184,7 +186,7 @@ public class CollectionExerciseServiceImplTest {
       assertEquals(toCreate.getName(), collex.getName());
       assertEquals(toCreate.getUserDescription(), collex.getUserDescription());
       assertEquals(toCreate.getExerciseRef(), collex.getExerciseRef());
-      assertEquals(toCreate.getSurveyId(), collex.getSurvey().getId().toString());
+      assertEquals(toCreate.getSurveyId(), collex.getSurveyUuid().toString());
       assertNotNull(collex.getCreated());
   }
 
@@ -192,10 +194,11 @@ public class CollectionExerciseServiceImplTest {
   public void testUpdateCollectionExercise() throws Exception {
     CollectionExerciseDTO toUpdate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
     CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
-    Survey survey = FixtureHelper.loadClassFixtures(Survey[].class).get(0);
-    existing.setSurvey(survey);
+    SurveyDTO survey = FixtureHelper.loadClassFixtures(SurveyDTO[].class).get(0);
+    UUID surveyId = UUID.fromString(survey.getId());
+    existing.setSurveyUuid(surveyId);
     when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
-    when(surveyRepo.findById(survey.getId())).thenReturn(survey);
+    when(surveyService.findSurvey(surveyId)).thenReturn(survey);
 
     this.collectionExerciseServiceImpl.updateCollectionExercise(existing.getId(), toUpdate);
 
@@ -203,7 +206,7 @@ public class CollectionExerciseServiceImplTest {
 
     verify(collexRepo).save(captor.capture());
     CollectionExercise collex = captor.getValue();
-    assertEquals(UUID.fromString(toUpdate.getSurveyId()), collex.getSurvey().getId());
+    assertEquals(UUID.fromString(toUpdate.getSurveyId()), collex.getSurveyUuid());
     assertEquals(toUpdate.getExerciseRef(), collex.getExerciseRef());
     assertEquals(toUpdate.getName(), collex.getName());
     assertEquals(toUpdate.getUserDescription(), collex.getUserDescription());
@@ -215,7 +218,7 @@ public class CollectionExerciseServiceImplTest {
     CollectionExerciseDTO toUpdate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
     CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     Survey survey = FixtureHelper.loadClassFixtures(Survey[].class).get(0);
-    existing.setSurvey(survey);
+    existing.setSurveyUuid(survey.getId());
     when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
 
     try {
@@ -231,7 +234,7 @@ public class CollectionExerciseServiceImplTest {
     CollectionExerciseDTO toUpdate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
     CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     Survey survey = FixtureHelper.loadClassFixtures(Survey[].class).get(0);
-    existing.setSurvey(survey);
+    existing.setSurveyUuid(survey.getId());
     // Set up the mock to return the one we are attempting to update
     when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
 
@@ -313,7 +316,7 @@ public class CollectionExerciseServiceImplTest {
   private CollectionExercise setupCollectionExercise() throws Exception {
     CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     Survey survey = FixtureHelper.loadClassFixtures(Survey[].class).get(0);
-    existing.setSurvey(survey);
+    existing.setSurveyUuid(survey.getId());
     when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
 
     return existing;
@@ -375,7 +378,7 @@ public class CollectionExerciseServiceImplTest {
     CollectionExerciseDTO toUpdate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
     CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     Survey survey = FixtureHelper.loadClassFixtures(Survey[].class).get(0);
-    existing.setSurvey(survey);
+    existing.setSurveyUuid(survey.getId());
     // Set up the mock to return the one we are attempting to update
     when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
@@ -239,7 +239,7 @@ public class CollectionExerciseServiceImplTest {
     CollectionExercise otherExisting = new CollectionExercise();
     otherExisting.setId(uuid);
     // Set up the mock to return a different one with the same exercise ref and survey id
-    when(collexRepo.findByExerciseRefAndSurveyId(toUpdate.getExerciseRef(), UUID.fromString(toUpdate.getSurveyId())))
+    when(collexRepo.findByExerciseRefAndSurveyUuid(toUpdate.getExerciseRef(), UUID.fromString(toUpdate.getSurveyId())))
             .thenReturn(Arrays.asList(otherExisting));
 
     try {
@@ -383,7 +383,7 @@ public class CollectionExerciseServiceImplTest {
     CollectionExercise otherExisting = new CollectionExercise();
     otherExisting.setId(uuid);
     // Set up the mock to return a different one with the same exercise ref and survey id
-    when(collexRepo.findByExerciseRefAndSurveyId(toUpdate.getExerciseRef(), UUID.fromString(toUpdate.getSurveyId())))
+    when(collexRepo.findByExerciseRefAndSurveyUuid(toUpdate.getExerciseRef(), UUID.fromString(toUpdate.getSurveyId())))
             .thenReturn(Arrays.asList(otherExisting));
 
     try {

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.ExerciseSampleUnitGroup.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.ExerciseSampleUnitGroup.json
@@ -8,10 +8,7 @@
 		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000001,
 		"state": "VALIDATED",
-		"survey":
-           {"surveyPK": 1,
-            "id":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
-           },
+		"surveyUuid":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
         "sampleSize": 2
 	},
 	"formType": "B",
@@ -26,10 +23,7 @@
 		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000002,
 		"state": "VALIDATED",
-		"survey":
-           {"surveyPK": 1,
-            "id":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"           
-           },
+		"surveyUuid":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
         "sampleSize": 2
        },
        "formType": "B",

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExercise.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExercise.json
@@ -5,8 +5,6 @@
 		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000000,
 		"state": "EXECUTED",
-		"survey":
-			{"surveyPK": 1},
 		"exerciseRef": "2017",
 		"surveyUuid": "31ec898e-f370-429a-bca4-eab1045aff4e"
 	},
@@ -16,8 +14,6 @@
 		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000000,
 		"state": "EXECUTED",
-		"survey":
-			{"surveyPK": 1},
 		"exerciseRef": "2017",
 		"surveyUuid": "32ec898e-f370-429a-bca4-eab1045aff4e"
 	}

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExercise.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExercise.json
@@ -7,7 +7,8 @@
 		"state": "EXECUTED",
 		"survey":
 			{"surveyPK": 1},
-		"exerciseRef": "2017"
+		"exerciseRef": "2017",
+		"surveyUuid": "31ec898e-f370-429a-bca4-eab1045aff4e"
 	},
 	{
 		"exercisePK": 2,
@@ -17,6 +18,7 @@
 		"state": "EXECUTED",
 		"survey":
 			{"surveyPK": 1},
-		"exerciseRef": "2017"
+		"exerciseRef": "2017",
+		"surveyUuid": "32ec898e-f370-429a-bca4-eab1045aff4e"
 	}
 ]

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExercise.post.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExercise.post.json
@@ -6,6 +6,6 @@
 		"exercisePK": 1,
 		"id": "3ec82e0e-18ff-4886-8703-5b83442041ba",
 		"state": "INIT",
-		"survey": {"surveyPK": 1}
+        "surveyUuid": "31ec898e-f370-429a-bca4-eab1045aff4e"
 	}
 ]

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post-survey-ref.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post-survey-ref.json
@@ -1,0 +1,6 @@
+  {
+    "surveyRef": "221",
+    "name": "Survey Name",
+    "exerciseRef": "202103",
+    "userDescription": "March 2021"
+  }

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.SurveyDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.SurveyDTO.json
@@ -1,0 +1,14 @@
+[
+	{
+		"id": "31ec898e-f370-429a-bca4-eab1045aff4e",
+		"surveyRef": "221",
+		"longName": "Business Register and Employment Survey",
+		"shortName": "BRES"
+	},
+	{
+		"id": "32ec898e-f370-429a-bca4-eab1045aff4e",
+		"surveyRef": "222",
+		"longName": "Personal Register and Employment Survey",
+		"shortName": "PRES"
+	}
+]

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.CollectionExercise.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.CollectionExercise.json
@@ -5,8 +5,7 @@
 		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000000,
 		"state": "EXECUTED",
-		"survey":
-			{"surveyPK": 1},
+		"surveyUuid": "31ec898e-f370-429a-bca4-eab1045aff4e",
 		"exerciseRef": "2017"
 	},
 	{
@@ -15,8 +14,7 @@
 		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000000,
 		"state": "EXECUTED",
-		"survey":
-			{"surveyPK": 1},
+		"surveyUuid": "31ec898e-f370-429a-bca4-eab1045aff4e",
 		"exerciseRef": "2017"
 	}
 ]

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.SurveyDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.SurveyDTO.json
@@ -1,0 +1,14 @@
+[
+	{
+		"id": "31ec898e-f370-429a-bca4-eab1045aff4e",
+		"surveyRef": "221",
+		"longName": "Business Register and Employment Survey",
+		"shortName": "BRES"
+	},
+	{
+		"id": "32ec898e-f370-429a-bca4-eab1045aff4e",
+		"surveyRef": "222",
+		"longName": "Personal Register and Employment Survey",
+		"shortName": "PRES"
+	}
+]

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.CollectionExercise.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.CollectionExercise.json
@@ -5,11 +5,7 @@
     "name": "BRES_2016",
     "scheduledExecutionDateTime": 1494846000001,
     "state": "EXECUTED",
-    "survey":
-      {
-        "surveyPK": 1,
-        "id":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"			
-      },
+    "surveyUuid": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
     "sampleSize": 2
   },
   {
@@ -18,11 +14,7 @@
     "name": "BRES_2016",
     "scheduledExecutionDateTime": 1494846000002,
     "state": "EXECUTED",
-    "survey":
-      {
-        "surveyPK": 1,
-        "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
-      },
+    "surveyUuid": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
     "sampleSize": 2
   }
 ]

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.ExerciseSampleUnit.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.ExerciseSampleUnit.json
@@ -18,12 +18,7 @@
              "scheduledExecutionDateTime": 1494846000001,   
              "state": "EXECUTED",
              "sampleSize": 2,
-             "survey":
-               {
-                 "surveyPK": 1,
-                 "id":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
-                 "surveyRef": "221"
-               }
+             "surveyUuid": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
 	       }
 	  }
   }

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.ExerciseSampleUnitGroup.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.ExerciseSampleUnitGroup.json
@@ -8,10 +8,7 @@
 		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000001,
 		"state": "EXECUTED",
-		"survey":
-           {"surveyPK": 1,
-            "id":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
-           },
+        "surveyUuid": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
         "sampleSize": 2
 	},
 	"formType": "0015",
@@ -26,10 +23,7 @@
 		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000002,
 		"state": "EXECUTED",
-		"survey":
-           {"surveyPK": 1,
-            "id":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"           
-           },
+        "surveyUuid": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
         "sampleSize": 2
        },
        "formType": "0015",
@@ -44,10 +38,7 @@
 		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000001,
 		"state": "EXECUTED",
-		"survey":
-           {"surveyPK": 1,
-            "id":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
-           },
+        "surveyUuid": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
         "sampleSize": 2
 	},
 	"formType": "0015",
@@ -62,10 +53,7 @@
 		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000002,
 		"state": "EXECUTED",
-		"survey":
-           {"surveyPK": 1,
-            "id":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"           
-           },
+        "surveyUuid": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
         "sampleSize": 2
        },
        "formType": "0015",


### PR DESCRIPTION
This pull request is a major refactoring of the collection exercise service.   Originally, the service had a private copy of the survey table of the survey service.  Unfortunately there was no method in place for this to be updated so it contained BRES and wouldn't contain anything else without a DFA.  

I have refactored the service to remove this dependency entirely.  The service will now call the survey service directly when it requires information about a particular survey.  In 95% of cases the only information the service was interested in was the survey UUID which is now held as part of the collection exercise (so no call required).  The points where further information *is* required are while handling REST requests to create/update collection exercises and to create sample links.  These are sufficiently infrequent to not cause performance issues.

Additionally, in the event there are performance issues with the cadence of calls between collection exercise service and survey service, this would be best addressed by improving the performance of the survey service.  The survey data is almost static - in the event there is a bottleneck it could easily be cached, e.g. cache all GET requests using a CDN with a 24 hour TTL

Please note: this pull request is against the collection exercise refactoring branch not master so that the changes specific to this piece of work can be viewed independently