### PR TITLE
Fixed possible port clash on integration tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,12 @@ services:
   container_name: rabbitmq-it
   image: rabbitmq:3.6.10-management
   ports:
-    - "14369:4369"
-    - "35672:25672"
-    - "15671:5671"
-    - "15672:5672"
-    - "25671:15671"
-    - "26672:15672"
+    - "34369:4369"
+    - "55672:25672"
+    - "35671:5671"
+    - "35672:5672"
+    - "46671:15671"
+    - "46672:15672"
  sftp:
     container_name: sftp-it
     image: atmoz/sftp

--- a/pom.xml
+++ b/pom.xml
@@ -237,9 +237,6 @@
         <configuration>
           <executable>true</executable>
           <mainClass>uk.gov.ons.ctp.response.collection.exercise.CollectionExerciseApplication</mainClass>
-          <profiles>
-            <profile>test</profile>
-          </profiles>
         </configuration>
         <executions>
           <execution>

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -18,4 +18,4 @@ redisson-config:
 
 rabbitmq:
   host: localhost
-  port: 15672
+  port: 35672

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -33,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 @Slf4j
 @RunWith(SpringRunner.class)
 @ContextConfiguration
+@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class CollectionExerciseEndpointIT {
 


### PR DESCRIPTION
- also made sure integration tests run with the test Spring profile

# Motivation and Context
The method used to tell spring to use the test profile when running the integration tests was flawed, forcing a command line parameter to be used to make them work.  This is now fixed. Additionally the Rabbit UI was specified on a port that is sometimes used elsewhere so all Rabbit ports have been moved up the range to prevent clashes.

# What has changed
- @ActiveProfiles("test") annotation added to CollectionExerciseEndpointIT
- active profile removed from pom
- rabbit ports changed in docker-compose.yml and application-test.yml

# How to test?
- Run up the full ras-rm-docker-env services via make up or similar
- Run 'mvn clean install' for rm-collection-exercise-service
- Ensure all tests complete successfully 

