### PR TITLE
use FORM_TYPE classifier

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/CollectionInstrumentClassifierTypes.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/CollectionInstrumentClassifierTypes.java
@@ -15,7 +15,8 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
  */
 public enum CollectionInstrumentClassifierTypes implements Function<ExerciseSampleUnit, String> {
   COLLECTION_EXERCISE(unit -> unit.getSampleUnitGroup().getCollectionExercise().getId().toString()),
-  RU_REF(ExerciseSampleUnit::getSampleUnitRef);
+  RU_REF(ExerciseSampleUnit::getSampleUnitRef),
+  FORM_TYPE(unit -> unit.getSampleUnitGroup().getFormType());
 
   private final Function<ExerciseSampleUnit, String> func;
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/CollectionInstrumentClassifierTypesTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/CollectionInstrumentClassifierTypesTest.java
@@ -20,6 +20,7 @@ public class CollectionInstrumentClassifierTypesTest {
 
   private static final String COLLECTION_EXERCISE = "COLLECTION_EXERCISE";
   private static final String RU_REF = "RU_REF";
+  private static final String FORM_TYPE = "FORM_TYPE";
 
   /**
    * Test have correct classifierTypes and value is set correctly.
@@ -38,6 +39,10 @@ public class CollectionInstrumentClassifierTypesTest {
     CollectionInstrumentClassifierTypes classifierTypeSampleUnitRef = CollectionInstrumentClassifierTypes
         .valueOf(RU_REF);
     assertEquals("50000065975", classifierTypeSampleUnitRef.apply(sampleUnit));
+
+    CollectionInstrumentClassifierTypes classifierTypeFormType = CollectionInstrumentClassifierTypes
+            .valueOf(FORM_TYPE);
+    assertEquals("0015", classifierTypeFormType.apply(sampleUnit));
 
   }
 }

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/CollectionInstrumentClassifierTypesTest.ExerciseSampleUnit.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/CollectionInstrumentClassifierTypesTest.ExerciseSampleUnit.json
@@ -7,7 +7,8 @@
         {
           "exercisePK": 1,
           "id": "14fb3e68-4dca-46db-bf49-04b84e07e77c"
-        }
+        },
+      "formType": "0015"
      },
   "sampleUnitRef": "50000065975"
 }


### PR DESCRIPTION
This PR adds FORM_TYPE classifier type as it was not getting used when fetching a collection instrument. 

Dependencies:
- https://github.com/ONSdigital/rm-survey-service/pull/27 (classifiers are fetched from this service but FORM_TYPE classifier currently is not in the DB until this PR goes in)
- Response operations should read form type from file name (WIP)
- Acceptance tests need to load a CI with form_type with it (WIP)