### PR TITLE
Added an integration test to test receiving sample upload finished messages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '2'
+services:
+ postgres:
+  container_name: postgres-it
+  image: sdcplatform/ras-rm-docker-postgres
+  ports:
+   - "15432:5432"
+ redis:
+  container_name: redis-it
+  image: redis:3.2.9
+  ports:
+   - "17379:6379"
+ rabbitmq:
+  container_name: rabbitmq-it
+  image: rabbitmq:3.6.10-management
+  ports:
+    - "14369:4369"
+    - "35672:25672"
+    - "15671:5671"
+    - "15672:5672"
+    - "25671:15671"
+    - "26672:15672"
+ sftp:
+    container_name: sftp-it
+    image: atmoz/sftp
+    volumes:
+        - ~/Documents/sftp:/home/centos/Documents/sftp
+    ports:
+        - "222:22"
+    command: centos:JLibV2&XD,:1001
+ survey:
+   container_name: survey-it
+   image: sdcplatform/surveysvc
+   ports:
+    - "18080:8080"
+   external_links:
+    - postgres-it
+   environment:
+    - DATABASE_URL=postgres://postgres:postgres@postgres-it:5432/postgres?sslmode=disable
+    - security_user_name=admin
+    - security_user_password=secret
+

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>collectionexercisesvc-api</artifactId>
-      <version>10.49.11</version>
+      <version>10.49.12</version>
     </dependency>
 
     <dependency>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.common</groupId>
       <artifactId>framework</artifactId>
-      <version>10.49.10</version>
+      <version>10.49.12</version>
     </dependency>
 
     <dependency>
@@ -183,6 +183,13 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-context-support</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.mashape.unirest</groupId>
+      <artifactId>unirest-java</artifactId>
+      <version>1.4.9</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <scm>
@@ -218,6 +225,9 @@
         <configuration>
           <executable>true</executable>
           <mainClass>uk.gov.ons.ctp.response.collection.exercise.CollectionExerciseApplication</mainClass>
+          <profiles>
+            <profile>test</profile>
+          </profiles>
         </configuration>
         <executions>
           <execution>
