### PR TITLE
Service now waits for sample upload message before transitioning to READY_FOR_REVIEW.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>collectionexercisesvc-api</artifactId>
-      <version>10.49.9</version>
+      <version>10.49.11-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
@@ -27,6 +27,7 @@ import uk.gov.ons.ctp.common.state.StateTransitionManagerFactory;
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
+import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
 import uk.gov.ons.ctp.response.collection.exercise.service.impl.EventValidator;
@@ -189,7 +190,20 @@ public class CollectionExerciseApplication {
   @Qualifier("sampleUnitGroup")
   public StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent> sampleUnitGroupStateTransitionManager() {
     return collectionExerciseStateTransitionManagerFactory
-        .getStateTransitionManager(CollectionExerciseStateTransitionManagerFactory.SAMPLEUNITGROUP_ENTITY);
+            .getStateTransitionManager(CollectionExerciseStateTransitionManagerFactory.SAMPLEUNITGROUP_ENTITY);
+  }
+
+  /**
+   * Bean to allow controlled state transitions of SampleLinks.
+   *
+   * @return the state transition manager specifically for SampleLinks
+   */
+  @Bean
+  @Qualifier("sampleLink")
+  public StateTransitionManager<LinkSampleSummaryDTO.SampleLinkState, LinkSampleSummaryDTO.SampleLinkEvent>
+  sampleLinkStateTransitionManager() {
+    return collectionExerciseStateTransitionManagerFactory
+        .getStateTransitionManager(CollectionExerciseStateTransitionManagerFactory.SAMPLELINK_ENTITY);
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/SampleLink.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/SampleLink.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -15,6 +17,7 @@ import org.hibernate.annotations.Parameter;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import net.sourceforge.cobertura.CoverageIgnore;
+import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO;
 
 @CoverageIgnore
 @Data
@@ -39,4 +42,7 @@ public class SampleLink {
   @Column(name = "samplesummaryid")
   private UUID sampleSummaryId;
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "statefk")
+  private LinkSampleSummaryDTO.SampleLinkState state;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUploadedInboundReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUploadedInboundReceiver.java
@@ -1,0 +1,65 @@
+package uk.gov.ons.ctp.response.collection.exercise.message.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.integration.annotation.MessageEndpoint;
+import org.springframework.integration.annotation.ServiceActivator;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.state.StateTransitionManager;
+import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
+import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO;
+import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
+import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
+import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
+
+import java.util.List;
+
+/**
+ * Class to hold service activator method to handle incoming sample uploaded messages
+ */
+@MessageEndpoint
+@Slf4j
+public class SampleUploadedInboundReceiver {
+
+    @Autowired
+    private CollectionExerciseService collectionExerciseService;
+
+    @Autowired
+    private SampleService sampleService;
+
+    @Autowired
+    @Qualifier("sampleLink")
+    private StateTransitionManager<LinkSampleSummaryDTO.SampleLinkState, LinkSampleSummaryDTO.SampleLinkEvent>
+            sampleLinkState;
+
+    private void activateSampleLink(SampleLink sampleLink){
+        try {
+            LinkSampleSummaryDTO.SampleLinkState newState =
+                    this.sampleLinkState.transition(sampleLink.getState(),
+                            LinkSampleSummaryDTO.SampleLinkEvent.ACTIVATE);
+
+            sampleLink.setState(newState);
+
+            this.sampleService.saveSampleLink(sampleLink);
+
+            this.collectionExerciseService.transitionScheduleCollectionExerciseToReadyToReview(
+                    sampleLink.getCollectionExerciseId());
+        } catch (CTPException e) {
+            log.error("Failed to activate sample link {} - {}", sampleLink, e);
+        }
+    }
+
+    /**
+     * Service activator method - check we know about the sample link and set it to active
+     *
+     * @param sampleSummary the sample summary for which the upload has completed
+     */
+    @ServiceActivator(inputChannel = "sampleSummaryInMessage")
+    public void sampleUploaded(final SampleSummaryDTO sampleSummary){
+            List<SampleLink> links = this.sampleService.getSampleLinksForSummary(sampleSummary.getId());
+
+            links.stream().forEach(l -> activateSampleLink(l));
+    }
+}
+

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleLinkRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleLinkRepository.java
@@ -27,4 +27,11 @@ public interface SampleLinkRepository extends JpaRepository<SampleLink, Integer>
    */
   List<SampleLink> findByCollectionExerciseId(UUID id);
 
+  /**
+   * Find sample link for a sample summary
+   *
+   * @param sampleSummaryId the id of the sample summary to find the links for
+   * @return a list of SampleLinks with the given sample summary
+   */
+  List<SampleLink> findBySampleSummaryId(UUID sampleSummaryId);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
@@ -1,10 +1,12 @@
 package uk.gov.ons.ctp.response.collection.exercise.service;
 
+import java.util.List;
 import java.util.UUID;
 
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
+import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitValidationErrorDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
@@ -54,4 +56,18 @@ public interface SampleService {
    * @return an array of validation errors
    */
   SampleUnitValidationErrorDTO[] getValidationErrors(UUID collectionExerciseId);
+
+  /**
+   * Gets a list of sample links for a given sample summary
+   * @param sampleSummaryId the id of the sample summary to find sample links for
+   * @return a list of sample links
+   */
+  List<SampleLink> getSampleLinksForSummary(UUID sampleSummaryId);
+
+  /**
+   * Method to save a sample link
+   * @param sampleLink the sample link to save
+   * @return the updated sample link
+   */
+  SampleLink saveSampleLink(SampleLink sampleLink);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -206,4 +206,14 @@ public class SampleServiceImpl implements SampleService {
                 .map(SampleServiceImpl::validateSampleUnit)
                 .toArray(SampleUnitValidationErrorDTO[]::new);
     }
+
+    @Override
+    public List<SampleLink> getSampleLinksForSummary(UUID sampleSummaryId) {
+        return this.sampleLinkRepository.findBySampleSummaryId(sampleSummaryId);
+    }
+
+    @Override
+    public SampleLink saveSampleLink(SampleLink sampleLink) {
+        return this.sampleLinkRepository.saveAndFlush(sampleLink);
+    }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
@@ -10,6 +10,7 @@ import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.common.state.StateTransitionManagerFactory;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
+import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
 
@@ -22,6 +23,8 @@ public class CollectionExerciseStateTransitionManagerFactory implements StateTra
   public static final String COLLLECTIONEXERCISE_ENTITY = "CollectionExercise";
 
   public static final String SAMPLEUNITGROUP_ENTITY = "SampleUnitGroup";
+
+  public static final String SAMPLELINK_ENTITY = "SampleLink";
 
   private Map<String, StateTransitionManager<?, ?>> managers;
 
@@ -40,6 +43,9 @@ public class CollectionExerciseStateTransitionManagerFactory implements StateTra
         createSampleUnitGroupStateTransitionManager();
     managers.put(SAMPLEUNITGROUP_ENTITY, sampleUnitGroupStateTransitionManager);
 
+    StateTransitionManager<LinkSampleSummaryDTO.SampleLinkState, LinkSampleSummaryDTO.SampleLinkEvent>
+            sampleLinkStateTransitionManager = createSampleLinkStateTransitionManager();
+    managers.put(SAMPLELINK_ENTITY, sampleLinkStateTransitionManager);
   }
 
   /**
@@ -118,7 +124,7 @@ public class CollectionExerciseStateTransitionManagerFactory implements StateTra
    * @return StateTransitionManager
    */
   private StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent>
-      createSampleUnitGroupStateTransitionManager() {
+  createSampleUnitGroupStateTransitionManager() {
 
     Map<SampleUnitGroupState, Map<SampleUnitGroupEvent, SampleUnitGroupState>> transitions = new HashMap<>();
 
@@ -134,10 +140,36 @@ public class CollectionExerciseStateTransitionManagerFactory implements StateTra
     transitions.put(SampleUnitGroupState.VALIDATED, transitionForValidated);
 
     StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent> sampleUnitTransitionManager =
+            new BasicStateTransitionManager<>(transitions);
+
+    return sampleUnitTransitionManager;
+  }
+
+  /**
+   * Create and initialise the factory with the concrete StateTransitionManager
+   * for the SampleLink entity
+   *
+   * @return StateTransitionManager
+   */
+  private StateTransitionManager<LinkSampleSummaryDTO.SampleLinkState, LinkSampleSummaryDTO.SampleLinkEvent>
+      createSampleLinkStateTransitionManager() {
+
+    Map<LinkSampleSummaryDTO.SampleLinkState,
+        Map<LinkSampleSummaryDTO.SampleLinkEvent, LinkSampleSummaryDTO.SampleLinkState>> transitions = new HashMap<>();
+
+    // INIT
+    Map<LinkSampleSummaryDTO.SampleLinkEvent, LinkSampleSummaryDTO.SampleLinkState> transitionForInit = new HashMap<>();
+    transitionForInit.put(LinkSampleSummaryDTO.SampleLinkEvent.ACTIVATE, LinkSampleSummaryDTO.SampleLinkState.ACTIVE);
+
+    transitions.put(LinkSampleSummaryDTO.SampleLinkState.INIT, transitionForInit);
+
+    StateTransitionManager<LinkSampleSummaryDTO.SampleLinkState,
+            LinkSampleSummaryDTO.SampleLinkEvent> sampleUnitTransitionManager =
         new BasicStateTransitionManager<>(transitions);
 
     return sampleUnitTransitionManager;
   }
+
 
   @SuppressWarnings("unchecked")
   @Override

--- a/src/main/resources/database/changes/release-10.49.2/add-state-to-samplelink.sql
+++ b/src/main/resources/database/changes/release-10.49.2/add-state-to-samplelink.sql
@@ -1,0 +1,21 @@
+-- Table: state
+CREATE TABLE collectionexercise.samplelinkstate
+(
+  statePK character varying(20) NOT NULL PRIMARY KEY
+);
+
+INSERT INTO collectionexercise.samplelinkstate ( statePK ) VALUES ('INIT');
+INSERT INTO collectionexercise.samplelinkstate ( statePK ) VALUES ('ACTIVE');
+
+ALTER TABLE collectionexercise.samplelink ADD COLUMN statefk CHARACTER VARYING(20);
+
+-- Assume any existing samplelinks are ACTIVE
+UPDATE collectionexercise.samplelink SET statefk = 'ACTIVE';
+
+ALTER TABLE collectionexercise.samplelink
+ADD CONSTRAINT sl_statefk_fkey FOREIGN KEY (statefk) REFERENCES collectionexercise.samplelinkstate(statePK);
+
+ALTER TABLE collectionexercise.samplelink ALTER COLUMN statefk SET NOT NULL;
+
+
+

--- a/src/main/resources/database/changes/release-10.49.2/changelog.yml
+++ b/src/main/resources/database/changes/release-10.49.2/changelog.yml
@@ -98,3 +98,12 @@ databaseChangeLog:
             comment: Remove remaining vestiges of cached survey data
             path: drop-survey-table.sql
             relativeToChangelogFile: true
+
+  - changeSet:
+      id: 10.49.2-12
+      author: Matt Innes
+      changes:
+        - sqlFile:
+            comment: Adds state to samplelink
+            path: add-state-to-samplelink.sql
+            relativeToChangelogFile: true

--- a/src/main/resources/springintegration/flows.xml
+++ b/src/main/resources/springintegration/flows.xml
@@ -13,5 +13,6 @@
     <import resource="collex-event-messager-outbound.xml"/>
     <import resource="collex-event-messager-inbound.xml"/>
     <import resource="collection-instrument-inbound.xml"/>
+    <import resource="sample-uploaded-inbound.xml"/>
 
 </beans>

--- a/src/main/resources/springintegration/sample-uploaded-inbound.xml
+++ b/src/main/resources/springintegration/sample-uploaded-inbound.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+       xmlns:int="http://www.springframework.org/schema/integration"
+       xmlns:int-amqp="http://www.springframework.org/schema/integration/amqp"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+  http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+  http://www.springframework.org/schema/rabbit
+  http://www.springframework.org/schema/rabbit/spring-rabbit-1.6.xsd
+  http://www.springframework.org/schema/integration
+  http://www.springframework.org/schema/integration/spring-integration.xsd
+  http://www.springframework.org/schema/integration/amqp
+  http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
+  http://www.springframework.org/schema/integration/xml
+  http://www.springframework.org/schema/integration/xml/spring-integration-xml.xsd">
+
+    <!-- JSON input channel bound to incoming AMQP message -->
+    <int:channel id="sampleSummaryInJson" />
+    <!-- Channel containing Java object parsed from incoming JSON -->
+    <int:channel id="sampleSummaryInMessage" />
+
+    <bean id="simpleMessageConverter"
+          class="org.springframework.amqp.support.converter.SimpleMessageConverter" />
+
+    <int-amqp:inbound-channel-adapter channel="sampleSummaryInJson"
+                                      queue-names="collex.sample.uploaded.inbound"
+                                      connection-factory="connectionFactory"
+                                      message-converter="simpleMessageConverter"
+                                      error-channel="logger"/>
+
+    <int:logging-channel-adapter id="logger" level="ERROR"/>
+
+    <int:json-to-object-transformer input-channel="sampleSummaryInJson" output-channel="sampleSummaryInMessage"
+                                    type="uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO"/>
+
+    <rabbit:queue name="collex.sample.uploaded.inbound" durable="false"/>
+
+    <rabbit:direct-exchange name="sample-outbound-exchange">
+        <rabbit:bindings>
+            <rabbit:binding queue="collex.sample.uploaded.inbound" key="Sample.SampleUploadFinished.binding"/>
+        </rabbit:bindings>
+    </rabbit:direct-exchange>
+</beans>

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
@@ -21,6 +21,7 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
 import uk.gov.ons.ctp.response.collection.exercise.state.CollectionExerciseStateTransitionManagerFactory;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
@@ -423,7 +424,9 @@ public class CollectionExerciseServiceImplTest {
     // Given
     CollectionExercise exercise = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     exercise.setState(CollectionExerciseDTO.CollectionExerciseState.SCHEDULED);
-    given(sampleLinkRepository.findByCollectionExerciseId(exercise.getId())).willReturn(Collections.singletonList(new SampleLink()));
+    SampleLink testSampleLink = new SampleLink();
+    testSampleLink.setState(LinkSampleSummaryDTO.SampleLinkState.ACTIVE);
+    given(sampleLinkRepository.findByCollectionExerciseId(exercise.getId())).willReturn(Collections.singletonList(testSampleLink));
     String searchStringJson = new JSONObject(Collections.singletonMap("COLLECTION_EXERCISE", exercise.getId().toString())).toString();
     given(collectionInstrument.countCollectionInstruments(searchStringJson)).willReturn(1);
 


### PR DESCRIPTION
- change the sample service to create a sample summary straight away, kick off the upload in the background and return immediately
- change the collection exercise service to create a sample link immediately but only activate it when it receives a message on the sample-outbound-exchange with routing key Sample.SampleUploadFinished.binding
- change response-operations-ui to display the state of the upload and any successful completion or error