### PR TITLE
Add instructions for settings up maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@
 # Collection Exercise Service
 The Collection Exercise service will be responsible for the orchestration of the processes necessary to begin the data collection for a particular field period for a particular survey.
 
+## Running
+
+There are two ways of running this service
+
+* The easiest way is via docker (https://github.com/ONSdigital/ras-rm-docker-dev)
+* Alternatively running the service up in isolation
+    ```bash
+    cp .maven.settings.xml ~/.m2/settings.xml  # This only needs to be done once to set up mavens settings file
+    mvn clean install
+    mvn spring-boot:run
+    ```
+
 # API
 See [API.md](https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/API.md) for API documentation.
 


### PR DESCRIPTION
## Background
Developers who have recently started working on this project have not been aware that they need to update their local ~/.m2/settings.xml file to be able to build the project.

The service depends on artifacts that are being stored in artifactory.
The instructions that have been added describe how to configure maven
locally for building the project.

## What has changed
Added documentation describing how to start service

## How to review
Check instructions to start service are correct