@@ -257,6 +267,77 @@
           </formats>
           <check />
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.23.0</version>
+        <executions>
+          <execution>
+            <id>pre-stop</id>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+            <phase>pre-integration-test</phase>
+            <configuration>
+              <images>
+                <image>
+                  <external>
+                    <type>compose</type>
+                    <basedir>${project.basedir}</basedir>
+                  </external>
+                </image>
+              </images>
+            </configuration>
+          </execution>
+          <execution>
+            <id>start</id>
+            <goals>
+              <goal>start</goal>
+            </goals>
+            <configuration>
+              <showLogs>false</showLogs>
+              <images>
+                <image>
+                  <external>
+                    <type>compose</type>
+                    <basedir>${project.basedir}</basedir>
+                  </external>
+                </image>
+              </images>
+            </configuration>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+            <configuration>
+              <images>
+                <image>
+                  <external>
+                    <type>compose</type>
+                    <basedir>${project.basedir}</basedir>
+                  </external>
+                </image>
+              </images>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.18.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
     <resources>

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
@@ -127,7 +127,7 @@ public class SurveySvcRestClientImpl implements SurveySvcClient {
     HttpEntity<?> httpEntity = restUtility.createHttpEntity(null);
 
     try {
-      log.debug("about to get to the Survey SVC with surveyId {}", surveyId);
+      log.debug("about to get to the Survey SVC with surveyId {} from {}", surveyId, uriComponents.toUri());
       ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
               String.class);
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
@@ -145,7 +145,7 @@ public class SurveySvcRestClientImpl implements SurveySvcClient {
     HttpEntity<?> httpEntity = restUtility.createHttpEntity(null);
 
     try {
-      log.debug("about to get to the Survey SVC with surveyRef {}", surveyRef);
+      log.debug("about to get to the Survey SVC with surveyRef {} from {}", surveyRef, uriComponents.toUri());
       ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
               String.class);
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/AppConfig.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 import lombok.Data;
+import uk.gov.ons.ctp.common.message.rabbit.Rabbitmq;
 
 /**
  * The apps main holder for centralised configuration read from application.yml
@@ -24,5 +25,6 @@ public class AppConfig {
   private RedissonConfig redissonConfig;
   private ScheduleSettings schedules;
   private SwaggerSettings swaggerSettings;
+  private Rabbitmq rabbitmq;
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -29,6 +29,7 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExer
 import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.LinkedSampleSummariesDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.SampleLinkDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitValidationErrorDTO;
 import uk.gov.ons.ctp.response.collection.exercise.schedule.SchedulerConfiguration;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
@@ -228,7 +229,8 @@ public class CollectionExerciseEndpoint {
      * @return 200 if all is ok, 400 for bad request, 409 for conflict
      * @throws CTPException thrown if constraint violation etc
      */
-    private ResponseEntity<?> patchCollectionExercise(final UUID id, final CollectionExerciseDTO collexDto) throws CTPException {
+    private ResponseEntity<?> patchCollectionExercise(final UUID id, final CollectionExerciseDTO collexDto)
+            throws CTPException {
         validateConstraints(collexDto);
 
         this.collectionExerciseService.patchCollectionExercise(id, collexDto);
@@ -252,12 +254,14 @@ public class CollectionExerciseEndpoint {
         CollectionExerciseDTO collexDto = new CollectionExerciseDTO();
 
         try {
-            LocalDateTime date = LocalDateTime.parse(scheduledStart, DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSX", Locale.ROOT));
+            LocalDateTime date = LocalDateTime.parse(scheduledStart,
+                    DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSX", Locale.ROOT));
             collexDto.setScheduledStartDateTime(java.sql.Timestamp.valueOf(date));
 
             return patchCollectionExercise(id, collexDto);
         } catch (DateTimeParseException e) {
-            throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format("Unparseable date %s (%s)", scheduledStart, e.getLocalizedMessage()));
+            throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format("Unparseable date %s (%s)",
+                    scheduledStart, e.getLocalizedMessage()));
         }
     }
 
@@ -444,7 +448,8 @@ public class CollectionExerciseEndpoint {
         }
 
         List<SampleLink> linkSampleSummaryToCollectionExercise = collectionExerciseService
-                .linkSampleSummaryToCollectionExercise(collectionExerciseId, linkSampleSummaryDTO.getSampleSummaryIds());
+                .linkSampleSummaryToCollectionExercise(collectionExerciseId,
+                        linkSampleSummaryDTO.getSampleSummaryIds());
         LinkedSampleSummariesDTO result = new LinkedSampleSummariesDTO();
 
         if (linkSampleSummaryToCollectionExercise != null) {
@@ -461,12 +466,29 @@ public class CollectionExerciseEndpoint {
     }
 
     /**
+     * Endpoint to return the list of samples linked to a collection exercise
+     *
+     * @param collectionExerciseId the collection exercise for which the links are required
+     * @return a list of sample summaries linked to the collection exercise
+     */
+    @RequestMapping(value = "/link/{collectionExerciseId}", method = RequestMethod.GET,
+            produces = "application/vnd.ons.sdc.samplelink.v1+json")
+    public ResponseEntity<List<SampleLinkDTO>> getSampleLinks(
+            @PathVariable("collectionExerciseId") final UUID collectionExerciseId) {
+        log.debug("Getting linked sample summaries for {}", collectionExerciseId);
+        List<SampleLink> sampleLinks = this.collectionExerciseService.findLinkedSampleSummaries(collectionExerciseId);
+        List<SampleLinkDTO> sampleLinkList = mapperFacade.mapAsList(sampleLinks, SampleLinkDTO.class);
+
+        return ResponseEntity.ok(sampleLinkList);
+    }
+
+    /**
      * for unlinking sample summary from a collection exercise
      *
      * @param collectionExerciseId the collection exercise to unlink from sample
-     * @param sampleSummaryId the collection exercise to unlink from collection exercise
+     * @param sampleSummaryId      the collection exercise to unlink from collection exercise
      * @return noContent response
-     * @throws CTPException            on resource not found
+     * @throws CTPException on resource not found
      */
     @RequestMapping(value = "/unlink/{collectionExerciseId}/sample/{sampleSummaryId}", method = RequestMethod.DELETE)
     public ResponseEntity<?> unlinkSampleSummary(
@@ -579,7 +601,9 @@ public class CollectionExerciseEndpoint {
     public ResponseEntity<List<EventDTO>> getCollectionExerciseEvents(
             @PathVariable("id") final UUID id)
             throws CTPException {
-        List<EventDTO> result = this.eventService.getEvents(id).stream().map(EventService::createEventDTOFromEvent).collect(Collectors.toList());
+        List<EventDTO> result =
+                this.eventService.getEvents(id).stream().map(
+                        EventService::createEventDTOFromEvent).collect(Collectors.toList());
 
         return ResponseEntity.ok(result);
     }
@@ -641,7 +665,8 @@ public class CollectionExerciseEndpoint {
      * @throws CTPException on resource not found
      */
     @RequestMapping(value = "/{id}/events/{tag}", method = RequestMethod.DELETE)
-    public ResponseEntity<Event> deleteCollectionExerciseEvent(@PathVariable("id") final UUID id, @PathVariable("tag") final String tag)
+    public ResponseEntity<Event> deleteCollectionExerciseEvent(@PathVariable("id") final UUID id,
+                                                               @PathVariable("tag") final String tag)
             throws CTPException {
         log.info("Deleting collection exercise event id {}, event tag ", id, tag);
 
@@ -666,7 +691,8 @@ public class CollectionExerciseEndpoint {
 
         if (collex == null) {
             throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("Cannot find collection exercise for survey %s and period %s", surveyRef, exerciseRef));
+                    String.format("Cannot find collection exercise for survey %s and period %s", surveyRef,
+                            exerciseRef));
         } else {
             return ResponseEntity.ok(getCollectionExerciseDTO(collex));
         }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -369,8 +369,17 @@ public class CollectionExerciseEndpoint {
 
         if (StringUtils.isBlank(surveyId) == false) {
             survey = this.surveyService.findSurvey(UUID.fromString(collex.getSurveyId()));
+
+            if (survey == null){
+                throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format("Survey with id %s not found",
+                        surveyId));
+            }
         } else if (StringUtils.isBlank(surveyRef) == false) {
             survey = this.surveyService.findSurveyByRef(surveyRef);
+            if (survey == null){
+                throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format("Survey with ref %s not found",
+                        surveyRef));
+            }
             // Downstream expects the surveyId to be present so add it now
             collex.setSurveyId(survey.getId());
         } else {

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,18 @@
+liquibase:
+  url: jdbc:postgresql://localhost:15432/postgres
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:15432/postgres
+
+survey-svc:
+  connection-config:
+    port: 18080
+
+redisson-config:
+  address: localhost:17379
+
+rabbitmq:
+  host: localhost
+  port: 15672
+

--- a/src/main/resources/springintegration/flows.xml
+++ b/src/main/resources/springintegration/flows.xml
@@ -14,5 +14,6 @@
     <import resource="collex-event-messager-inbound.xml"/>
     <import resource="collection-instrument-inbound.xml"/>
     <import resource="sample-uploaded-inbound.xml"/>
+    <import resource="generic-collection-outbound-flow.xml"/>
 
 </beans>

--- a/src/main/resources/springintegration/generic-collection-outbound-flow.xml
+++ b/src/main/resources/springintegration/generic-collection-outbound-flow.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+  http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+  http://www.springframework.org/schema/rabbit
+  http://www.springframework.org/schema/rabbit/spring-rabbit-1.6.xsd">
+
+    <rabbit:template id="genericRabbitTemplate" connection-factory="connectionFactory" channel-transacted="true" />
+</beans>

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
@@ -1,0 +1,208 @@
+package uk.gov.ons.ctp.response.collection.exercise.endpoint;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.SampleLinkDTO;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A class to wrap the collection exercise REST API in Java using Unirest
+ */
+public class CollectionExerciseClient {
+
+    private ObjectMapper jacksonMapper;
+    private int port;
+    private String username;
+    private String password;
+
+    /**
+     * Constructor for client - accepts API connection information
+     * @param aPort collection exercise API port
+     * @param aUsername  collection exercise API username
+     * @param aPassword collection exercise API password
+     * @param aMapper an object mapper
+     */
+    public CollectionExerciseClient(final int aPort, final String aUsername, final String aPassword,
+                                    final ObjectMapper aMapper) {
+        this.port = aPort;
+        this.jacksonMapper = aMapper;
+        this.username = aUsername;
+        this.password = aPassword;
+
+        initialiseUnirestObjectMapper();
+    }
+
+    /**
+     * Initialises object mapper as used by unirest (needs a Jackson ObjectMapper to construct)
+     */
+    private void initialiseUnirestObjectMapper() {
+        Unirest.setObjectMapper(new com.mashape.unirest.http.ObjectMapper() {
+            public <T> T readValue(final String value, final Class<T> valueType) {
+                try {
+                    return jacksonMapper.readValue(value, valueType);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            public String writeValue(final Object value) {
+                try {
+                    return jacksonMapper.writeValueAsString(value);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+
+    /**
+     * Calls the API to create a collection exercise
+     * @param surveyId survey to create collection exercise for
+     * @param exerciseRef the period of the collection exercise
+     * @param userDescription the description of the collection exercise
+     * @return a Pair of the status code of the operation and the location at which the new resource has been created
+     * @throws CTPException thrown if an error occurred creating the collection exercise
+     */
+    public Pair<Integer, String> createCollectionExercise(final UUID surveyId, final String exerciseRef,
+                                                          final String userDescription)
+            throws CTPException {
+        CollectionExerciseDTO inputDto = new CollectionExerciseDTO();
+
+        inputDto.setSurveyId(surveyId.toString());
+        inputDto.setExerciseRef(exerciseRef);
+        inputDto.setUserDescription(userDescription);
+
+        try {
+            HttpResponse<String> createCollexResponse =
+                    Unirest.post("http://localhost:" + this.port + "/collectionexercises")
+                            .basicAuth(this.username, this.password)
+                            .header("accept", "application/json")
+                            .header("Content-Type", "application/json")
+                            .body(inputDto)
+                            .asString();
+            int statusCode = createCollexResponse.getStatus();
+            List<String> locations = createCollexResponse.getHeaders().get("Location");
+            String location = locations != null && locations.size() > 0 ? locations.get(0) : null;
+
+            return new ImmutablePair<>(statusCode, location);
+        } catch (UnirestException e) {
+            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to create collection exercise", e);
+        }
+    }
+
+    /**
+     * Calls the API to get a collection exercise from a UUID
+     * @param collexId the uuid of the collection exercise
+     * @return the full details of the collection exercise
+     * @throws CTPException thrown if an error occurred retrieving the collection exercise details
+     */
+    public CollectionExerciseDTO getCollectionExercise(final UUID collexId) throws CTPException {
+        try {
+            return Unirest.get("http://localhost:" + this.port + "/collectionexercises/{id}")
+                    .routeParam("id", collexId.toString())
+                    .basicAuth(this.username, this.password)
+                    .header("accept", "application/json")
+                    .asObject(CollectionExerciseDTO.class)
+                    .getBody();
+        } catch (UnirestException e) {
+            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to get collection exercise", e);
+        }
+    }
+
+    /**
+     * Calls the API to link a list of sample summaries to a collection exercise
+     * @param collexId the uuid of the collection exercise to link
+     * @param sampleSummaryIds a list of the uuids of the sample summaries to link
+     * @return the http status code of the operation
+     * @throws CTPException thrown if there was an error linking the sample summaries to the collection exercise
+     */
+    public int linkSampleSummaries(final UUID collexId, final List<UUID> sampleSummaryIds) throws CTPException {
+        try {
+            JSONObject jsonPayload = new JSONObject();
+            JSONArray jsonSampleSummaryIds = new JSONArray();
+            sampleSummaryIds.stream().forEach(ssi -> jsonSampleSummaryIds.put(ssi.toString()));
+            jsonPayload.put("sampleSummaryIds", jsonSampleSummaryIds);
+
+            HttpResponse<JsonNode> linkResponse =
+                    Unirest.put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+                            .routeParam("id", collexId.toString())
+                            .basicAuth(this.username, this.password)
+                            .header("accept", "application/json")
+                            .header("Content-Type", "application/json")
+                            .body(jsonPayload)
+                            .asJson();
+
+            return linkResponse.getStatus();
+        } catch (JSONException e) {
+            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to create payload", e);
+        } catch (UnirestException e) {
+            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to serialize payload", e);
+        }
+    }
+
+    /**
+     * Links a sample summary to a collection exercise
+     * @param collexId the uuid of the collection exercise to link
+     * @param sampleSummaryId the uuid of the sample summary to link
+     * @return the http status code of the operation
+     * @throws CTPException thrown if there was an error linking the sample summary to the collection exercise
+     * @see CollectionExerciseClient#linkSampleSummaries
+     */
+    public int linkSampleSummary(final UUID collexId, final UUID sampleSummaryId) throws CTPException {
+        return linkSampleSummaries(collexId, Arrays.asList(sampleSummaryId));
+    }
+
+    /**
+     * Gets a collection exercise given the whole URI (e.g. as returned in a Location header)
+     * @param uriStr the full URI of the collection exercise resource
+     * @return a representation of the collection exercise
+     * @throws CTPException thrown if there was an error retrieving the collection exercise
+     */
+    public CollectionExerciseDTO getCollectionExercise(final String uriStr) throws CTPException {
+        try {
+            return Unirest.get(uriStr)
+                    .basicAuth(this.username, this.password)
+                    .header("accept", "application/json")
+                    .asObject(CollectionExerciseDTO.class)
+                    .getBody();
+        } catch (UnirestException e) {
+            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to get collection exercise", e);
+        }
+    }
+
+    /**
+     * Get the samples linked to a collection exercise
+     * @param collexId the uuid of the collection exercise
+     * @return a list of samole links
+     * @throws CTPException thrown if an error occurs retrieving the sample links
+     */
+    public List<SampleLinkDTO> getSampleLinks(final UUID collexId) throws CTPException {
+        try {
+            SampleLinkDTO[] linkArray = Unirest.get("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+                    .routeParam("id", collexId.toString())
+                    .basicAuth(this.username, this.password)
+                    .header("accept", "application/vnd.ons.sdc.samplelink.v1+json")
+                    .asObject(SampleLinkDTO[].class)
+                    .getBody();
+
+            return Arrays.asList(linkArray);
+        } catch (UnirestException e) {
+            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to get collection exercise", e);
+        }
+    }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
@@ -1,0 +1,161 @@
+package uk.gov.ons.ctp.response.collection.exercise.endpoint;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.message.rabbit.Rabbitmq;
+import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageBase;
+import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageListener;
+import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageSender;
+import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.SampleLinkDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A class to contain integration tests for the collection exercise service
+ */
+@Slf4j
+@RunWith(SpringRunner.class)
+@ContextConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class CollectionExerciseEndpointIT {
+
+    // TODO pull these from config
+    private static final UUID TEST_SURVEY_ID = UUID.fromString("c23bb1c1-5202-43bb-8357-7a07c844308f");
+    private static final String TEST_USERNAME = "admin";
+    private static final String TEST_PASSWORD = "secret";
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
+    private AppConfig appConfig;
+
+    private CollectionExerciseClient client;
+
+    /**
+     * Method to set up integration test
+     */
+    @Before
+    public void setUp() {
+        client = new CollectionExerciseClient(this.port, TEST_USERNAME, TEST_PASSWORD, this.mapper);
+    }
+
+    /**
+     * Method to test construction of a collection exercise via the API
+     * - Create a collection exercise
+     * - Get the collection exercise from the returned Location header
+     * - Assert the collection exercise fields match those expected
+     *
+     * @throws CTPException thrown by error creating collection exercise
+     */
+    @Test
+    public void shouldCreateCollectionExercise() throws CTPException {
+        String exerciseRef = "899990";
+        String userDescription = "Test Description";
+        Pair<Integer, String> result = this.client.createCollectionExercise(TEST_SURVEY_ID, exerciseRef,
+                userDescription);
+
+        assertEquals(201, (int) result.getLeft());
+
+        CollectionExerciseDTO newCollex = this.client.getCollectionExercise(result.getRight());
+
+        assertEquals(TEST_SURVEY_ID, UUID.fromString(newCollex.getSurveyId()));
+        assertEquals(exerciseRef, newCollex.getExerciseRef());
+        assertEquals(userDescription, newCollex.getUserDescription());
+    }
+
+    /**
+     * Creates a new SimpleMessageSender based on the config in AppConfig
+     * @return a new SimpleMessageSender
+     */
+    private SimpleMessageSender getMessageSender() {
+        Rabbitmq config = this.appConfig.getRabbitmq();
+
+        return new SimpleMessageSender(config.getHost(), config.getPort(), config.getUsername(), config.getPassword());
+    }
+
+    /**
+     * Creates a new SimpleMessageListener based on the config in AppConfig
+     * @return a new SimpleMessageListener
+     */
+    private SimpleMessageListener getMessageListener() {
+        Rabbitmq config = this.appConfig.getRabbitmq();
+
+        return new SimpleMessageListener(config.getHost(), config.getPort(), config.getUsername(), config.getPassword());
+    }
+
+    /**
+     * Method to test the flow receving a message that a sample upload has finished.
+     * - Create a collection exercise
+     * - Get the collection exercise
+     * - Link the collection exercise to a sample summary with a random sample summary id
+     * - Send a message to Sample.SampleUploadFinished.binding key on sample-outbound-exchange
+     * - Get the sample links for the collection exercise
+     * - Assert the sample link is active (and the sample summary ids match)
+     *
+     * @throws CTPException throw if errors occur in any of the interactions
+     */
+    @Test
+    public void shouldActivateSampleLink() throws Exception {
+        String exerciseRef = "899991";
+        String userDescription = "Test Description";
+        Pair<Integer, String> result = this.client.createCollectionExercise(TEST_SURVEY_ID, exerciseRef, userDescription);
+
+        assertEquals(201, (int) result.getLeft());
+        CollectionExerciseDTO newCollex = this.client.getCollectionExercise(result.getRight());
+
+        log.info("Collection exercise to link: {}", newCollex);
+
+        UUID sampleSummaryId = UUID.randomUUID();
+
+        final int status = this.client.linkSampleSummary(newCollex.getId(), sampleSummaryId);
+        assertEquals(200, status);
+
+        SimpleMessageSender sender = getMessageSender();
+
+        SampleSummaryDTO sampleSummary = new SampleSummaryDTO();
+        sampleSummary.setId(sampleSummaryId);
+
+        SimpleMessageListener listener = getMessageListener();
+        BlockingQueue<String> queue = listener.listen( SimpleMessageBase.ExchangeType.Direct,
+                "collection-outbound-exchange", "SampleLink.Activated.binding");
+
+        // This will cause an exception to be thrown as there is no collection instrument service but this is
+        // harmless to our purpose
+        sender.sendMessage("sample-outbound-exchange", "Sample.SampleUploadFinished.binding",
+                this.mapper.writeValueAsString(sampleSummary));
+
+        queue.take();
+
+        List<SampleLinkDTO> links = this.client.getSampleLinks(newCollex.getId());
+
+        assertEquals(1, links.size());
+
+        SampleLinkDTO link = links.get(0);
+
+        assertEquals(sampleSummaryId, UUID.fromString(link.getSampleSummaryId()));
+        assertEquals("ACTIVE", link.getState());
+    }
+}
+


### PR DESCRIPTION
# Motivation and Context
This is the second attempt to introduce integration tests to the collection exercise service.  The original attempt failed as it used a simple Java client to send rabbit messages.   This did not work as expected on cloud foundry so had to be backed out.  This version uses spring integration to drive the messaging so should configure ok on cloud foundry (same approach works on other services).

The integration tests that have been added have been designed to play nice with the standard docker setup so there should be no port clashes (i.e. the integration tests can be run at the same time as the full docker env)

This reverts commit 55cbda5b2fae24fa9a08b7ab602c5cd0641914e4.

# What has changed
- when a sample link is activated, a message is sent to collection-outbound-exchange
- an integration test has been added to test sample link activation

# How to test?
- run 'make up' to spin up all docker services
- run 'mvn clean install' and check for successful completion

