### PR TITLE
Set a whole bunch of other dates from incoming events

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStartDateHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStartDateHandler.java
@@ -39,19 +39,29 @@ public final class ScheduledStartDateHandler implements EventChangeHandler {
     private void updateCollectionExerciseFromEvent(final Event event) {
         try {
             EventService.Tag tag = EventService.Tag.valueOf(event.getTag());
+            CollectionExercise collex = event.getCollectionExercise();
 
-            switch(tag) {
-                case mps:
-                    CollectionExercise collex = event.getCollectionExercise();
-
-                    if (collex != null) {
+            if (collex != null) {
+                switch (tag) {
+                    case mps:
                         log.info("Setting scheduledStartDate for {} to {}", collex.getId(), event.getTimestamp());
                         collex.setScheduledStartDateTime(event.getTimestamp());
-                        this.collectionExerciseService.updateCollectionExercise(collex);
-                    }
-                    break;
-                default:
-                    break;
+                        collex.setScheduledExecutionDateTime(event.getTimestamp());
+                        collex.setPeriodStartDateTime(event.getTimestamp());
+                        break;
+                    case exercise_end:
+                        log.info("Setting scheduledEndDate for {} to {}", collex.getId(), event.getTimestamp());
+                        collex.setScheduledEndDateTime(event.getTimestamp());
+                        collex.setPeriodEndDateTime(event.getTimestamp());
+                        break;
+                    case return_by:
+                        log.info("Setting scheduledReturnDate for {} to {}", collex.getId(), event.getTimestamp());
+                        collex.setScheduledReturnDateTime(event.getTimestamp());
+                        break;
+                    default:
+                        break;
+                }
+                this.collectionExerciseService.updateCollectionExercise(collex);
             }
         } catch(IllegalArgumentException e) {
             // Thrown if tag isn't one of the mandatory types - if it happens we don't care about the event


### PR DESCRIPTION
Additional information has shed light on which events should be matched to which dates on collection exercise. This PR sets the values from the events.  Period start/end just need to be set so currently are set to scheduled start/end date but this may need to change