### PR TITLE
Changed error handling to avoid infinite retry

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandler.java
@@ -1,19 +1,14 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.MessageHandlingException;
 import uk.gov.ons.ctp.common.error.CTPException;
-import uk.gov.ons.ctp.response.collection.exercise.message.SampleUnitPublisher;
 import uk.gov.ons.ctp.response.collection.exercise.message.dto.CollectionInstrumentMessageDTO;
-import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * Error handling class containing service activator method to convert MessageHandlingException into a map
@@ -23,28 +18,25 @@ import java.util.UUID;
 @Slf4j
 public class ExceptionHandler {
 
-    enum ResultKey {
-        collectionExercise, collectionInstrument, errorType, errorMessage, errorTimestamp
-    }
-
     /**
      * Service activator method that accepts a MessageHandlingException, pulls out the important bits and returns
      * them as a map suitable for posting as a Rabbit message or logging.  It pulls messages from the ciErrorChannel
      * Spring integration channel and the results get posted to the ciErrorCleanChannel
+     *
      * @param e a message handling exception
      * @return a map containing details of the collection exercise & instument if available and the error message
      */
     @ServiceActivator(inputChannel = "ciErrorChannel", outputChannel = "ciErrorCleanChannel")
-    public Map<ResultKey, String> handleException(MessageHandlingException e){
+    public Map<ResultKey, String> handleException(final MessageHandlingException e) {
         Map<ResultKey, String> result = new HashMap<>();
 
         // Exceptions thrown in error handlers are really annoying so check all incoming data THOROUGHLY
-        if (e != null){
+        if (e != null) {
             if (e.getFailedMessage() != null) {
                 Object payload = e.getFailedMessage().getPayload();
 
                 if (payload != null && payload instanceof CollectionInstrumentMessageDTO) {
-                    CollectionInstrumentMessageDTO dto = (CollectionInstrumentMessageDTO)payload;
+                    CollectionInstrumentMessageDTO dto = (CollectionInstrumentMessageDTO) payload;
 
                     result.put(ResultKey.collectionExercise, dto.getExerciseId().toString());
                     result.put(ResultKey.collectionInstrument, dto.getInstrumentId().toString());
@@ -52,9 +44,9 @@ public class ExceptionHandler {
             }
             Throwable t = e.getCause();
 
-            if (t != null){
-                if (t instanceof CTPException){
-                    CTPException ctpException = (CTPException)t;
+            if (t != null) {
+                if (t instanceof CTPException) {
+                    CTPException ctpException = (CTPException) t;
 
                     result.put(ResultKey.errorType, ctpException.getFault().name());
                     result.put(ResultKey.errorTimestamp, Long.toString(ctpException.getTimestamp()));
@@ -65,6 +57,13 @@ public class ExceptionHandler {
         }
 
         return result;
+    }
+
+    /**
+     * Definition of fields that appear in error message sent to DLQ
+     */
+    enum ResultKey {
+        collectionExercise, collectionInstrument, errorType, errorMessage, errorTimestamp
     }
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandler.java
@@ -1,0 +1,70 @@
+package uk.gov.ons.ctp.response.collection.exercise.message.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.annotation.MessageEndpoint;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.messaging.MessageHandlingException;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.message.SampleUnitPublisher;
+import uk.gov.ons.ctp.response.collection.exercise.message.dto.CollectionInstrumentMessageDTO;
+import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Error handling class containing service activator method to convert MessageHandlingException into a map
+ * that's more friendly to posting as messages
+ */
+@MessageEndpoint
+@Slf4j
+public class ExceptionHandler {
+
+    enum ResultKey {
+        collectionExercise, collectionInstrument, errorType, errorMessage, errorTimestamp
+    }
+
+    /**
+     * Service activator method that accepts a MessageHandlingException, pulls out the important bits and returns
+     * them as a map suitable for posting as a Rabbit message or logging.  It pulls messages from the ciErrorChannel
+     * Spring integration channel and the results get posted to the ciErrorCleanChannel
+     * @param e a message handling exception
+     * @return a map containing details of the collection exercise & instument if available and the error message
+     */
+    @ServiceActivator(inputChannel = "ciErrorChannel", outputChannel = "ciErrorCleanChannel")
+    public Map<ResultKey, String> handleException(MessageHandlingException e){
+        Map<ResultKey, String> result = new HashMap<>();
+
+        // Exceptions thrown in error handlers are really annoying so check all incoming data THOROUGHLY
+        if (e != null){
+            if (e.getFailedMessage() != null) {
+                Object payload = e.getFailedMessage().getPayload();
+
+                if (payload != null && payload instanceof CollectionInstrumentMessageDTO) {
+                    CollectionInstrumentMessageDTO dto = (CollectionInstrumentMessageDTO)payload;
+
+                    result.put(ResultKey.collectionExercise, dto.getExerciseId().toString());
+                    result.put(ResultKey.collectionInstrument, dto.getInstrumentId().toString());
+                }
+            }
+            Throwable t = e.getCause();
+
+            if (t != null){
+                if (t instanceof CTPException){
+                    CTPException ctpException = (CTPException)t;
+
+                    result.put(ResultKey.errorType, ctpException.getFault().name());
+                    result.put(ResultKey.errorTimestamp, Long.toString(ctpException.getTimestamp()));
+                }
+
+                result.put(ResultKey.errorMessage, t.getLocalizedMessage());
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/resources/springintegration/collection-instrument-inbound.xml
+++ b/src/main/resources/springintegration/collection-instrument-inbound.xml
@@ -10,17 +10,39 @@
 		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
+    <!-- JSON input channel bound to incoming AMQP message -->
     <int:channel id="ciJson" />
+    <!-- Channel containing Java object parsed from incoming JSON -->
     <int:channel id="ciMessageDto" />
+    <!-- Error channel - will contain raw exceptions -->
+    <int:channel id="ciErrorChannel" />
+    <!-- ExceptionCleaner takes messages from ciErrorChannel, removes stacktrace for brevity then puts the output
+         on ciErrorCleanChannel -->
+    <int:channel id="ciErrorCleanChannel" />
+
+    <!-- Channel containing JSON representations of exception minus stack trace, bound to outgoing AMQP message to DLQ -->
+    <int:channel id="ciErrorChannelJson">
+        <!-- Log the errors as well as dumping the on the DLQ -->
+        <int:interceptors> <int:wire-tap channel="logger"/> </int:interceptors>
+    </int:channel>
 
     <bean id="simpleMessageConverter"
           class="org.springframework.amqp.support.converter.SimpleMessageConverter" />
 
     <int-amqp:inbound-channel-adapter channel="ciJson"
                                       queue-names="collex.seft.instruments" connection-factory="connectionFactory"
-                                      message-converter="simpleMessageConverter"/>
+                                      message-converter="simpleMessageConverter" error-channel="ciErrorChannel"/>
 
-    <int:json-to-object-transformer id="json-to-ci-message-dto" input-channel="ciJson" output-channel="ciMessageDto" type="uk.gov.ons.ctp.response.collection.exercise.message.dto.CollectionInstrumentMessageDTO"/>
+    <int:logging-channel-adapter id="logger" level="ERROR"/>
+
+    <int-amqp:outbound-channel-adapter channel="ciErrorChannelJson"
+                                       exchange-name="Seft.Instruments.DLQ"/>
+
+    <int:json-to-object-transformer input-channel="ciJson" output-channel="ciMessageDto"
+                     type="uk.gov.ons.ctp.response.collection.exercise.message.dto.CollectionInstrumentMessageDTO"/>
+
+    <int:object-to-json-transformer input-channel="ciErrorCleanChannel"
+                                    output-channel="ciErrorChannelJson"/>
 
     <rabbit:queue name="collex.seft.instruments"/>
 
@@ -29,5 +51,7 @@
             <rabbit:binding queue="collex.seft.instruments"/>
         </rabbit:bindings>
     </rabbit:fanout-exchange>
+
+    <rabbit:fanout-exchange name="Seft.Instruments.DLQ"/>
 
 </beans>

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandlerTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandlerTests.java
@@ -1,0 +1,129 @@
+package uk.gov.ons.ctp.response.collection.exercise.message.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.support.GenericMessage;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.message.dto.CollectionInstrumentMessageDTO;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for ExceptionHandler class
+ */
+public class ExceptionHandlerTests {
+
+    private static final UUID COLLECTION_INSTRUMENT_ID = UUID.fromString("699632ec-c75b-4454-a0ae-d15c592a6473");
+    private static final UUID COLLECTION_EXERCISE_ID = UUID.fromString("d42f358c-812c-45f7-a064-39739d0189a6");
+
+    private static final CTPException.Fault EXCEPTION_FAULT = CTPException.Fault.RESOURCE_VERSION_CONFLICT;
+    private static final String EXCEPTION_MESSAGE = "Test exception message";
+
+    private ExceptionHandler exceptionHandler;
+
+    private CollectionInstrumentMessageDTO messageDto;
+
+    private CTPException ctpException;
+
+    /**
+     * Create objects common to many tests
+     */
+    @Before
+    public void setUp(){
+        this.exceptionHandler = new ExceptionHandler();
+        this.ctpException = new CTPException(EXCEPTION_FAULT, EXCEPTION_MESSAGE);
+        this.messageDto = new CollectionInstrumentMessageDTO(null, COLLECTION_EXERCISE_ID.toString(), COLLECTION_INSTRUMENT_ID.toString());
+    }
+
+    /**
+     * Given null exception
+     * When handleException
+     * Then empty response
+     */
+    @Test
+    public void givenNullExceptionWhenHandleExceptionThenEmptyResponse(){
+        Map<ExceptionHandler.ResultKey,String> result = this.exceptionHandler.handleException(null);
+
+        assertEquals(0, result.size());
+    }
+
+    /**
+     * Given all fields
+     * When handleException
+     * Then all fields returned
+     */
+    @Test
+    public void givenAllFieldsWhenHandleExceptionThenAllFields(){
+        GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
+        MessageHandlingException exception = new MessageHandlingException(message, this.ctpException);
+
+        Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(exception);
+
+        assertEquals(COLLECTION_INSTRUMENT_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionInstrument));
+        assertEquals(COLLECTION_EXERCISE_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionExercise));
+        assertEquals(EXCEPTION_FAULT.name(), result.get(ExceptionHandler.ResultKey.errorType));
+        assertEquals(EXCEPTION_MESSAGE, result.get(ExceptionHandler.ResultKey.errorMessage));
+        assertEquals(this.ctpException.getTimestamp(), Long.parseLong(result.get(ExceptionHandler.ResultKey.errorTimestamp)));
+    }
+
+    /**
+     * Given no failed message
+     * When handleException
+     * Then only exeception details returned
+     */
+    @Test
+    public void givenNoFailedMessageWhenHandleExceptionThenOnlyExeceptionDetails(){
+        MessageHandlingException exception = new MessageHandlingException(null, this.ctpException);
+
+        Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(exception);
+
+        assertNull(result.get(ExceptionHandler.ResultKey.collectionInstrument));
+        assertNull(result.get(ExceptionHandler.ResultKey.collectionExercise));
+        assertEquals(EXCEPTION_FAULT.name(), result.get(ExceptionHandler.ResultKey.errorType));
+        assertEquals(EXCEPTION_MESSAGE, result.get(ExceptionHandler.ResultKey.errorMessage));
+        assertEquals(this.ctpException.getTimestamp(), Long.parseLong(result.get(ExceptionHandler.ResultKey.errorTimestamp)));
+    }
+
+    /**
+     * Given no exception
+     * When handleException
+     * Then only message details returned
+     */
+    @Test
+    public void givenNoExceptionWhenHandleExceptionThenOnlyMessageDetails(){
+        GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
+        MessageHandlingException exception = new MessageHandlingException(message, (Exception)null);
+
+        Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(exception);
+
+        assertEquals(COLLECTION_INSTRUMENT_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionInstrument));
+        assertEquals(COLLECTION_EXERCISE_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionExercise));
+        assertNull(result.get(ExceptionHandler.ResultKey.errorType));
+        assertNull(result.get(ExceptionHandler.ResultKey.errorMessage));
+        assertNull(result.get(ExceptionHandler.ResultKey.errorTimestamp));
+    }
+
+    /**
+     * Given non CTPException
+     * When handleException
+     * Then only exception message returned
+     */
+    @Test
+    public void givenNonCtpExceptionWhenHandleExceptionThenOnlyExceptionMessage(){
+        GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
+        MessageHandlingException exception = new MessageHandlingException(message, new Exception(EXCEPTION_MESSAGE));
+
+        Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(exception);
+
+        assertEquals(COLLECTION_INSTRUMENT_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionInstrument));
+        assertEquals(COLLECTION_EXERCISE_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionExercise));
+        assertNull(result.get(ExceptionHandler.ResultKey.errorType));
+        assertNull(result.get(ExceptionHandler.ResultKey.errorTimestamp));
+        assertEquals(EXCEPTION_MESSAGE, result.get(ExceptionHandler.ResultKey.errorMessage));
+    }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandlerTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandlerTests.java
@@ -34,10 +34,11 @@ public class ExceptionHandlerTests {
      * Create objects common to many tests
      */
     @Before
-    public void setUp(){
+    public void setUp() {
         this.exceptionHandler = new ExceptionHandler();
         this.ctpException = new CTPException(EXCEPTION_FAULT, EXCEPTION_MESSAGE);
-        this.messageDto = new CollectionInstrumentMessageDTO(null, COLLECTION_EXERCISE_ID.toString(), COLLECTION_INSTRUMENT_ID.toString());
+        this.messageDto = new CollectionInstrumentMessageDTO(null, COLLECTION_EXERCISE_ID.toString(),
+                COLLECTION_INSTRUMENT_ID.toString());
     }
 
     /**
@@ -46,8 +47,8 @@ public class ExceptionHandlerTests {
      * Then empty response
      */
     @Test
-    public void givenNullExceptionWhenHandleExceptionThenEmptyResponse(){
-        Map<ExceptionHandler.ResultKey,String> result = this.exceptionHandler.handleException(null);
+    public void givenNullExceptionWhenHandleExceptionThenEmptyResponse() {
+        Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(null);
 
         assertEquals(0, result.size());
     }
@@ -58,7 +59,7 @@ public class ExceptionHandlerTests {
      * Then all fields returned
      */
     @Test
-    public void givenAllFieldsWhenHandleExceptionThenAllFields(){
+    public void givenAllFieldsWhenHandleExceptionThenAllFields() {
         GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
         MessageHandlingException exception = new MessageHandlingException(message, this.ctpException);
 
@@ -68,7 +69,8 @@ public class ExceptionHandlerTests {
         assertEquals(COLLECTION_EXERCISE_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionExercise));
         assertEquals(EXCEPTION_FAULT.name(), result.get(ExceptionHandler.ResultKey.errorType));
         assertEquals(EXCEPTION_MESSAGE, result.get(ExceptionHandler.ResultKey.errorMessage));
-        assertEquals(this.ctpException.getTimestamp(), Long.parseLong(result.get(ExceptionHandler.ResultKey.errorTimestamp)));
+        assertEquals(this.ctpException.getTimestamp(),
+                Long.parseLong(result.get(ExceptionHandler.ResultKey.errorTimestamp)));
     }
 
     /**
@@ -77,7 +79,7 @@ public class ExceptionHandlerTests {
      * Then only exeception details returned
      */
     @Test
-    public void givenNoFailedMessageWhenHandleExceptionThenOnlyExeceptionDetails(){
+    public void givenNoFailedMessageWhenHandleExceptionThenOnlyExeceptionDetails() {
         MessageHandlingException exception = new MessageHandlingException(null, this.ctpException);
 
         Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(exception);
@@ -86,7 +88,8 @@ public class ExceptionHandlerTests {
         assertNull(result.get(ExceptionHandler.ResultKey.collectionExercise));
         assertEquals(EXCEPTION_FAULT.name(), result.get(ExceptionHandler.ResultKey.errorType));
         assertEquals(EXCEPTION_MESSAGE, result.get(ExceptionHandler.ResultKey.errorMessage));
-        assertEquals(this.ctpException.getTimestamp(), Long.parseLong(result.get(ExceptionHandler.ResultKey.errorTimestamp)));
+        assertEquals(this.ctpException.getTimestamp(),
+                Long.parseLong(result.get(ExceptionHandler.ResultKey.errorTimestamp)));
     }
 
     /**
@@ -95,9 +98,9 @@ public class ExceptionHandlerTests {
      * Then only message details returned
      */
     @Test
-    public void givenNoExceptionWhenHandleExceptionThenOnlyMessageDetails(){
+    public void givenNoExceptionWhenHandleExceptionThenOnlyMessageDetails() {
         GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
-        MessageHandlingException exception = new MessageHandlingException(message, (Exception)null);
+        MessageHandlingException exception = new MessageHandlingException(message, (Exception) null);
 
         Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(exception);
 
@@ -114,7 +117,7 @@ public class ExceptionHandlerTests {
      * Then only exception message returned
      */
     @Test
-    public void givenNonCtpExceptionWhenHandleExceptionThenOnlyExceptionMessage(){
+    public void givenNonCtpExceptionWhenHandleExceptionThenOnlyExceptionMessage() {
         GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
         MessageHandlingException exception = new MessageHandlingException(message, new Exception(EXCEPTION_MESSAGE));
 


### PR DESCRIPTION
Originally the message would be left on the queue if an error occurred
handling an incoming message on the Seft.Instruments queue.  This would
cause the message to be processed again and the error most likely
repeated.

This PR covers a change to remove the message from the Seft.Instruments
queue and drop an error to the Seft.Instruments.DLQ queue in the following format:
```{"collectionInstrument":"3360762f-1e3e-45f3-82ff-c0698820e71e","collectionExercise":"a9350d52-7613-42cf-bbec-a704d4388168","errorTimestamp":"1519306705553","errorMessage":"State Transition from READY_FOR_LIVE via CI_SAMPLE_ADDED is forbidden.","errorType":"BAD_REQUEST"}```