### PR TITLE
Defect R17-2 Remove party service link call

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -483,10 +483,6 @@ public class CollectionExerciseEndpoint {
                 .linkSampleSummaryToCollectionExercise(collectionExerciseId, linkSampleSummaryDTO.getSampleSummaryIds());
         LinkedSampleSummariesDTO result = new LinkedSampleSummariesDTO();
 
-        for (UUID summaryId : linkSampleSummaryDTO.getSampleSummaryIds()) {
-            partySvcClient.linkSampleSummaryId(summaryId.toString(), collectionExerciseId.toString());
-        }
-
         if (linkSampleSummaryToCollectionExercise != null) {
             List<UUID> summaryIds = new ArrayList<UUID>();
             for (SampleLink sampleLink : linkSampleSummaryToCollectionExercise) {

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -343,8 +343,6 @@ public class CollectionExerciseEndpointUnitTests {
         .thenReturn(collectionExerciseResults.get(0));
     when(collectionExerciseService.linkSampleSummaryToCollectionExercise(COLLECTIONEXERCISE_ID1, sampleSummaries))
         .thenReturn(sampleLink);
-    when(partySvcClient.linkSampleSummaryId(SAMPLE_SUMMARY_ID1.toString(), COLLECTIONEXERCISE_ID1.toString())).thenReturn(sampleLinkDTO1);
-    when(partySvcClient.linkSampleSummaryId(SAMPLE_SUMMARY_ID2.toString(), COLLECTIONEXERCISE_ID1.toString())).thenReturn(sampleLinkDTO2);
 
     ResultActions actions = mockCollectionExerciseMvc
         .perform(
@@ -355,11 +353,6 @@ public class CollectionExerciseEndpointUnitTests {
         .andExpect(handler().methodName("linkSampleSummary"))
         .andExpect(jsonPath("$.collectionExerciseId", is(COLLECTIONEXERCISE_ID1.toString())))
         .andExpect(jsonPath("$.sampleSummaryIds[*]", containsInAnyOrder(SAMPLE_SUMMARY_ID1.toString(), SAMPLE_SUMMARY_ID2.toString())));
-
-
-    InOrder inOrder = Mockito.inOrder((partySvcClient));
-    inOrder.verify(partySvcClient).linkSampleSummaryId(SAMPLE_SUMMARY_ID1.toString(), COLLECTIONEXERCISE_ID1.toString());
-    inOrder.verify(partySvcClient).linkSampleSummaryId(SAMPLE_SUMMARY_ID2.toString(), COLLECTIONEXERCISE_ID1.toString());
   }
 
   /**


### PR DESCRIPTION
We no longer need to manually link party to a collection exercise

Works with other PR's
https://github.com/ONSdigital/ras-party/pull/119
https://github.com/ONSdigital/rm-party-service-api/pull/10
https://github.com/ONSdigital/rm-sample-service/pull/25
https://github.com/ONSdigital/ras-backstage/pull/87

[Trello](https://trello.com/c/nakcH70j/161-defect-r172-if-the-business-name-is-updated-in-a-sample-for-the-next-period-it-is-historically-updating-the-business-name-for-pr)