### PR TITLE
Defect-R17_2-Link parties to collection exercise at execution

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -483,10 +483,6 @@ public class CollectionExerciseEndpoint {
                 .linkSampleSummaryToCollectionExercise(collectionExerciseId, linkSampleSummaryDTO.getSampleSummaryIds());
         LinkedSampleSummariesDTO result = new LinkedSampleSummariesDTO();
 
-        for (UUID summaryId : linkSampleSummaryDTO.getSampleSummaryIds()) {
-            partySvcClient.linkSampleSummaryId(summaryId.toString(), collectionExerciseId.toString());
-        }
-
         if (linkSampleSummaryToCollectionExercise != null) {
             List<UUID> summaryIds = new ArrayList<UUID>();
             for (SampleLink sampleLink : linkSampleSummaryToCollectionExercise) {

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -111,7 +111,8 @@ public class SampleServiceImpl implements SampleService {
 
             if (replyDTO != null && replyDTO.getSampleUnitsTotal() > 0) {
 
-                List<SampleLink> sampleLinks = sampleLinkRepository.findByCollectionExerciseId(collectionExercise.getId());
+                List<SampleLink> sampleLinks = sampleLinkRepository.findByCollectionExerciseId(
+                        collectionExercise.getId());
                 for (SampleLink samplelink : sampleLinks) {
                     partySvcClient.linkSampleSummaryId(samplelink.getSampleSummaryId().toString(),
                             collectionExercise.getId().toString());

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -8,12 +8,15 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
+import uk.gov.ons.ctp.response.collection.exercise.client.PartySvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.client.SampleSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.distribution.SampleUnitDistributor;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
+import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
+import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitGroupRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;
@@ -41,6 +44,12 @@ import java.util.function.Predicate;
 public class SampleServiceImpl implements SampleService {
 
     private static final int TRANSACTION_TIMEOUT = 60;
+
+    @Autowired
+    private PartySvcClient partySvcClient;
+
+    @Autowired
+    private SampleLinkRepository sampleLinkRepository;
 
     @Autowired
     private SampleUnitRepository sampleUnitRepo;
@@ -101,9 +110,14 @@ public class SampleServiceImpl implements SampleService {
             replyDTO = sampleSvcClient.requestSampleUnits(collectionExercise);
 
             if (replyDTO != null && replyDTO.getSampleUnitsTotal() > 0) {
-                log.info("HERE");
-                collectionExercise.setSampleSize(replyDTO.getSampleUnitsTotal());
 
+                List<SampleLink> sampleLinks = sampleLinkRepository.findByCollectionExerciseId(collectionExercise.getId());
+                for (SampleLink samplelink : sampleLinks) {
+                    partySvcClient.linkSampleSummaryId(samplelink.getSampleSummaryId().toString(),
+                            collectionExercise.getId().toString());
+                }
+
+                collectionExercise.setSampleSize(replyDTO.getSampleUnitsTotal());
                 collectionExercise.setState(collectionExerciseTransitionState.transition(collectionExercise.getState(),
                         CollectionExerciseEvent.EXECUTE));
                 collectRepo.saveAndFlush(collectionExercise);

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -14,7 +14,6 @@ import static uk.gov.ons.ctp.common.MvcHelper.postJson;
 import static uk.gov.ons.ctp.common.MvcHelper.putJson;
 import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
 
-import java.time.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -343,8 +343,6 @@ public class CollectionExerciseEndpointUnitTests {
         .thenReturn(collectionExerciseResults.get(0));
     when(collectionExerciseService.linkSampleSummaryToCollectionExercise(COLLECTIONEXERCISE_ID1, sampleSummaries))
         .thenReturn(sampleLink);
-    when(partySvcClient.linkSampleSummaryId(SAMPLE_SUMMARY_ID1.toString(), COLLECTIONEXERCISE_ID1.toString())).thenReturn(sampleLinkDTO1);
-    when(partySvcClient.linkSampleSummaryId(SAMPLE_SUMMARY_ID2.toString(), COLLECTIONEXERCISE_ID1.toString())).thenReturn(sampleLinkDTO2);
 
     ResultActions actions = mockCollectionExerciseMvc
         .perform(
@@ -355,11 +353,6 @@ public class CollectionExerciseEndpointUnitTests {
         .andExpect(handler().methodName("linkSampleSummary"))
         .andExpect(jsonPath("$.collectionExerciseId", is(COLLECTIONEXERCISE_ID1.toString())))
         .andExpect(jsonPath("$.sampleSummaryIds[*]", containsInAnyOrder(SAMPLE_SUMMARY_ID1.toString(), SAMPLE_SUMMARY_ID2.toString())));
-
-
-    InOrder inOrder = Mockito.inOrder((partySvcClient));
-    inOrder.verify(partySvcClient).linkSampleSummaryId(SAMPLE_SUMMARY_ID1.toString(), COLLECTIONEXERCISE_ID1.toString());
-    inOrder.verify(partySvcClient).linkSampleSummaryId(SAMPLE_SUMMARY_ID2.toString(), COLLECTIONEXERCISE_ID1.toString());
   }
 
   /**

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseExecutionEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseExecutionEndpointUnitTests.java
@@ -1,43 +1,29 @@
 package uk.gov.ons.ctp.response.collection.exercise.endpoint;
 
 import lombok.extern.slf4j.Slf4j;
-import ma.glasnost.orika.MapperFacade;
-import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.ons.ctp.common.FixtureHelper;
-import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.RestExceptionHandler;
 import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
-import uk.gov.ons.ctp.response.collection.exercise.CollectionExerciseBeanMapper;
-import uk.gov.ons.ctp.response.collection.exercise.domain.*;
-import uk.gov.ons.ctp.response.collection.exercise.representation.LinkedSampleSummariesDTO;
-import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
-import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static uk.gov.ons.ctp.common.MvcHelper.*;
-import static uk.gov.ons.ctp.common.TestHelper.createTestDate;
 import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
 
 /**


### PR DESCRIPTION
Stop linking parties to a collection exercise when the collection exercise is initially linked to the sample.

Instead do this link when collection exercise is executed. 
This fixes(improves at least) a problem with race conditions we were having and it will make it easier to change a sample in the future