### PR TITLE
Us047 live state

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventInboundReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventInboundReceiver.java
@@ -14,6 +14,9 @@ import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
 import java.util.UUID;
 
+/**
+ * Class to hold service activator method to handle incoming collection exercise event lifecycle messages
+ */
 @MessageEndpoint
 @Slf4j
 public class CollectionExerciseEventInboundReceiver {
@@ -21,18 +24,26 @@ public class CollectionExerciseEventInboundReceiver {
     @Autowired
     private CollectionExerciseService collectionExerciseService;
 
+    /**
+     * Service activator method - if it's a go_live event and it's EventElapsed then send a GO_LIVE event to the
+     * collection exercise to push it into the LIVE state
+     *
+     * @param message an event message
+     */
     @ServiceActivator(inputChannel = "cemInMessage")
-    public void handleEventMessage(EventMessageDTO message){
+    public void handleEventMessage(final EventMessageDTO message) {
         EventDTO event = message.getEvent();
         CollectionExerciseEventPublisher.MessageType messageType = message.getMessageType();
         EventService.Tag tag = EventService.Tag.valueOf(event.getTag());
 
         // If it's a go_live event then attempt to transition the state of the collection exercise to live
-        if (tag == EventService.Tag.go_live && messageType == CollectionExerciseEventPublisher.MessageType.EventElapsed){
+        if (tag == EventService.Tag.go_live
+                && messageType == CollectionExerciseEventPublisher.MessageType.EventElapsed) {
             UUID collexId = event.getCollectionExerciseId();
 
             try {
-                this.collectionExerciseService.transitionCollectionExercise(collexId, CollectionExerciseDTO.CollectionExerciseEvent.GO_LIVE);
+                this.collectionExerciseService.transitionCollectionExercise(collexId,
+                        CollectionExerciseDTO.CollectionExerciseEvent.GO_LIVE);
             } catch (CTPException e) {
                 log.error("Failed to set collection exerise to live state - {}", e);
             }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventInboundReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventInboundReceiver.java
@@ -1,0 +1,41 @@
+package uk.gov.ons.ctp.response.collection.exercise.message.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.annotation.MessageEndpoint;
+import org.springframework.integration.annotation.ServiceActivator;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEventPublisher;
+import uk.gov.ons.ctp.response.collection.exercise.message.dto.EventMessageDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
+import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
+
+import java.util.UUID;
+
+@MessageEndpoint
+@Slf4j
+public class CollectionExerciseEventInboundReceiver {
+
+    @Autowired
+    private CollectionExerciseService collectionExerciseService;
+
+    @ServiceActivator(inputChannel = "cemInMessage")
+    public void handleEventMessage(EventMessageDTO message){
+        EventDTO event = message.getEvent();
+        CollectionExerciseEventPublisher.MessageType messageType = message.getMessageType();
+        EventService.Tag tag = EventService.Tag.valueOf(event.getTag());
+
+        // If it's a go_live event then attempt to transition the state of the collection exercise to live
+        if (tag == EventService.Tag.go_live && messageType == CollectionExerciseEventPublisher.MessageType.EventElapsed){
+            UUID collexId = event.getCollectionExerciseId();
+
+            try {
+                this.collectionExerciseService.transitionCollectionExercise(collexId, CollectionExerciseDTO.CollectionExerciseEvent.GO_LIVE);
+            } catch (CTPException e) {
+                log.error("Failed to set collection exerise to live state - {}", e);
+            }
+        }
+    }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
@@ -154,9 +154,30 @@ public interface CollectionExerciseService {
    */
   CollectionExercise undeleteCollectionExercise(UUID id) throws CTPException;
 
+  /**
+   * Find all collection exercises with a given state
+   * @param state the state to find
+   * @return a list of collection exercises with the given state
+   */
   List<CollectionExercise> findByState(CollectionExerciseDTO.CollectionExerciseState state);
 
+  /**
+   * Utility method to transition a collection exercise to a new state
+   * @param collex a collection exercise
+   * @param event a collection exercise event
+   * @throws CTPException thrown if the specified event is not valid for the current state
+   */
   void transitionCollectionExercise(CollectionExercise collex, CollectionExerciseDTO.CollectionExerciseEvent event)
+          throws CTPException;
+
+  /**
+   * Utility method to transition a collection exercise to a new state
+   * @param collectionExerciseId a collection exercise UUID
+   * @param event a collection exercise event
+   * @throws CTPException thrown if the specified event is not valid for the current state or a collection exercise
+   *                      with the given id cannot be found
+   */
+  void transitionCollectionExercise(UUID collectionExerciseId, CollectionExerciseDTO.CollectionExerciseEvent event)
           throws CTPException;
 
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
@@ -39,4 +39,18 @@ public interface EventService {
     void clearEventMessageSent(UUID eventId) throws CTPException;
     boolean isScheduled(UUID collexUuid) throws CTPException;
 
+    /**
+     * Unschedule a collection exercise event
+     * @param event the event to unshchedule
+     * @throws CTPException thrown if error occurred unscheduling event
+     */
+    void unscheduleEvent(Event event) throws CTPException;
+
+    /**
+     * Schedule a collection exercise event
+     * @param event the event to shchedule
+     * @throws CTPException thrown if error occurred scheduling event
+     */
+    void scheduleEvent(Event event) throws CTPException;
+
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -36,340 +36,344 @@ import java.util.UUID;
 
 /**
  * The implementation of the SampleService
- *
  */
 @Service
 @Slf4j
 public class CollectionExerciseServiceImpl implements CollectionExerciseService {
 
-  @Autowired
-  private CollectionExerciseRepository collectRepo;
+    @Autowired
+    private CollectionExerciseRepository collectRepo;
 
-  @Autowired
-  private CaseTypeOverrideRepository caseTypeOverrideRepo;
+    @Autowired
+    private CaseTypeOverrideRepository caseTypeOverrideRepo;
 
-  @Autowired
-  private CaseTypeDefaultRepository caseTypeDefaultRepo;
+    @Autowired
+    private CaseTypeDefaultRepository caseTypeDefaultRepo;
 
-  @Autowired
-  private SurveyService surveyService;
+    @Autowired
+    private SurveyService surveyService;
 
-  @Autowired
-  private SampleLinkRepository sampleLinkRepository;
+    @Autowired
+    private SampleLinkRepository sampleLinkRepository;
 
-  @Autowired
-  @Qualifier("collectionExercise")
-  private StateTransitionManager<CollectionExerciseDTO.CollectionExerciseState, CollectionExerciseDTO.CollectionExerciseEvent> collectionExerciseTransitionState;
+    @Autowired
+    @Qualifier("collectionExercise")
+    private StateTransitionManager<CollectionExerciseDTO.CollectionExerciseState,
+            CollectionExerciseDTO.CollectionExerciseEvent> collectionExerciseTransitionState;
 
-  @Autowired
-  private CollectionInstrumentSvcClient collectionInstrument;
+    @Autowired
+    private CollectionInstrumentSvcClient collectionInstrument;
 
-  @Override
-  public List<CollectionExercise> findCollectionExercisesForSurvey(SurveyDTO survey) {
-    return this.collectRepo.findBySurveyId(UUID.fromString(survey.getId()));
-  }
-
-  @Override
-  public List<CollectionExercise> findCollectionExercisesForParty(final UUID id) {
-    return this.collectRepo.findByPartyId(id);
-  }
-
-  @Override
-  public CollectionExercise findCollectionExercise(UUID id) {
-
-    return collectRepo.findOneById(id);
-  }
-
-  @Override
-  public List<SampleLink> findLinkedSampleSummaries(UUID id) {
-    return sampleLinkRepository.findByCollectionExerciseId(id);
-  }
-
-  @Override
-  public List<CollectionExercise> findAllCollectionExercise() {
-    return collectRepo.findAll();
-  }
-
-  @Override
-  public CollectionExercise findCollectionExercise(String surveyRef, String exerciseRef) {
-      CollectionExercise collex = null;
-      SurveyDTO survey = this.surveyService.findSurveyByRef(surveyRef);
-
-      if (survey != null){
-          collex = findCollectionExercise(exerciseRef, survey);
-      }
-
-      return collex;
-  }
-
-  @Override
-  public Collection<CaseType> getCaseTypesList(CollectionExercise collectionExercise) {
-
-    List<CaseTypeDefault> caseTypeDefaultList = caseTypeDefaultRepo.findBySurveyId(collectionExercise.getSurveyId());
-
-    List<CaseTypeOverride> caseTypeOverrideList = caseTypeOverrideRepo
-        .findByExerciseFK(collectionExercise.getExercisePK());
-
-    return createCaseTypeList(caseTypeDefaultList, caseTypeOverrideList);
-  }
-
-  /**
-   * Creates a Collection of CaseTypes
-   *
-   * @param caseTypeDefaultList List of caseTypeDefaults
-   * @param caseTypeOverrideList List of caseTypeOverrides
-   * @return Collection<CaseType> Collection of CaseTypes
-   */
-  public Collection<CaseType> createCaseTypeList(List<? extends CaseType> caseTypeDefaultList,
-      List<? extends CaseType> caseTypeOverrideList) {
-
-    Map<String, CaseType> defaultMap = new HashMap<>();
-
-    for (CaseType caseTypeDefault : caseTypeDefaultList) {
-      defaultMap.put(caseTypeDefault.getSampleUnitTypeFK(), caseTypeDefault);
+    @Override
+    public List<CollectionExercise> findCollectionExercisesForSurvey(SurveyDTO survey) {
+        return this.collectRepo.findBySurveyId(UUID.fromString(survey.getId()));
     }
 
-    for (CaseType caseTypeOverride : caseTypeOverrideList) {
-      defaultMap.put(caseTypeOverride.getSampleUnitTypeFK(), caseTypeOverride);
+    @Override
+    public List<CollectionExercise> findCollectionExercisesForParty(final UUID id) {
+        return this.collectRepo.findByPartyId(id);
     }
 
-    return defaultMap.values();
-  }
+    @Override
+    public CollectionExercise findCollectionExercise(UUID id) {
 
-  /**
-   * Delete existing SampleSummary links for input CollectionExercise then link
-   * all SampleSummaries in list to CollectionExercise
-   *
-   * @param collectionExerciseId the Id of the CollectionExercise to link to
-   * @param sampleSummaryIds the list of Ids of the SampleSummaries to be linked
-   * @return linkedSummaries the list of CollectionExercises and the linked
-   *         SampleSummaries
-   */
-  @Transactional
-  @Override
-  public List<SampleLink> linkSampleSummaryToCollectionExercise(UUID collectionExerciseId,
-      List<UUID> sampleSummaryIds) {
-    sampleLinkRepository.deleteByCollectionExerciseId(collectionExerciseId);
-    List<SampleLink> linkedSummaries = new ArrayList<>();
-    for (UUID summaryId : sampleSummaryIds) {
-      linkedSummaries.add(createLink(summaryId, collectionExerciseId));
+        return collectRepo.findOneById(id);
     }
 
-      try {
-        transitionScheduleCollectionExerciseToReadyToReview(collectionExerciseId);
-      } catch (CTPException e) {
-        log.error("Failed to set state for collection exercise {} - {}", collectionExerciseId, e);
-      }
+    @Override
+    public List<SampleLink> findLinkedSampleSummaries(UUID id) {
+        return sampleLinkRepository.findByCollectionExerciseId(id);
+    }
 
-      return linkedSummaries;
-  }
+    @Override
+    public List<CollectionExercise> findAllCollectionExercise() {
+        return collectRepo.findAll();
+    }
+
+    @Override
+    public CollectionExercise findCollectionExercise(String surveyRef, String exerciseRef) {
+        CollectionExercise collex = null;
+        SurveyDTO survey = this.surveyService.findSurveyByRef(surveyRef);
+
+        if (survey != null) {
+            collex = findCollectionExercise(exerciseRef, survey);
+        }
+
+        return collex;
+    }
+
+    @Override
+    public Collection<CaseType> getCaseTypesList(CollectionExercise collectionExercise) {
+
+        List<CaseTypeDefault> caseTypeDefaultList =
+                caseTypeDefaultRepo.findBySurveyId(collectionExercise.getSurveyId());
+
+        List<CaseTypeOverride> caseTypeOverrideList = caseTypeOverrideRepo
+                .findByExerciseFK(collectionExercise.getExercisePK());
+
+        return createCaseTypeList(caseTypeDefaultList, caseTypeOverrideList);
+    }
+
+    /**
+     * Creates a Collection of CaseTypes
+     *
+     * @param caseTypeDefaultList  List of caseTypeDefaults
+     * @param caseTypeOverrideList List of caseTypeOverrides
+     * @return Collection<CaseType> Collection of CaseTypes
+     */
+    public Collection<CaseType> createCaseTypeList(List<? extends CaseType> caseTypeDefaultList,
+                                                   List<? extends CaseType> caseTypeOverrideList) {
+
+        Map<String, CaseType> defaultMap = new HashMap<>();
+
+        for (CaseType caseTypeDefault : caseTypeDefaultList) {
+            defaultMap.put(caseTypeDefault.getSampleUnitTypeFK(), caseTypeDefault);
+        }
+
+        for (CaseType caseTypeOverride : caseTypeOverrideList) {
+            defaultMap.put(caseTypeOverride.getSampleUnitTypeFK(), caseTypeOverride);
+        }
+
+        return defaultMap.values();
+    }
+
+    /**
+     * Delete existing SampleSummary links for input CollectionExercise then link
+     * all SampleSummaries in list to CollectionExercise
+     *
+     * @param collectionExerciseId the Id of the CollectionExercise to link to
+     * @param sampleSummaryIds     the list of Ids of the SampleSummaries to be linked
+     * @return linkedSummaries the list of CollectionExercises and the linked
+     * SampleSummaries
+     */
+    @Transactional
+    @Override
+    public List<SampleLink> linkSampleSummaryToCollectionExercise(UUID collectionExerciseId,
+                                                                  List<UUID> sampleSummaryIds) {
+        sampleLinkRepository.deleteByCollectionExerciseId(collectionExerciseId);
+        List<SampleLink> linkedSummaries = new ArrayList<>();
+        for (UUID summaryId : sampleSummaryIds) {
+            linkedSummaries.add(createLink(summaryId, collectionExerciseId));
+        }
+
+        try {
+            transitionScheduleCollectionExerciseToReadyToReview(collectionExerciseId);
+        } catch (CTPException e) {
+            log.error("Failed to set state for collection exercise {} - {}", collectionExerciseId, e);
+        }
+
+        return linkedSummaries;
+    }
 
     /**
      * Sets the values in a supplied collection exercise from a supplied DTO.
      * WARNING: Mutates collection exercise
-     * @param collex the dto containing the data
+     *
+     * @param collex             the dto containing the data
      * @param collectionExercise the collection exercise to apply the value from the dto to
      */
-  private void setCollectionExerciseFromDto(CollectionExerciseDTO collex, CollectionExercise collectionExercise) {
-      collectionExercise.setName(collex.getName());
-      collectionExercise.setUserDescription(collex.getUserDescription());
-      collectionExercise.setExerciseRef(collex.getExerciseRef());
-      collectionExercise.setSurveyId(UUID.fromString(collex.getSurveyId()));
+    private void setCollectionExerciseFromDto(CollectionExerciseDTO collex, CollectionExercise collectionExercise) {
+        collectionExercise.setName(collex.getName());
+        collectionExercise.setUserDescription(collex.getUserDescription());
+        collectionExercise.setExerciseRef(collex.getExerciseRef());
+        collectionExercise.setSurveyId(UUID.fromString(collex.getSurveyId()));
 
-      // In the strictest sense, some of these dates are mandatory fields for collection exercises.  However as they
-      // are not supplied at creation time, but later as "events" we will allow them to be null
-      if (collex.getScheduledStartDateTime() != null) {
-          collectionExercise.setScheduledStartDateTime(new Timestamp(collex.getScheduledStartDateTime().getTime()));
-      }
-      if (collex.getScheduledEndDateTime() != null) {
-          collectionExercise.setScheduledEndDateTime(new Timestamp(collex.getScheduledEndDateTime().getTime()));
-      }
-      if (collex.getScheduledExecutionDateTime() != null) {
-          collectionExercise.setScheduledExecutionDateTime(
-                  new Timestamp(collex.getScheduledExecutionDateTime().getTime()));
-      }
-      if (collex.getActualExecutionDateTime() != null) {
-          collectionExercise.setActualExecutionDateTime(new Timestamp(collex.getActualExecutionDateTime().getTime()));
-      }
-      if (collex.getActualPublishDateTime() != null) {
-          collectionExercise.setActualPublishDateTime(new Timestamp(collex.getActualPublishDateTime().getTime()));
-      }
-  }
+        // In the strictest sense, some of these dates are mandatory fields for collection exercises.  However as they
+        // are not supplied at creation time, but later as "events" we will allow them to be null
+        if (collex.getScheduledStartDateTime() != null) {
+            collectionExercise.setScheduledStartDateTime(new Timestamp(collex.getScheduledStartDateTime().getTime()));
+        }
+        if (collex.getScheduledEndDateTime() != null) {
+            collectionExercise.setScheduledEndDateTime(new Timestamp(collex.getScheduledEndDateTime().getTime()));
+        }
+        if (collex.getScheduledExecutionDateTime() != null) {
+            collectionExercise.setScheduledExecutionDateTime(
+                    new Timestamp(collex.getScheduledExecutionDateTime().getTime()));
+        }
+        if (collex.getActualExecutionDateTime() != null) {
+            collectionExercise.setActualExecutionDateTime(new Timestamp(collex.getActualExecutionDateTime().getTime()));
+        }
+        if (collex.getActualPublishDateTime() != null) {
+            collectionExercise.setActualPublishDateTime(new Timestamp(collex.getActualPublishDateTime().getTime()));
+        }
+    }
 
-  @Override
-  public CollectionExercise createCollectionExercise(CollectionExerciseDTO collex) {
-      CollectionExercise collectionExercise = new CollectionExercise();
+    @Override
+    public CollectionExercise createCollectionExercise(CollectionExerciseDTO collex) {
+        CollectionExercise collectionExercise = new CollectionExercise();
 
-      setCollectionExerciseFromDto(collex, collectionExercise);
+        setCollectionExerciseFromDto(collex, collectionExercise);
 
-      collectionExercise.setState(CollectionExerciseDTO.CollectionExerciseState.CREATED);
-      collectionExercise.setCreated(new Timestamp(new Date().getTime()));
-      collectionExercise.setId(UUID.randomUUID());
+        collectionExercise.setState(CollectionExerciseDTO.CollectionExerciseState.CREATED);
+        collectionExercise.setCreated(new Timestamp(new Date().getTime()));
+        collectionExercise.setId(UUID.randomUUID());
 
-      return this.collectRepo.saveAndFlush(collectionExercise);
-  }
+        return this.collectRepo.saveAndFlush(collectionExercise);
+    }
 
-  @Override
-  public CollectionExercise findCollectionExercise(String exerciseRef, SurveyDTO survey) {
-      List<CollectionExercise> existing = this.collectRepo.findByExerciseRefAndSurveyId(
-              exerciseRef,
-              UUID.fromString(survey.getId()));
+    @Override
+    public CollectionExercise findCollectionExercise(String exerciseRef, SurveyDTO survey) {
+        List<CollectionExercise> existing = this.collectRepo.findByExerciseRefAndSurveyId(
+                exerciseRef,
+                UUID.fromString(survey.getId()));
 
-      switch (existing.size()) {
-        case 0:
-          return null;
-        default:
-          return existing.get(0);
-      }
-  }
+        switch (existing.size()) {
+            case 0:
+                return null;
+            default:
+                return existing.get(0);
+        }
+    }
 
-   @Override
-   public CollectionExercise findCollectionExercise(String exerciseRef, UUID surveyId) {
-      List<CollectionExercise> existing = this.collectRepo.findByExerciseRefAndSurveyId(exerciseRef, surveyId);
+    @Override
+    public CollectionExercise findCollectionExercise(String exerciseRef, UUID surveyId) {
+        List<CollectionExercise> existing = this.collectRepo.findByExerciseRefAndSurveyId(exerciseRef, surveyId);
 
-       switch (existing.size()) {
-           case 0:
-               return null;
-           default:
-               return existing.get(0);
-       }
-   }
+        switch (existing.size()) {
+            case 0:
+                return null;
+            default:
+                return existing.get(0);
+        }
+    }
 
-   @Override
-   public CollectionExercise patchCollectionExercise(UUID id, CollectionExerciseDTO patchData) throws CTPException {
-      CollectionExercise collex = findCollectionExercise(id);
+    @Override
+    public CollectionExercise patchCollectionExercise(UUID id, CollectionExerciseDTO patchData) throws CTPException {
+        CollectionExercise collex = findCollectionExercise(id);
 
-      if (collex == null) {
-          throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                  String.format("Collection exercise %s not found", id));
-      } else {
-          String proposedPeriod = patchData.getExerciseRef() == null
-                  ? collex.getExerciseRef()
-                  : patchData.getExerciseRef();
-          UUID proposedSurvey = patchData.getSurveyId() == null
-                  ? collex.getSurveyId()
-                  : UUID.fromString(patchData.getSurveyId());
+        if (collex == null) {
+            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
+                    String.format("Collection exercise %s not found", id));
+        } else {
+            String proposedPeriod = patchData.getExerciseRef() == null
+                    ? collex.getExerciseRef()
+                    : patchData.getExerciseRef();
+            UUID proposedSurvey = patchData.getSurveyId() == null
+                    ? collex.getSurveyId()
+                    : UUID.fromString(patchData.getSurveyId());
 
-          // If period/survey not supplied in patchData then this call will trivially return
-          validateUniqueness(collex, proposedPeriod, proposedSurvey);
+            // If period/survey not supplied in patchData then this call will trivially return
+            validateUniqueness(collex, proposedPeriod, proposedSurvey);
 
-          if (!StringUtils.isBlank(patchData.getSurveyId())) {
-              UUID surveyId = UUID.fromString(patchData.getSurveyId());
+            if (!StringUtils.isBlank(patchData.getSurveyId())) {
+                UUID surveyId = UUID.fromString(patchData.getSurveyId());
 
-              SurveyDTO survey = this.surveyService.findSurvey(surveyId);
+                SurveyDTO survey = this.surveyService.findSurvey(surveyId);
 
-              if (survey == null) {
-                  throw new CTPException(CTPException.Fault.BAD_REQUEST,
-                          String.format("Survey %s does not exist", surveyId));
-              } else {
-                  collex.setSurveyId(surveyId);
-              }
-          }
+                if (survey == null) {
+                    throw new CTPException(CTPException.Fault.BAD_REQUEST,
+                            String.format("Survey %s does not exist", surveyId));
+                } else {
+                    collex.setSurveyId(surveyId);
+                }
+            }
 
-          if (!StringUtils.isBlank(patchData.getExerciseRef())) {
-              collex.setExerciseRef(patchData.getExerciseRef());
-          }
-          if (!StringUtils.isBlank(patchData.getName())) {
-              collex.setName(patchData.getName());
-          }
-          if (!StringUtils.isBlank(patchData.getUserDescription())) {
-              collex.setUserDescription(patchData.getUserDescription());
-          }
-          if (patchData.getScheduledStartDateTime() != null){
-              collex.setScheduledStartDateTime(new Timestamp(patchData.getScheduledStartDateTime().getTime()));
-          }
+            if (!StringUtils.isBlank(patchData.getExerciseRef())) {
+                collex.setExerciseRef(patchData.getExerciseRef());
+            }
+            if (!StringUtils.isBlank(patchData.getName())) {
+                collex.setName(patchData.getName());
+            }
+            if (!StringUtils.isBlank(patchData.getUserDescription())) {
+                collex.setUserDescription(patchData.getUserDescription());
+            }
+            if (patchData.getScheduledStartDateTime() != null) {
+                collex.setScheduledStartDateTime(new Timestamp(patchData.getScheduledStartDateTime().getTime()));
+            }
 
-          collex.setUpdated(new Timestamp(new Date().getTime()));
+            collex.setUpdated(new Timestamp(new Date().getTime()));
 
-          return updateCollectionExercise(collex);
-      }
-   }
+            return updateCollectionExercise(collex);
+        }
+    }
 
     /**
      * This method checks whether the supplied CollectionExercise (existing) can change it's period to candidatePeriod
      * and it's survey to candidateSurvey without breaching the uniqueness constraint on those fields
-     * @param existing the collection exercise that is to be updated
+     *
+     * @param existing        the collection exercise that is to be updated
      * @param candidatePeriod the proposed new value for the period (exerciseRef)
      * @param candidateSurvey the proposed new value for the survey
      * @throws CTPException thrown if there is an existing different collection exercise that already uses the proposed
      *                      combination of period and survey
      */
-   private void validateUniqueness(CollectionExercise existing, String candidatePeriod, UUID candidateSurvey)
-           throws CTPException {
-       if (!existing.getSurveyId().equals(candidateSurvey)
-               || !existing.getExerciseRef().equals(candidatePeriod)) {
-           CollectionExercise otherExisting = findCollectionExercise(candidatePeriod, candidateSurvey);
+    private void validateUniqueness(CollectionExercise existing, String candidatePeriod, UUID candidateSurvey)
+            throws CTPException {
+        if (!existing.getSurveyId().equals(candidateSurvey)
+                || !existing.getExerciseRef().equals(candidatePeriod)) {
+            CollectionExercise otherExisting = findCollectionExercise(candidatePeriod, candidateSurvey);
 
-           if (otherExisting != null && !otherExisting.getId().equals(existing.getId())) {
-               throw new CTPException(
-                       CTPException.Fault.RESOURCE_VERSION_CONFLICT,
-                       String.format("A collection exercise with period %s and id %s already exists.",
-                               candidatePeriod,
-                               candidateSurvey));
-           }
-       }
-   }
-
-    @Override
-  public CollectionExercise updateCollectionExercise(UUID id, CollectionExerciseDTO collexDto)  throws CTPException {
-    CollectionExercise existing = findCollectionExercise(id);
-
-    if (existing == null) {
-      throw new CTPException(
-              CTPException.Fault.RESOURCE_NOT_FOUND,
-              String.format("Collection exercise with id %s does not exist", id));
-    } else {
-        UUID surveyUuid = UUID.fromString(collexDto.getSurveyId());
-        String period = collexDto.getExerciseRef();
-
-        // This will throw exception if period & surveyId are not unique
-        validateUniqueness(existing, period, surveyUuid);
-
-        SurveyDTO survey = this.surveyService.findSurvey(surveyUuid);
-
-        if (survey == null) {
-            throw new CTPException(
-                    CTPException.Fault.BAD_REQUEST,
-                    String.format("Survey %s does not exist", surveyUuid));
-        } else {
-            setCollectionExerciseFromDto(collexDto, existing);
-            existing.setUpdated(new Timestamp(new Date().getTime()));
-
-            return updateCollectionExercise(existing);
+            if (otherExisting != null && !otherExisting.getId().equals(existing.getId())) {
+                throw new CTPException(
+                        CTPException.Fault.RESOURCE_VERSION_CONFLICT,
+                        String.format("A collection exercise with period %s and id %s already exists.",
+                                candidatePeriod,
+                                candidateSurvey));
+            }
         }
     }
-  }
+
+    @Override
+    public CollectionExercise updateCollectionExercise(UUID id, CollectionExerciseDTO collexDto) throws CTPException {
+        CollectionExercise existing = findCollectionExercise(id);
+
+        if (existing == null) {
+            throw new CTPException(
+                    CTPException.Fault.RESOURCE_NOT_FOUND,
+                    String.format("Collection exercise with id %s does not exist", id));
+        } else {
+            UUID surveyUuid = UUID.fromString(collexDto.getSurveyId());
+            String period = collexDto.getExerciseRef();
+
+            // This will throw exception if period & surveyId are not unique
+            validateUniqueness(existing, period, surveyUuid);
+
+            SurveyDTO survey = this.surveyService.findSurvey(surveyUuid);
+
+            if (survey == null) {
+                throw new CTPException(
+                        CTPException.Fault.BAD_REQUEST,
+                        String.format("Survey %s does not exist", surveyUuid));
+            } else {
+                setCollectionExerciseFromDto(collexDto, existing);
+                existing.setUpdated(new Timestamp(new Date().getTime()));
+
+                return updateCollectionExercise(existing);
+            }
+        }
+    }
 
     @Override
     public CollectionExercise updateCollectionExercise(final CollectionExercise collex) {
-       collex.setUpdated(new Timestamp(new Date().getTime()));
-       return this.collectRepo.saveAndFlush(collex);
+        collex.setUpdated(new Timestamp(new Date().getTime()));
+        return this.collectRepo.saveAndFlush(collex);
     }
 
 
     /**
      * Utility method to set the deleted flag for a collection exercise
-     * @param id the uuid of the collection exercise to update
+     *
+     * @param id      the uuid of the collection exercise to update
      * @param deleted true if the collection exercise is to be marked as deleted, false otherwise
      * @return 200 if success, 404 if not found
      * @throws CTPException thrown if specified collection exercise does not exist
      */
-  private CollectionExercise updateCollectionExerciseDeleted(UUID id, boolean deleted) throws CTPException {
-      CollectionExercise collex = findCollectionExercise(id);
+    private CollectionExercise updateCollectionExerciseDeleted(UUID id, boolean deleted) throws CTPException {
+        CollectionExercise collex = findCollectionExercise(id);
 
-      if (collex == null) {
-          throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                  String.format("Collection exercise %s does not exists", id));
-      } else {
-          collex.setDeleted(deleted);
+        if (collex == null) {
+            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
+                    String.format("Collection exercise %s does not exists", id));
+        } else {
+            collex.setDeleted(deleted);
 
-          return updateCollectionExercise(collex);
-      }
-  }
+            return updateCollectionExercise(collex);
+        }
+    }
 
     @Override
     public CollectionExercise deleteCollectionExercise(UUID id) throws CTPException {
-      return updateCollectionExerciseDeleted(id, true);
+        return updateCollectionExerciseDeleted(id, true);
     }
 
     @Override
@@ -388,59 +392,67 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
         CollectionExerciseDTO.CollectionExerciseState oldState = collex.getState();
         CollectionExerciseDTO.CollectionExerciseState newState =
                 collectionExerciseTransitionState.transition(collex.getState(), event);
-        if (oldState != newState){
+        if (oldState != newState) {
             collex.setState(newState);
             updateCollectionExercise(collex);
         }
     }
 
     @Override
-    public void transitionCollectionExercise(UUID collectionExerciseId, CollectionExerciseDTO.CollectionExerciseEvent event) throws CTPException {
-      CollectionExercise collex = findCollectionExercise(collectionExerciseId);
+    public void transitionCollectionExercise(final UUID collectionExerciseId,
+                                             final CollectionExerciseDTO.CollectionExerciseEvent event)
+            throws CTPException {
+        CollectionExercise collex = findCollectionExercise(collectionExerciseId);
 
-      if (collex == null){
-          throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, String.format("Cannot find collection exercise %s", collectionExerciseId));
-      }
+        if (collex == null) {
+            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
+                    String.format("Cannot find collection exercise %s", collectionExerciseId));
+        }
 
-      transitionCollectionExercise(collex, event);
+        transitionCollectionExercise(collex, event);
     }
 
     @Override
-    public void transitionScheduleCollectionExerciseToReadyToReview(UUID collectionExerciseId) throws CTPException {
+    public void transitionScheduleCollectionExerciseToReadyToReview(final UUID collectionExerciseId)
+            throws CTPException {
         CollectionExercise collex = findCollectionExercise(collectionExerciseId);
 
-        if (collex != null){
+        if (collex != null) {
             transitionScheduleCollectionExerciseToReadyToReview(collex);
         }
     }
 
     @Override
-    public void transitionScheduleCollectionExerciseToReadyToReview(CollectionExercise collectionExercise) throws CTPException {
-      UUID collexId = collectionExercise.getId();
-      List<SampleLink> sampleLinks = this.sampleLinkRepository.findByCollectionExerciseId(collexId);
+    public void transitionScheduleCollectionExerciseToReadyToReview(final CollectionExercise collectionExercise)
+            throws CTPException {
+        UUID collexId = collectionExercise.getId();
+        List<SampleLink> sampleLinks = this.sampleLinkRepository.findByCollectionExerciseId(collexId);
 
-      Map<String, String> searchStringMap = Collections.singletonMap("COLLECTION_EXERCISE", collectionExercise.getId().toString());
-      String searchStringJson = new JSONObject(searchStringMap).toString();
-      Integer numberOfCollectionInstruments = collectionInstrument.countCollectionInstruments(searchStringJson);
-      if (sampleLinks.size() > 0 && numberOfCollectionInstruments != null && numberOfCollectionInstruments > 0){
-          transitionCollectionExercise(collectionExercise, CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_ADDED);
-      } else {
-          transitionCollectionExercise(collectionExercise, CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_DELETED);
-      }
+        Map<String, String> searchStringMap = Collections.singletonMap("COLLECTION_EXERCISE",
+                collectionExercise.getId().toString());
+        String searchStringJson = new JSONObject(searchStringMap).toString();
+        Integer numberOfCollectionInstruments = collectionInstrument.countCollectionInstruments(searchStringJson);
+        if (sampleLinks.size() > 0 && numberOfCollectionInstruments != null && numberOfCollectionInstruments > 0) {
+            transitionCollectionExercise(collectionExercise,
+                    CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_ADDED);
+        } else {
+            transitionCollectionExercise(collectionExercise,
+                    CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_DELETED);
+        }
     }
 
     /**
-   * Links a sample summary to a collection exercise and stores in db
-   *
-   * @param sampleSummaryId the Id of the Sample summary to be linked
-   * @param collectionExerciseId the Id of the Sample summary to be linked
-   * @return sampleLink stored in database
-   */
-  private SampleLink createLink(UUID sampleSummaryId, UUID collectionExerciseId) {
-    SampleLink sampleLink = new SampleLink();
-    sampleLink.setSampleSummaryId(sampleSummaryId);
-    sampleLink.setCollectionExerciseId(collectionExerciseId);
-    return sampleLinkRepository.saveAndFlush(sampleLink);
-  }
+     * Links a sample summary to a collection exercise and stores in db
+     *
+     * @param sampleSummaryId      the Id of the Sample summary to be linked
+     * @param collectionExerciseId the Id of the Sample summary to be linked
+     * @return sampleLink stored in database
+     */
+    private SampleLink createLink(final UUID sampleSummaryId, final UUID collectionExerciseId) {
+        SampleLink sampleLink = new SampleLink();
+        sampleLink.setSampleSummaryId(sampleSummaryId);
+        sampleLink.setCollectionExerciseId(collectionExerciseId);
+        return sampleLinkRepository.saveAndFlush(sampleLink);
+    }
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -395,6 +395,17 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
     }
 
     @Override
+    public void transitionCollectionExercise(UUID collectionExerciseId, CollectionExerciseDTO.CollectionExerciseEvent event) throws CTPException {
+      CollectionExercise collex = findCollectionExercise(collectionExerciseId);
+
+      if (collex == null){
+          throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, String.format("Cannot find collection exercise %s", collectionExerciseId));
+      }
+
+      transitionCollectionExercise(collex, event);
+    }
+
+    @Override
     public void transitionScheduleCollectionExerciseToReadyToReview(UUID collectionExerciseId) throws CTPException {
         CollectionExercise collex = findCollectionExercise(collectionExerciseId);
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduleEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduleEvent.java
@@ -1,0 +1,40 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.change;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEventPublisher;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventChangeHandler;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
+
+/**
+ * EventChangeHandler to schedule and unschedule collection exercise events when CRUD operations occur
+ */
+@Component
+public class ScheduleEvent implements EventChangeHandler {
+    @Autowired
+    private EventService eventService;
+
+    /**
+     * Schedules and unschedules events based on collection exericse event CRUD events
+     * @param change the type of change that occurred
+     * @param event the event to which the change occurred
+     * @throws CTPException
+     */
+    @Override
+    public void handleEventLifecycle(final CollectionExerciseEventPublisher.MessageType change, final Event event)
+            throws CTPException {
+        switch (change) {
+            case EventCreated:
+            case EventUpdated:
+                this.eventService.scheduleEvent(event);
+                break;
+            case EventDeleted:
+                this.eventService.unscheduleEvent(event);
+                break;
+            default:
+                // We don't care about Elapsed
+        }
+    }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
@@ -94,6 +94,11 @@ public class CollectionExerciseStateTransitionManagerFactory implements StateTra
     transitionForValidated.put(CollectionExerciseEvent.PUBLISH, CollectionExerciseState.READY_FOR_LIVE);
     transitions.put(CollectionExerciseState.VALIDATED, transitionForValidated);
 
+    // READY_FOR_LIVE
+    Map<CollectionExerciseEvent, CollectionExerciseState> transitionForReadyForLive = new HashMap<>();
+    transitionForValidated.put(CollectionExerciseEvent.GO_LIVE, CollectionExerciseState.LIVE);
+    transitions.put(CollectionExerciseState.READY_FOR_LIVE, transitionForValidated);
+
     StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent> collectionExerciseTransitionManager =
         new BasicStateTransitionManager<>(transitions);
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
@@ -96,8 +96,8 @@ public class CollectionExerciseStateTransitionManagerFactory implements StateTra
 
     // READY_FOR_LIVE
     Map<CollectionExerciseEvent, CollectionExerciseState> transitionForReadyForLive = new HashMap<>();
-    transitionForValidated.put(CollectionExerciseEvent.GO_LIVE, CollectionExerciseState.LIVE);
-    transitions.put(CollectionExerciseState.READY_FOR_LIVE, transitionForValidated);
+    transitionForReadyForLive.put(CollectionExerciseEvent.GO_LIVE, CollectionExerciseState.LIVE);
+    transitions.put(CollectionExerciseState.READY_FOR_LIVE, transitionForReadyForLive);
 
     StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent> collectionExerciseTransitionManager =
         new BasicStateTransitionManager<>(transitions);

--- a/src/main/resources/springintegration/collex-event-messager-inbound.xml
+++ b/src/main/resources/springintegration/collex-event-messager-inbound.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+       xmlns:int="http://www.springframework.org/schema/integration"
+       xmlns:int-amqp="http://www.springframework.org/schema/integration/amqp"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+  http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+  http://www.springframework.org/schema/rabbit
+  http://www.springframework.org/schema/rabbit/spring-rabbit-1.6.xsd
+  http://www.springframework.org/schema/integration
+  http://www.springframework.org/schema/integration/spring-integration.xsd
+  http://www.springframework.org/schema/integration/amqp
+  http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
+  http://www.springframework.org/schema/integration/xml
+  http://www.springframework.org/schema/integration/xml/spring-integration-xml.xsd">
+
+    <!-- JSON input channel bound to incoming AMQP message -->
+    <int:channel id="cemInJson" />
+    <!-- Channel containing Java object parsed from incoming JSON -->
+    <int:channel id="cemInMessage" />
+
+    <bean id="simpleMessageConverter"
+          class="org.springframework.amqp.support.converter.SimpleMessageConverter" />
+
+    <int-amqp:inbound-channel-adapter channel="cemInJson"
+                                      queue-names="collex.event.message.inbound" connection-factory="connectionFactory"
+                                      message-converter="simpleMessageConverter" error-channel="logger"/>
+
+    <int:logging-channel-adapter id="logger" level="ERROR"/>
+
+    <int:json-to-object-transformer input-channel="cemInJson" output-channel="cemInMessage"
+                                    type="uk.gov.ons.ctp.response.collection.exercise.message.dto.EventMessageDTO"/>
+
+    <rabbit:queue name="collex.event.message.inbound" durable="false"/>
+
+    <rabbit:fanout-exchange name="collex-event-message-outbound-exchange">
+        <rabbit:bindings>
+            <rabbit:binding queue="collex.event.message.inbound"/>
+        </rabbit:bindings>
+    </rabbit:fanout-exchange>
+</beans>

--- a/src/main/resources/springintegration/collex-event-messager-outbound.xml
+++ b/src/main/resources/springintegration/collex-event-messager-outbound.xml
@@ -15,7 +15,7 @@
   http://www.springframework.org/schema/integration/xml
   http://www.springframework.org/schema/integration/xml/spring-integration-xml.xsd">
 
-<rabbit:admin connection-factory="connectionFactory" />
+    <rabbit:admin connection-factory="connectionFactory" />
     <rabbit:template id="collexEventTemplate" connection-factory="connectionFactory" exchange="collex-event-message-outbound-exchange"
                        channel-transacted="true" />
 </beans>

--- a/src/main/resources/springintegration/flows.xml
+++ b/src/main/resources/springintegration/flows.xml
@@ -10,7 +10,8 @@
 
     <import resource="sample-sampleunit-inbound-flow.xml"/>
 	<import resource="case-outbound-flow.xml"/>
-    <import resource="collex-event-messager.xml"/>
+    <import resource="collex-event-messager-outbound.xml"/>
+    <import resource="collex-event-messager-inbound.xml"/>
     <import resource="collection-instrument-inbound.xml"/>
 
 </beans>

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduleEventTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduleEventTests.java
@@ -1,0 +1,129 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.change;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.quartz.SchedulerException;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEventPublisher;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
+
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test class for ScheduleEvent
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ScheduleEventTests {
+
+    /**
+     * Test timestamp to use
+     */
+    private static final Date EVENT_TIMESTAMP = new Date();
+    /**
+     * Random collection exercise id
+     */
+    private static final UUID COLLECTION_EXERCISE_ID = UUID.randomUUID();
+    /**
+     * Random collection exercise event id
+     */
+    private static final UUID EVENT_ID = UUID.randomUUID();
+    /**
+     * Scheduler mock
+     */
+    @Mock
+    private EventService eventService;
+    /**
+     * Schedule event object under test
+     */
+    @InjectMocks
+    private ScheduleEvent scheduleEvent;
+    /**
+     * Test event
+     */
+    private Event event;
+
+    /**
+     * Setup method - creates an Event for testing
+     */
+    @Before
+    public void setUp() {
+        Event newEvent = new Event();
+
+        newEvent.setTimestamp(new Timestamp(EVENT_TIMESTAMP.getTime()));
+        newEvent.setTag(EventService.Tag.go_live.name());
+        newEvent.setId(EVENT_ID);
+
+        CollectionExercise collex = new CollectionExercise();
+        collex.setId(COLLECTION_EXERCISE_ID);
+
+        newEvent.setCollectionExercise(collex);
+
+        this.event = newEvent;
+    }
+
+    /**
+     * Given all fields
+     * When created
+     * Then schedule event
+     *
+     * @throws CTPException thrown if error occurs
+     * @throws SchedulerException thrown if error occurs
+     */
+    @Test
+    public void givenAllFieldsWhenCreatedThenScheduleEvent() throws CTPException, SchedulerException {
+        this.scheduleEvent.handleEventLifecycle(CollectionExerciseEventPublisher.MessageType.EventCreated, this.event);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(this.eventService).scheduleEvent(eventCaptor.capture());
+
+        assertEquals(this.event, eventCaptor.getValue());
+    }
+
+    /**
+     * Given all fields
+     * When updated
+     * Then schedule event
+     *
+     * @throws CTPException thrown if error occurs
+     * @throws SchedulerException thrown if error occurs
+     */
+    @Test
+    public void givenAllFieldsWhenUpdatedThenScheduleEvent() throws CTPException, SchedulerException {
+        this.scheduleEvent.handleEventLifecycle(CollectionExerciseEventPublisher.MessageType.EventUpdated, this.event);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(this.eventService).scheduleEvent(eventCaptor.capture());
+
+        assertEquals(this.event, eventCaptor.getValue());
+    }
+
+    /**
+     * Given all fields
+     * When deleted
+     * Then unschedule event
+     *
+     * @throws CTPException thrown if error occurs
+     * @throws SchedulerException thrown if error occurs
+     */
+    @Test
+    public void givenAllFieldsWhenDeletedThenUnscheduleEvent() throws CTPException, SchedulerException {
+        this.scheduleEvent.handleEventLifecycle(CollectionExerciseEventPublisher.MessageType.EventDeleted, this.event);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(this.eventService).unscheduleEvent(eventCaptor.capture());
+
+        assertEquals(this.event, eventCaptor.getValue());
+    }
+}


### PR DESCRIPTION
Implemented the transition from READY_FOR_LIVE to LIVE.  The collection exercise service now listens to messages on the collex-event-message-outbound-exchange and when a message with type Elapsed occurs for an event tag of go_live it will send a go_live event to the corresponding collection exercise state machine, hopefully putting the collection exercise into the LIVE state.  If the state is no READY_FOR_LIVE the event will bounce off and currently no other action is taken than an error will be logged (possibly needs more thought from the business)