### PR TITLE
Remove exercises by party id endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -190,59 +190,6 @@ An `HTTP 404 Not Found` status code is returned if the survey with the specified
 ]
 ```
 
-## Get Collection Exercises for Party
-* `GET /collectionexercises/party/{party_id}` will return a list of known collection exercises for the party id.
-
-### Example JSON Response
-```json
-[
-  {
-    "id": "c6467711-21eb-4e78-804c-1db8392f93fb",
-    "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
-    "name": "Monthly Survey of Building Materials Bricks",
-    "actualExecutionDateTime": null,
-    "scheduledExecutionDateTime": null,
-    "scheduledStartDateTime": null,
-    "actualPublishDateTime": null,
-    "periodStartDateTime": null,
-    "periodEndDateTime": null,
-    "scheduledReturnDateTime": null,
-    "scheduledEndDateTime": null,
-    "executedBy": null,
-    "state": "INIT",
-    "caseTypes": null,
-    "exerciseRef": "201801",
-    "userDescription": "January 2018",
-    "created": "2018-01-09T12:56:09.652Z",
-    "updated": null,
-    "deleted": null,
-    "validationErrors": []
-  },
-  {
-    "id": "b447e134-5e5d-46fb-b4fc-15efdcbe5ca7",
-    "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
-    "name": "Monthly Survey of Building materials Bricks",
-    "actualExecutionDateTime": null,
-    "scheduledExecutionDateTime": null,
-    "scheduledStartDateTime": null,
-    "actualPublishDateTime": null,
-    "periodStartDateTime": null,
-    "periodEndDateTime": null,
-    "scheduledReturnDateTime": null,
-    "scheduledEndDateTime": null,
-    "executedBy": null,
-    "state": "INIT",
-    "caseTypes": null,
-    "exerciseRef": "201802",
-    "userDescription": "February 2018",
-    "created": "2018-01-09T12:56:09.709Z",
-    "updated": null,
-    "deleted": null,
-    "validationErrors": []
-  }
-]
-```
-
 ## Get Collection Exercise
 * `GET /collectionexercises/{collection_exercise_id}` will return the details of the collection exercise with the given id.
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.InvalidRequestException;
-import uk.gov.ons.ctp.response.collection.exercise.client.PartySvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseType;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
@@ -68,11 +67,8 @@ public class CollectionExerciseEndpoint {
     private static final String RETURN_COLLECTIONEXERCISENOTFOUND =
             "Collection Exercise not found for collection exercise Id";
     private static final String RETURN_SURVEYNOTFOUND = "Survey not found for survey Id";
-    private static final String RETURN_PARTYNOTFOUND = "Party not found for party Id";
     private static final ValidatorFactory VALIDATOR_FACTORY = Validation.buildDefaultValidatorFactory();
 
-    @Autowired
-    private PartySvcClient partySvcClient;
 
     @Autowired
     private CollectionExerciseService collectionExerciseService;
@@ -133,38 +129,6 @@ public class CollectionExerciseEndpoint {
             if (collectionExerciseList.isEmpty()) {
                 return ResponseEntity.noContent().build();
             }
-        }
-
-        return ResponseEntity.ok(collectionExerciseSummaryDTOList);
-    }
-
-    /**
-     * GET to find collection exercises from the collection exercise service for
-     * the given party Id.
-     *
-     * @param id party Id for which to trigger delivery of collection exercises
-     * @return list of collection exercises associated to party
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/party/{id}", method = RequestMethod.GET)
-    public ResponseEntity<List<CollectionExerciseDTO>> getCollectionExercisesForParty(
-            @PathVariable("id") final UUID id) throws CTPException {
-
-        Boolean partyExists = sampleService.partyExists(id);
-
-        List<CollectionExerciseDTO> collectionExerciseSummaryDTOList;
-
-        if (!partyExists) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("%s %s", RETURN_PARTYNOTFOUND, id));
-        }
-
-        log.debug("Entering collection exercise fetch with party Id {}", id);
-        List<CollectionExercise> collectionExerciseList = collectionExerciseService
-                .findCollectionExercisesForParty(id);
-        collectionExerciseSummaryDTOList = collectionExerciseList.stream().map(collex -> getCollectionExerciseDTO(collex)).collect(Collectors.toList());
-        if (collectionExerciseList.isEmpty()) {
-            return ResponseEntity.noContent().build();
         }
 
         return ResponseEntity.ok(collectionExerciseSummaryDTOList);

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepository.java
@@ -36,16 +36,6 @@ public interface SampleUnitRepository extends JpaRepository<ExerciseSampleUnit, 
   boolean tupleExists(@Param("p_exercisefk") Integer id, @Param("p_sampleunitref") String sampleUnitRef,
       @Param("p_sampleunittypefk") String sampleUnitTypeFK);
 
-  /**
-   * Check repository for SampleUnit existence by party ID.
-   *
-   * @param partyID sample unit party id to check for existence of sample unit.
-   * @return boolean whether exists
-   */
-  @Query(value = "select exists (select 1 from "
-          + "collectionexercise.sampleunit su "
-          + "where su.partyid = :p_partyid);", nativeQuery = true)
-  boolean partyExists(@Param("p_partyid") UUID partyID);
 
   /**
    * Count the number of SampleUnits for the CollectionExercise.

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
@@ -47,13 +47,6 @@ public interface SampleService {
    */
   void distributeSampleUnits(CollectionExercise exercise);
 
-  /**
-   * Check if SampleUnit exists by party ID.
-   *
-   * @param id for which to distribute SampleUnits.
-   * @return boolean
-   */
-  boolean partyExists(UUID id);
 
   /**
    * Get the sample unit validation errors for a given collection exercise

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -196,11 +196,6 @@ public class SampleServiceImpl implements SampleService {
     }
 
     @Override
-    public boolean partyExists(final UUID id) {
-        return this.sampleUnitRepo.partyExists(id);
-    }
-
-    @Override
     public SampleUnitValidationErrorDTO[] getValidationErrors(final UUID collectionExerciseId) {
         List<ExerciseSampleUnit> sampleUnits = this.sampleUnitRepo.findInvalidByCollectionExercise(collectionExerciseId);
         Predicate<ExerciseSampleUnit> validTest = su -> !(su.getPartyId() instanceof UUID)

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -198,48 +198,6 @@ public class CollectionExerciseEndpointUnitTests {
   }
 
   /**
-   * Tests if collection exercise found for party.
-   *
-   * @throws Exception exception thrown
-   */
-  @Test
-  public void findCollectionExercisesForParty() throws Exception {
-    when(sampleService.partyExists(PARTY_ID_1)).thenReturn(true);
-    when(collectionExerciseService.findCollectionExercisesForParty(PARTY_ID_1))
-            .thenReturn(collectionExerciseResults);
-
-    ResultActions actions = mockCollectionExerciseMvc.perform(getJson(String.format("/collectionexercises/party/%s", PARTY_ID_1)));
-
-    actions.andExpect(status().isOk())
-            .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
-            .andExpect(handler().methodName("getCollectionExercisesForParty"))
-            .andExpect(jsonPath("$", hasSize(2)))
-            .andExpect(jsonPath("$[*].id",
-                    containsInAnyOrder(COLLECTIONEXERCISE_ID1.toString(), COLLECTIONEXERCISE_ID2.toString())))
-            .andExpect(jsonPath("$[*].name", containsInAnyOrder(COLLECTIONEXERCISE_NAME, COLLECTIONEXERCISE_NAME)))
-            .andExpect(jsonPath("$[*].scheduledExecutionDateTime",
-                    containsInAnyOrder(new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT),
-                            new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT))));
-  }
-
-  /**
-   * Tests collection exercise not found.
-   *
-   * @throws Exception exception thrown
-   */
-  @Test
-  public void findCollectionExercisesForPartyNotFound() throws Exception {
-    ResultActions actions = mockCollectionExerciseMvc
-            .perform(getJson(String.format("/collectionexercises/party/%s", Party_IDNOTFOUND)));
-
-    actions.andExpect(status().isNotFound())
-            .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
-            .andExpect(handler().methodName("getCollectionExercisesForParty"))
-            .andExpect(jsonPath("$.error.code", Is.is(CTPException.Fault.RESOURCE_NOT_FOUND.name())));
-
-  }
-
-  /**
    * Tests if collection exercise found for Id.
    *
    * @throws Exception exception thrown


### PR DESCRIPTION
We should not be using the party data in this service to determine CE association.
Currently backstage is the only service using this endpoint, which is being removed in https://github.com/ONSdigital/ras-backstage/pull/105. I am removing the endpoint to avoid future misuse. 