### PR TITLE
Set sequence value to skip hardcoded ids

### DIFF
--- a/src/main/resources/database/changes/release-10.49.2/changelog.yml
+++ b/src/main/resources/database/changes/release-10.49.2/changelog.yml
@@ -44,3 +44,12 @@ databaseChangeLog:
             comment: US004 - message sent flag
             path: us004-message-sent.sql
             relativeToChangelogFile: true
+
+  - changeSet:
+      id: 10.49.2-6
+      author: Ben Jefferies
+      changes:
+        - sqlFile:
+            comment: US004 - fix sequence number to compensate for BRES_collectionexercise_seeddata.sql
+            path: us004-fix-sequence.sql
+            relativeToChangelogFile: true

--- a/src/main/resources/database/changes/release-10.49.2/us004-fix-sequence.sql
+++ b/src/main/resources/database/changes/release-10.49.2/us004-fix-sequence.sql
@@ -1,0 +1,4 @@
+-- Set the value of the sequence to greater number of the current sequence number or 4
+SELECT SETVAL('collectionexercise.exercisepkseq', (SELECT
+              GREATEST((SELECT last_value
+                 FROM   collectionexercise.exercisepkseq), 4)));


### PR DESCRIPTION
When running up the collection exercise service locally
BRES_collectionexercise_seeddata.sql inserts a collection exercise with
a hardcoded id. This means the sequence doesn't get incremented
therefore the next time the api tries to insert a collection exercise
using the sequence it will fail.

This change should have any impact in production as it will either set
the sequence to what it currently is because it's greater than the 4.

The reason it has been set to 4 is because there are a couple more rows
in the dev database

## Testing
### Checking prod won't be affected
1. Run up the ras-rm-docker-dev services using `make up`
1. Set the sequence to a number higher that 4 `SELECT SETVAL('collectionexercise.exercisepkseq', 100);`
1. Check out this branch in rm-collection-exercise-service
1. Run `mvn clean install` to build the new docker image overwriting the old one
1. Rerun `make up` in ras-rm-docker-dev to start the new service (don't `make down` in between)
1. Check the sequence is the same `SELECT last_value FROM   collectionexercise.exercisepkseq;`

### Checking the fix works locally
1. Run up the ras-rm-docker-dev services using `make up`
1. Check out this branch in rm-collection-exercise-service
1. Run `mvn clean install` to build the new docker image overwriting the old one
1. Rerun `make up` in ras-rm-docker-dev to start the new service (don't `make down` in between)
1. Check the sequence is the same `SELECT last_value FROM  collectionexercise.exercisepkseq;`
1. Go into `rm-tools/collex-loader`
1. Run `python load.py config/collex-config.json` and observe it works first time with no 500 errors