### PR TITLE
Added plantuml diagrams and means to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target
 *.redo
 *.backup
 /.apt_generated/
+
+plantuml.jar
+diagrams/*.svg

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
-DIAGRAM_DIR=diagrams
-UML_FILES=$(wildcard $(DIAGRAM_DIR)/*.puml)
-SVG_FILES := $(patsubst $(DIAGRAM_DIR)/%.puml,$(DIAGRAM_DIR)/%.svg,$(UML_FILES))
+DOT := $(shell command -v dot 2> /dev/null)
 
-diagrams: download-plantuml $(SVG_FILES)
+diagrams: ensure-graphviz download-plantuml
+	java -jar plantuml.jar -tsvg diagrams/*.puml
 
 clean:
-	rm plantuml.jar; rm diagrams/*.svg
+	rm -f plantuml.jar; rm -f diagrams/*.svg
 
 download-plantuml:
 ifeq (,$(wildcard plantuml.jar))
 	curl -L --output plantuml.jar https://downloads.sourceforge.net/project/plantuml/plantuml.jar
+endif 
+
+ensure-graphviz:
+ifndef DOT
+	$(error "The dot command is not available - please install graphviz (brew install graphviz)")
 endif
-
-%.svg : %.puml
-	 java -jar plantuml.jar -tsvg $^
-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+diagrams: download-plantuml diagrams/collection-exercise-new-states.svg diagrams/collection-exercise-state.svg
+
+clean:
+	rm plantuml.jar; rm diagrams/*.svg
+
+download-plantuml:
+ifeq (,$(wildcard plantuml.jar))
+	curl -L --output plantuml.jar https://downloads.sourceforge.net/project/plantuml/plantuml.jar
+endif
+
+%.svg : %.puml
+	 java -jar plantuml.jar -tsvg $^
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-diagrams: download-plantuml diagrams/collection-exercise-new-states.svg diagrams/collection-exercise-state.svg
+DIAGRAM_DIR=diagrams
+UML_FILES=$(wildcard $(DIAGRAM_DIR)/*.puml)
+SVG_FILES := $(patsubst $(DIAGRAM_DIR)/%.puml,$(DIAGRAM_DIR)/%.svg,$(UML_FILES))
+
+diagrams: download-plantuml $(SVG_FILES)
 
 clean:
 	rm plantuml.jar; rm diagrams/*.svg

--- a/diagrams/collection-exercise-new-states.puml
+++ b/diagrams/collection-exercise-new-states.puml
@@ -1,0 +1,41 @@
+@startuml
+skinparam state {
+    BackgroundColor HoneyDew
+    BackgroundColor<<New>> MistyRose
+    BackgroundColor<<Changed>> PaleTurquoise
+}
+skinparam note {
+    BackgroundColor<<New>> MistyRose
+    BackgroundColor<<Changed>> PaleTurquoise
+}
+
+[*] --> CREATED
+note left of CREATED : this used to be INIT
+CREATED<<Changed>> --> CREATED : ci_sample_added
+CREATED<<Changed>> --> CREATED : ci_sample_deleted
+CREATED<<Changed>> --> CREATED : events_deleted
+CREATED<<Changed>> --> SCHEDULED : events_added
+note left #MistyRose
+   states this colour are new
+end note
+CREATED --> EXECUTION_STARTED : execute
+SCHEDULED<<New>> --> SCHEDULED : events_added
+SCHEDULED<<New>> --> SCHEDULED : ci_sample_deleted
+SCHEDULED<<New>> --> READY_FOR_REVIEW : ci_sample_added
+READY_FOR_REVIEW<<New>> --> SCHEDULED : ci_sample_deleted
+READY_FOR_REVIEW<<New>> --> CREATED : events_deleted
+SCHEDULED<<New>> --> CREATED : events_deleted
+READY_FOR_REVIEW<<New>> --> EXECUTION_STARTED : execute
+EXECUTION_STARTED<<Changed>> --> EXECUTION_STARTED : execute
+note left of EXECUTION_STARTED : this used to be PENDING
+EXECUTION_STARTED --> EXECUTED : execution_complete
+EXECUTED --> VALIDATED : validate
+EXECUTED --> FAILEDVALIDATION : invalidate
+VALIDATED --> READY_FOR_LIVE<<Changed>> : publish
+note left of READY_FOR_LIVE: this used to be PUBLISHED
+note right of READY_FOR_LIVE #PaleTurquoise
+    states this colour have been renamed
+end note
+READY_FOR_LIVE --> LIVE<<New>> : go_live
+FAILEDVALIDATION --> EXECUTION_STARTED : execute
+@enduml

--- a/diagrams/collection-exercise-state.puml
+++ b/diagrams/collection-exercise-state.puml
@@ -1,0 +1,31 @@
+@startuml
+skinparam state {
+    BackgroundColor HoneyDew
+}
+
+[*] --> CREATED
+note left 
+    CREATED -> EXECUTION_STARTED
+    is to support non-business surveys
+    that may be executed directly
+end note
+CREATED --> CREATED : ci_sample_added
+CREATED --> CREATED : ci_sample_deleted
+CREATED --> CREATED : events_deleted
+CREATED --> SCHEDULED : events_added [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStateTransitionHandler.java#L39 *]]
+CREATED --> EXECUTION_STARTED : execute [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java#L123 *]]
+SCHEDULED --> SCHEDULED : events_added
+SCHEDULED --> SCHEDULED : ci_sample_deleted
+SCHEDULED --> READY_FOR_REVIEW : ci_sample_added [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java#L477 *]]
+READY_FOR_REVIEW --> SCHEDULED : ci_sample_deleted [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java#L480 *]]
+READY_FOR_REVIEW --> CREATED : events_deleted [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStateTransitionHandler.java#L46 *]]
+SCHEDULED --> CREATED : events_deleted [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStateTransitionHandler.java#L46 *]]
+READY_FOR_REVIEW --> EXECUTION_STARTED : execute [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java#L123 *]]
+EXECUTION_STARTED --> EXECUTION_STARTED : execute [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java#L123 *]]
+EXECUTION_STARTED --> EXECUTED : execution_complete [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java#L169 *]]
+EXECUTED --> VALIDATED : validate [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java#L413 *]]
+EXECUTED --> FAILEDVALIDATION : invalidate [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java#L417 *]]
+VALIDATED --> READY_FOR_LIVE : publish [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributor.java#L279 *]]
+READY_FOR_LIVE --> LIVE : go_live [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventInboundReceiver.java#L79 *]]
+FAILEDVALIDATION --> EXECUTION_STARTED : execute [[https://github.com/ONSdigital/rm-collection-exercise-service/blob/master/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java#L123 *]]
+@enduml


### PR DESCRIPTION
# Motivation and Context
This PR adds 2 plantuml state diagrams for collection exercises and the means to build them

# What has changed
No code has been changed but a Makefile has been added

# How to test?
```
make diagrams
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome diagrams/collection-exercise-new-states.svg
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome diagrams/collection-exercise-state.svg
```
Ensure diagrams can be viewed
