### PR TITLE
Add formatter and checkstyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,8 @@ See [API.md](https://github.com/ONSdigital/rm-collection-exercise-service/blob/m
 # Swagger Specification
 To view the swagger Specification for the Collection Exercise service, run the service and navigate to http://localhost:8145/swagger-ui.html.
 
+# Code Styler
+To use the code styler please goto this url (https://github.com/google/google-java-format) and follow the Intellij instructions or Eclipse depending on what you use
+
 ## Copyright
 Copyright (C) 2017 Crown Copyright (Office for National Statistics)

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>uk.gov.ons.ctp.product</groupId>
     <artifactId>rm-common-config</artifactId>
-    <version>10.49.8</version>
+    <version>10.49.12</version>
   </parent>
 
   <dependencies>
@@ -366,6 +366,10 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+          <groupId>com.coveo</groupId>
+          <artifactId>fmt-maven-plugin</artifactId>
       </plugin>
     </plugins>
     <resources>

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
@@ -27,16 +27,16 @@ import uk.gov.ons.ctp.common.state.StateTransitionManagerFactory;
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
-import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO.SampleLinkState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO.SampleLinkEvent;
+import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO.SampleLinkState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
 import uk.gov.ons.ctp.response.collection.exercise.service.impl.EventValidator;
 import uk.gov.ons.ctp.response.collection.exercise.state.CollectionExerciseStateTransitionManagerFactory;
 
 /**
- * The main entry point into the Collection Exercise Service SpringBoot
- * Application. Also used for bean configuration.
+ * The main entry point into the Collection Exercise Service SpringBoot Application. Also used for
+ * bean configuration.
  */
 @CoverageIgnore
 @SpringBootApplication
@@ -51,11 +51,9 @@ public class CollectionExerciseApplication {
   private static final String VALIDATION_LIST = "collectionexercisesvc.sample.validation";
   private static final String DISTRIBUTION_LIST = "collectionexercisesvc.sample.distribution";
 
-  @Autowired
-  private AppConfig appConfig;
+  @Autowired private AppConfig appConfig;
 
-  @Autowired
-  private StateTransitionManagerFactory collectionExerciseStateTransitionManagerFactory;
+  @Autowired private StateTransitionManagerFactory collectionExerciseStateTransitionManagerFactory;
 
   /**
    * Bean used to map exceptions for endpoints
@@ -78,55 +76,8 @@ public class CollectionExerciseApplication {
   }
 
   /**
-   * Bean used to access Sample service through REST calls
-   *
-   * @return the service client
-   */
-/*  @Bean
-  @Qualifier("sampleSvc")
-  public RestClient sampleSvcClientRestTemplate() {
-    RestClient restHelper = new RestClient(appConfig.getSampleSvc().getConnectionConfig());
-    return restHelper;
-  }*/
-
-  /**
-   * Bean used to access Survey service through REST calls
-   *
-   * @return the service client
-   */
-/*  @Bean
-  @Qualifier("surveySvc")
-  public RestClient surveySvcClientRestTemplate() {
-    RestClient restHelper = new RestClient(appConfig.getSurveySvc().getConnectionConfig());
-    return restHelper;
-  }*/
-
-  /**
-   * Bean used to access CollectionInstrument service through REST calls
-   *
-   * @return the service client
-   */
-/*  @Bean
-  @Qualifier("collectionInstrumentSvc")
-  public RestClient collectionInstrumentSvcClientRestTemplate() {
-    RestClient restHelper = new RestClient(appConfig.getCollectionInstrumentSvc().getConnectionConfig());
-    return restHelper;
-  }*/
-
-  /**
-   * Bean used to access Party service through REST calls
-   *
-   * @return the service client
-   */
-/*  @Bean
-  @Qualifier("partySvc")
-  public RestClient partySvcClientRestTemplate() {
-    RestClient restHelper = new RestClient(appConfig.getPartySvc().getConnectionConfig());
-    return restHelper;
-  }*/
-
-  /**
    * The RestUtility bean for the Action service
+   *
    * @return the RestUtility bean for the Action service
    */
   @Bean
@@ -137,6 +88,7 @@ public class CollectionExerciseApplication {
 
   /**
    * The RestUtility bean for the CollectionInstrument service
+   *
    * @return the RestUtility bean for the CollectionInstrument service
    */
   @Bean
@@ -147,6 +99,7 @@ public class CollectionExerciseApplication {
 
   /**
    * The RestUtility bean for the Party service
+   *
    * @return the RestUtility bean for the Party service
    */
   @Bean
@@ -157,6 +110,7 @@ public class CollectionExerciseApplication {
 
   /**
    * The RestUtility bean for the Sample service
+   *
    * @return the RestUtility bean for the Sample service
    */
   @Bean
@@ -167,6 +121,7 @@ public class CollectionExerciseApplication {
 
   /**
    * The RestUtility bean for the Survey service
+   *
    * @return the RestUtility bean for the Survey service
    */
   @Bean
@@ -183,9 +138,9 @@ public class CollectionExerciseApplication {
   @Bean
   @Qualifier("collectionExercise")
   public StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent>
-    collectionExerciseStateTransitionManager() {
-    return collectionExerciseStateTransitionManagerFactory
-        .getStateTransitionManager(CollectionExerciseStateTransitionManagerFactory.COLLLECTIONEXERCISE_ENTITY);
+      collectionExerciseStateTransitionManager() {
+    return collectionExerciseStateTransitionManagerFactory.getStateTransitionManager(
+        CollectionExerciseStateTransitionManagerFactory.COLLLECTIONEXERCISE_ENTITY);
   }
 
   /**
@@ -195,9 +150,10 @@ public class CollectionExerciseApplication {
    */
   @Bean
   @Qualifier("sampleUnitGroup")
-  public StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent> sampleUnitGroupStateTransitionManager() {
-    return collectionExerciseStateTransitionManagerFactory
-            .getStateTransitionManager(CollectionExerciseStateTransitionManagerFactory.SAMPLEUNITGROUP_ENTITY);
+  public StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent>
+      sampleUnitGroupStateTransitionManager() {
+    return collectionExerciseStateTransitionManagerFactory.getStateTransitionManager(
+        CollectionExerciseStateTransitionManagerFactory.SAMPLEUNITGROUP_ENTITY);
   }
 
   /**
@@ -208,37 +164,43 @@ public class CollectionExerciseApplication {
   @Bean
   @Qualifier("sampleLink")
   public StateTransitionManager<SampleLinkState, SampleLinkEvent>
-  sampleLinkStateTransitionManager() {
-    return collectionExerciseStateTransitionManagerFactory
-        .getStateTransitionManager(CollectionExerciseStateTransitionManagerFactory.SAMPLELINK_ENTITY);
+      sampleLinkStateTransitionManager() {
+    return collectionExerciseStateTransitionManagerFactory.getStateTransitionManager(
+        CollectionExerciseStateTransitionManagerFactory.SAMPLELINK_ENTITY);
   }
 
   /**
    * The DistributedListManager for sampleUnitGroup validation.
+   *
    * @param redissonClient the redissonClient.
    * @return the DistributedListManager.
    */
   @Bean
   @Qualifier("validation")
-  public DistributedListManager<Integer> sampleValidationListManager(RedissonClient redissonClient) {
+  public DistributedListManager<Integer> sampleValidationListManager(
+      RedissonClient redissonClient) {
     return new DistributedListManagerRedissonImpl<Integer>(
-        VALIDATION_LIST, redissonClient,
+        VALIDATION_LIST,
+        redissonClient,
         appConfig.getRedissonConfig().getListTimeToWaitSeconds(),
-            appConfig.getRedissonConfig().getListTimeToLiveSeconds());
+        appConfig.getRedissonConfig().getListTimeToLiveSeconds());
   }
 
   /**
    * The DistributedListManager for sampleUnitGroup distribution.
+   *
    * @param redissonClient the redissonClient.
    * @return the DistributedListManager.
    */
   @Bean
   @Qualifier("distribution")
-  public DistributedListManager<Integer> sampleDistributionListManager(RedissonClient redissonClient) {
+  public DistributedListManager<Integer> sampleDistributionListManager(
+      RedissonClient redissonClient) {
     return new DistributedListManagerRedissonImpl<Integer>(
-        DISTRIBUTION_LIST, redissonClient,
+        DISTRIBUTION_LIST,
+        redissonClient,
         appConfig.getRedissonConfig().getListTimeToWaitSeconds(),
-            appConfig.getRedissonConfig().getListTimeToLiveSeconds());
+        appConfig.getRedissonConfig().getListTimeToLiveSeconds());
   }
 
   /**
@@ -249,8 +211,7 @@ public class CollectionExerciseApplication {
   @Bean
   public RedissonClient redissonClient() {
     Config config = new Config();
-    config.useSingleServer()
-        .setAddress(appConfig.getRedissonConfig().getAddress());
+    config.useSingleServer().setAddress(appConfig.getRedissonConfig().getAddress());
     return Redisson.create(config);
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseBeanMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseBeanMapper.java
@@ -1,15 +1,13 @@
 package uk.gov.ons.ctp.response.collection.exercise;
 
-import net.sourceforge.cobertura.CoverageIgnore;
-import org.springframework.stereotype.Component;
-
 import ma.glasnost.orika.impl.ConfigurableMapper;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.impl.generator.EclipseJdtCompilerStrategy;
+import net.sourceforge.cobertura.CoverageIgnore;
+import org.springframework.stereotype.Component;
 
 /**
- * The MapperFactory to obtain the MapperFacade to map Entity objects to/from
- * presentation objects.
+ * The MapperFactory to obtain the MapperFacade to map Entity objects to/from presentation objects.
  */
 @CoverageIgnore
 @Component

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
@@ -3,18 +3,16 @@ package uk.gov.ons.ctp.response.collection.exercise.client;
 import org.springframework.web.client.RestClientException;
 import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
 
-/**
- * HTTP RestClient implementation for calls to the Action service.
- *
- */
+/** HTTP RestClient implementation for calls to the Action service. */
 public interface ActionSvcClient {
 
-    /**
-        Request action plan is created.
-        @param name name of action plan
-        @param description description of action plan
-        @return ActionPlanDTO representation of the created action plan
-        @throws RestClientException for failed connection to action service
-     */
-    ActionPlanDTO createActionPlan(String name, String description) throws RestClientException;
+  /**
+   * Request action plan is created.
+   *
+   * @param name name of action plan
+   * @param description description of action plan
+   * @return ActionPlanDTO representation of the created action plan
+   * @throws RestClientException for failed connection to action service
+   */
+  ActionPlanDTO createActionPlan(String name, String description) throws RestClientException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/CollectionInstrumentSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/CollectionInstrumentSvcClient.java
@@ -1,35 +1,28 @@
 package uk.gov.ons.ctp.response.collection.exercise.client;
 
+import java.util.List;
 import org.springframework.web.client.RestClientException;
 import uk.gov.ons.ctp.response.collection.instrument.representation.CollectionInstrumentDTO;
 
-import java.util.List;
-
-/**
- * Service responsible for making client calls to the CollectionInstrument
- * service
- *
- */
+/** Service responsible for making client calls to the CollectionInstrument service */
 public interface CollectionInstrumentSvcClient {
 
   /**
    * Request the existing collection instruments
    *
-   * @param searchString search string for looking up collection instruments
-   *          based on classifiers
+   * @param searchString search string for looking up collection instruments based on classifiers
    * @return list of collection instruments matching the search string
    * @throws RestClientException something went wrong making http call
    */
-  List<CollectionInstrumentDTO> requestCollectionInstruments(String searchString) throws RestClientException;
+  List<CollectionInstrumentDTO> requestCollectionInstruments(String searchString)
+      throws RestClientException;
 
   /**
    * Request the count of existing collection instruments
    *
-   * @param searchString search string for looking up collection instruments
-   *          based on classifiers
+   * @param searchString search string for looking up collection instruments based on classifiers
    * @return count of collection instruments matching the search string
    * @throws RestClientException something went wrong making http call
    */
   Integer countCollectionInstruments(String searchString) throws RestClientException;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/PartySvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/PartySvcClient.java
@@ -1,15 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.client;
 
 import org.springframework.web.client.RestClientException;
-
 import uk.gov.ons.ctp.response.party.representation.PartyDTO;
 import uk.gov.ons.ctp.response.party.representation.SampleLinkDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 
-/**
- * Service responsible for making client calls to the Party service
- *
- */
+/** Service responsible for making client calls to the Party service */
 public interface PartySvcClient {
 
   /**
@@ -20,7 +16,9 @@ public interface PartySvcClient {
    * @return the party object
    * @throws RestClientException something went wrong making http call
    */
-  PartyDTO requestParty(SampleUnitDTO.SampleUnitType sampleUnitType, String sampleUnitRef) throws RestClientException;
+  PartyDTO requestParty(SampleUnitDTO.SampleUnitType sampleUnitType, String sampleUnitRef)
+      throws RestClientException;
 
-  SampleLinkDTO linkSampleSummaryId(String sampleSummaryId, String collectionExercise) throws RestClientException;
+  SampleLinkDTO linkSampleSummaryId(String sampleSummaryId, String collectionExercise)
+      throws RestClientException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
@@ -4,20 +4,14 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 
-/**
- * Service responsible for making client calls to the Sample service
- *
- */
+/** Service responsible for making client calls to the Sample service */
 public interface SampleSvcClient {
 
   /**
-   * Request the delivery of sample units from the Sample Service via a message
-   * queue.
+   * Request the delivery of sample units from the Sample Service via a message queue.
    *
-   * @param exercise the Collection Exercise for which to request sample
-   *          units.
+   * @param exercise the Collection Exercise for which to request sample units.
    * @return the total number of sample units in the collection exercise.
    */
   SampleUnitsRequestDTO requestSampleUnits(CollectionExercise exercise) throws CTPException;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SurveySvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SurveySvcClient.java
@@ -2,17 +2,12 @@ package uk.gov.ons.ctp.response.collection.exercise.client;
 
 import java.util.List;
 import java.util.UUID;
-
 import org.springframework.web.client.RestClientException;
-
 import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
 import uk.gov.ons.response.survey.representation.SurveyClassifierDTO;
 import uk.gov.ons.response.survey.representation.SurveyClassifierTypeDTO;
 
-/**
- * Service responsible for making client calls to the Survey service
- *
- */
+/** Service responsible for making client calls to the Survey service */
 public interface SurveySvcClient extends SurveyService {
 
   /**
@@ -21,9 +16,9 @@ public interface SurveySvcClient extends SurveyService {
    * @param surveyId UUID for which to request classifiers.
    * @return List of SurveyClassifierDTO classifier selectors.
    * @throws RestClientException something went wrong making http call.
-   *
    */
-  List<SurveyClassifierDTO> requestClassifierTypeSelectors(UUID surveyId) throws RestClientException;
+  List<SurveyClassifierDTO> requestClassifierTypeSelectors(UUID surveyId)
+      throws RestClientException;
 
   /**
    * Get classifier type selector for Survey UUID and ClassifierType UUID.
@@ -32,8 +27,7 @@ public interface SurveySvcClient extends SurveyService {
    * @param classifierType UUID for classifier type.
    * @return SurveyClassifierTypeDTO details of selector type requested.
    * @throws RestClientException something went wrong making http call.
-   *
    */
-  SurveyClassifierTypeDTO requestClassifierTypeSelector(UUID surveyId, UUID classifierType) throws RestClientException;
-
+  SurveyClassifierTypeDTO requestClassifierTypeSelector(UUID surveyId, UUID classifierType)
+      throws RestClientException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -15,52 +15,56 @@ import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
 import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 
-/**
- * HTTP RestClient implementation for calls to the Action service.
- *
- */
+/** HTTP RestClient implementation for calls to the Action service. */
 @Component
 @Slf4j
 public class ActionSvcRestClientImpl implements ActionSvcClient {
 
-    private AppConfig appConfig;
+  private AppConfig appConfig;
 
-    private RestTemplate restTemplate;
+  private RestTemplate restTemplate;
 
-    private RestUtility restUtility;
+  private RestUtility restUtility;
 
-    /**
-     * Implementation for request to action service to create action plan
-     * @param restTemplate Spring frameworks rest template
-     * @param restUtility for creating URI's and HTTPEntities
-     * @param appConfig application config object
-     */
-    @Autowired
-    public ActionSvcRestClientImpl(final RestTemplate restTemplate,
-                                   final @Qualifier("actionRestUtility") RestUtility restUtility, AppConfig appConfig) {
-        this.restTemplate = restTemplate;
-        this.appConfig = appConfig;
-        this.restUtility = restUtility;
-    }
+  /**
+   * Implementation for request to action service to create action plan
+   *
+   * @param restTemplate Spring frameworks rest template
+   * @param restUtility for creating URI's and HTTPEntities
+   * @param appConfig application config object
+   */
+  @Autowired
+  public ActionSvcRestClientImpl(
+      final RestTemplate restTemplate,
+      final @Qualifier("actionRestUtility") RestUtility restUtility,
+      AppConfig appConfig) {
+    this.restTemplate = restTemplate;
+    this.appConfig = appConfig;
+    this.restUtility = restUtility;
+  }
 
-    @Retryable(value = {RestClientException.class}, maxAttemptsExpression = "#{${retries.maxAttempts}}",
-            backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
-    @Override
-    public ActionPlanDTO createActionPlan(final String name, String description) throws RestClientException {
-        log.debug("Posting to action service to create action plan");
-        UriComponents uriComponents = restUtility.createUriComponents(appConfig.getActionSvc().getActionPlansPath(),
-                null);
+  @Retryable(
+      value = {RestClientException.class},
+      maxAttemptsExpression = "#{${retries.maxAttempts}}",
+      backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
+  @Override
+  public ActionPlanDTO createActionPlan(final String name, String description)
+      throws RestClientException {
+    log.debug("Posting to action service to create action plan");
+    UriComponents uriComponents =
+        restUtility.createUriComponents(appConfig.getActionSvc().getActionPlansPath(), null);
 
-        ActionPlanDTO actionPlanDTO = new ActionPlanDTO();
-        actionPlanDTO.setName(name);
-        actionPlanDTO.setDescription(description);
-        actionPlanDTO.setCreatedBy("SYSTEM");
-        HttpEntity<ActionPlanDTO> httpEntity = restUtility.createHttpEntity(actionPlanDTO);
+    ActionPlanDTO actionPlanDTO = new ActionPlanDTO();
+    actionPlanDTO.setName(name);
+    actionPlanDTO.setDescription(description);
+    actionPlanDTO.setCreatedBy("SYSTEM");
+    HttpEntity<ActionPlanDTO> httpEntity = restUtility.createHttpEntity(actionPlanDTO);
 
-        ActionPlanDTO createdActionPlan = restTemplate.postForObject(uriComponents.toUri(),
-                httpEntity, ActionPlanDTO.class);
-        log.debug("Successfully posted to action service to create action plan, ActionPlanId: {}",
-                createdActionPlan.getId());
-        return createdActionPlan;
-    }
+    ActionPlanDTO createdActionPlan =
+        restTemplate.postForObject(uriComponents.toUri(), httpEntity, ActionPlanDTO.class);
+    log.debug(
+        "Successfully posted to action service to create action plan, ActionPlanId: {}",
+        createdActionPlan.getId());
+    return createdActionPlan;
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/CollectionInstrumentSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/CollectionInstrumentSvcRestClientImpl.java
@@ -2,6 +2,8 @@ package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,57 +24,52 @@ import uk.gov.ons.ctp.response.collection.exercise.client.CollectionInstrumentSv
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 import uk.gov.ons.ctp.response.collection.instrument.representation.CollectionInstrumentDTO;
 
-import java.io.IOException;
-import java.util.List;
-
-/**
- * HTTP RestClient implementation for calls to the Collection Instrument
- * service.
- *
- */
+/** HTTP RestClient implementation for calls to the Collection Instrument service. */
 @Component
 @Slf4j
 public class CollectionInstrumentSvcRestClientImpl implements CollectionInstrumentSvcClient {
 
-  @Autowired
-  private AppConfig appConfig;
+  @Autowired private AppConfig appConfig;
 
-  @Autowired
-  private RestTemplate restTemplate;
+  @Autowired private RestTemplate restTemplate;
 
   @Qualifier("collectionInstrumentRestUtility")
   @Autowired
   private RestUtility restUtility;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
-  @Retryable(value = {RestClientException.class}, maxAttemptsExpression = "#{${retries.maxAttempts}}",
+  @Retryable(
+      value = {RestClientException.class},
+      maxAttemptsExpression = "#{${retries.maxAttempts}}",
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
-  public List<CollectionInstrumentDTO> requestCollectionInstruments(String searchString) throws RestClientException {
+  public List<CollectionInstrumentDTO> requestCollectionInstruments(String searchString)
+      throws RestClientException {
 
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     queryParams.add("searchString", searchString);
 
-    UriComponents uriComponents = restUtility.createUriComponents(
+    UriComponents uriComponents =
+        restUtility.createUriComponents(
             appConfig.getCollectionInstrumentSvc().getRequestCollectionInstruments(), queryParams);
 
     HttpEntity<List<CollectionInstrumentDTO>> httpEntity = restUtility.createHttpEntity(null);
 
-    ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
-        String.class);
+    ResponseEntity<String> responseEntity =
+        restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity, String.class);
 
     List<CollectionInstrumentDTO> result = null;
     if (responseEntity != null && responseEntity.getStatusCode().is2xxSuccessful()) {
       String responseBody = responseEntity.getBody();
       try {
-        result = objectMapper.readValue(responseBody, new TypeReference<List<CollectionInstrumentDTO>>() { });
+        result =
+            objectMapper.readValue(
+                responseBody, new TypeReference<List<CollectionInstrumentDTO>>() {});
       } catch (IOException e) {
         String msg = String.format("cause = %s - message = %s", e.getCause(), e.getMessage());
         log.error(msg);
       }
-
     }
 
     return result;
@@ -83,13 +80,15 @@ public class CollectionInstrumentSvcRestClientImpl implements CollectionInstrume
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     queryParams.add("searchString", searchString);
 
-    UriComponents uriComponents = restUtility.createUriComponents(
-            appConfig.getCollectionInstrumentSvc().getRequestCollectionInstrumentsCount(), queryParams);
+    UriComponents uriComponents =
+        restUtility.createUriComponents(
+            appConfig.getCollectionInstrumentSvc().getRequestCollectionInstrumentsCount(),
+            queryParams);
 
     HttpEntity<List<CollectionInstrumentDTO>> httpEntity = restUtility.createHttpEntity(null);
 
-    ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
-            String.class);
+    ResponseEntity<String> responseEntity =
+        restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity, String.class);
 
     Integer result = null;
     if (responseEntity != null && responseEntity.getStatusCode().is2xxSuccessful()) {

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
@@ -2,6 +2,9 @@ package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -22,75 +25,75 @@ import uk.gov.ons.response.survey.representation.SurveyClassifierDTO;
 import uk.gov.ons.response.survey.representation.SurveyClassifierTypeDTO;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.UUID;
-
-/**
- * HTTP RestClient implementation for calls to the Survey service
- *
- */
+/** HTTP RestClient implementation for calls to the Survey service */
 @Component
 @Slf4j
 @Qualifier("restClient")
 @Primary
 public class SurveySvcRestClientImpl implements SurveySvcClient {
 
-  @Autowired
-  private AppConfig appConfig;
+  @Autowired private AppConfig appConfig;
 
-  @Autowired
-  private RestTemplate restTemplate;
+  @Autowired private RestTemplate restTemplate;
 
   @Qualifier("surveyRestUtility")
   @Autowired
   private RestUtility restUtility;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
-  @Retryable(value = {RestClientException.class}, maxAttemptsExpression = "#{${retries.maxAttempts}}",
+  @Retryable(
+      value = {RestClientException.class},
+      maxAttemptsExpression = "#{${retries.maxAttempts}}",
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
-  public List<SurveyClassifierDTO> requestClassifierTypeSelectors(final UUID surveyId) throws RestClientException {
+  public List<SurveyClassifierDTO> requestClassifierTypeSelectors(final UUID surveyId)
+      throws RestClientException {
 
-    UriComponents uriComponents = restUtility.createUriComponents(
+    UriComponents uriComponents =
+        restUtility.createUriComponents(
             appConfig.getSurveySvc().getRequestClassifierTypesListPath(), null, surveyId);
 
     HttpEntity<List<SurveyClassifierDTO>> httpEntity = restUtility.createHttpEntity(null);
 
     log.debug("about to get to the Survey SVC with surveyId {}", surveyId);
-    ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
-        String.class);
+    ResponseEntity<String> responseEntity =
+        restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity, String.class);
 
     List<SurveyClassifierDTO> result = null;
     if (responseEntity != null && responseEntity.getStatusCode().is2xxSuccessful()) {
       String responseBody = responseEntity.getBody();
       try {
-        result = objectMapper.readValue(responseBody, new TypeReference<List<SurveyClassifierDTO>>() { });
+        result =
+            objectMapper.readValue(responseBody, new TypeReference<List<SurveyClassifierDTO>>() {});
       } catch (IOException e) {
         String msg = String.format("cause = %s - message = %s", e.getCause(), e.getMessage());
         log.error(msg);
       }
-
     }
 
     return result;
-
   }
 
   @Override
-  public SurveyClassifierTypeDTO requestClassifierTypeSelector(final UUID surveyId, final UUID classifierType)
-      throws RestClientException {
+  public SurveyClassifierTypeDTO requestClassifierTypeSelector(
+      final UUID surveyId, final UUID classifierType) throws RestClientException {
 
-    UriComponents uriComponents = restUtility.createUriComponents(
-            appConfig.getSurveySvc().getRequestClassifierTypesPath(), null, surveyId, classifierType);
+    UriComponents uriComponents =
+        restUtility.createUriComponents(
+            appConfig.getSurveySvc().getRequestClassifierTypesPath(),
+            null,
+            surveyId,
+            classifierType);
 
     HttpEntity<?> httpEntity = restUtility.createHttpEntity(null);
 
-    log.debug("about to get to the Survey SVC with surveyId {} and classifierType {}", surveyId, classifierType);
-    ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
-        String.class);
+    log.debug(
+        "about to get to the Survey SVC with surveyId {} and classifierType {}",
+        surveyId,
+        classifierType);
+    ResponseEntity<String> responseEntity =
+        restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity, String.class);
 
     SurveyClassifierTypeDTO result = null;
     if (responseEntity != null && responseEntity.getStatusCode().is2xxSuccessful()) {
@@ -105,7 +108,7 @@ public class SurveySvcRestClientImpl implements SurveySvcClient {
     return result;
   }
 
-  private SurveyDTO getSurveyDtoFromResponseEntity(ResponseEntity<String> responseEntity){
+  private SurveyDTO getSurveyDtoFromResponseEntity(ResponseEntity<String> responseEntity) {
     SurveyDTO result = null;
     if (responseEntity != null && responseEntity.getStatusCode().is2xxSuccessful()) {
       String responseBody = responseEntity.getBody();
@@ -121,38 +124,45 @@ public class SurveySvcRestClientImpl implements SurveySvcClient {
 
   @Override
   public SurveyDTO findSurvey(UUID surveyId) throws RestClientException {
-    UriComponents uriComponents = restUtility.createUriComponents(
+    UriComponents uriComponents =
+        restUtility.createUriComponents(
             appConfig.getSurveySvc().getSurveyDetailPath(), null, surveyId);
 
     HttpEntity<?> httpEntity = restUtility.createHttpEntity(null);
 
     try {
-      log.debug("about to get to the Survey SVC with surveyId {} from {}", surveyId, uriComponents.toUri());
-      ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
-              String.class);
+      log.debug(
+          "about to get to the Survey SVC with surveyId {} from {}",
+          surveyId,
+          uriComponents.toUri());
+      ResponseEntity<String> responseEntity =
+          restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity, String.class);
 
       return getSurveyDtoFromResponseEntity(responseEntity);
-    } catch(RestClientException e){
+    } catch (RestClientException e) {
       return null;
     }
   }
 
   @Override
   public SurveyDTO findSurveyByRef(String surveyRef) throws RestClientException {
-    UriComponents uriComponents = restUtility.createUriComponents(
+    UriComponents uriComponents =
+        restUtility.createUriComponents(
             appConfig.getSurveySvc().getSurveyRefPath(), null, surveyRef);
 
     HttpEntity<?> httpEntity = restUtility.createHttpEntity(null);
 
     try {
-      log.debug("about to get to the Survey SVC with surveyRef {} from {}", surveyRef, uriComponents.toUri());
-      ResponseEntity<String> responseEntity = restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity,
-              String.class);
+      log.debug(
+          "about to get to the Survey SVC with surveyRef {} from {}",
+          surveyRef,
+          uriComponents.toUri());
+      ResponseEntity<String> responseEntity =
+          restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity, String.class);
 
       return getSurveyDtoFromResponseEntity(responseEntity);
-    } catch(RestClientException e){
+    } catch (RestClientException e) {
       return null;
     }
   }
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/ActionSvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/ActionSvc.java
@@ -4,14 +4,10 @@ import lombok.Data;
 import net.sourceforge.cobertura.CoverageIgnore;
 import uk.gov.ons.ctp.common.rest.RestUtilityConfig;
 
-/**
- * Application Config bean for the connection details to the Action Service
- *
- */
+/** Application Config bean for the connection details to the Action Service */
 @Data
 @CoverageIgnore
 public class ActionSvc {
-    private RestUtilityConfig connectionConfig;
-    private String actionPlansPath;
+  private RestUtilityConfig connectionConfig;
+  private String actionPlansPath;
 }
-

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/AppConfig.java
@@ -1,16 +1,14 @@
 package uk.gov.ons.ctp.response.collection.exercise.config;
 
+import lombok.Data;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-
-import lombok.Data;
 import uk.gov.ons.ctp.common.message.rabbit.Rabbitmq;
 
 /**
- * The apps main holder for centralised configuration read from application.yml
- * or environment variables.
- *
+ * The apps main holder for centralised configuration read from application.yml or environment
+ * variables.
  */
 @CoverageIgnore
 @Configuration
@@ -27,5 +25,4 @@ public class AppConfig {
   private ScheduleSettings schedules;
   private SwaggerSettings swaggerSettings;
   private Rabbitmq rabbitmq;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/CollectionInstrumentSvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/CollectionInstrumentSvc.java
@@ -5,9 +5,7 @@ import net.sourceforge.cobertura.CoverageIgnore;
 import uk.gov.ons.ctp.common.rest.RestUtilityConfig;
 
 /**
- * App config POJO for CollectionInstrument service access - host/location and endpoint
- * locations
- *
+ * App config POJO for CollectionInstrument service access - host/location and endpoint locations
  */
 @CoverageIgnore
 @Data
@@ -15,5 +13,4 @@ public class CollectionInstrumentSvc {
   private RestUtilityConfig connectionConfig;
   private String requestCollectionInstruments;
   private String requestCollectionInstrumentsCount;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/DataSourceConfiguration.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/DataSourceConfiguration.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.config;
 
 import javax.sql.DataSource;
+import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.Cloud;
 import org.springframework.cloud.CloudFactory;
@@ -8,12 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
-import net.sourceforge.cobertura.CoverageIgnore;
-
-/**
- * DataSource bean, Required to override the CloudFoundry defaults - no practical use in code
- *
- */
+/** DataSource bean, Required to override the CloudFoundry defaults - no practical use in code */
 @CoverageIgnore
 @Configuration
 @Profile("cloud")
@@ -21,6 +17,7 @@ public class DataSourceConfiguration {
 
   /**
    * Creates the cloud object.
+   *
    * @return Cloud
    */
   @Bean
@@ -30,6 +27,7 @@ public class DataSourceConfiguration {
 
   /**
    * Creates the DataSource object.
+   *
    * @return DataSource
    */
   @Bean
@@ -37,5 +35,4 @@ public class DataSourceConfiguration {
   public DataSource dataSource() {
     return cloud().getSingletonServiceConnector(DataSource.class, null);
   }
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/PartySvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/PartySvc.java
@@ -4,11 +4,7 @@ import lombok.Data;
 import net.sourceforge.cobertura.CoverageIgnore;
 import uk.gov.ons.ctp.common.rest.RestUtilityConfig;
 
-/**
- * App config POJO for Party service access - host/location and endpoint
- * locations
- *
- */
+/** App config POJO for Party service access - host/location and endpoint locations */
 @CoverageIgnore
 @Data
 public class PartySvc {

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/RedissonConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/RedissonConfig.java
@@ -3,16 +3,11 @@ package uk.gov.ons.ctp.response.collection.exercise.config;
 import lombok.Data;
 import net.sourceforge.cobertura.CoverageIgnore;
 
-/**
- * Config POJO for Redisson
- *
- */
+/** Config POJO for Redisson */
 @CoverageIgnore
 @Data
 public class RedissonConfig {
   private String address;
   private Integer listTimeToLiveSeconds;
   private Integer listTimeToWaitSeconds;
-
 }
-

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SampleSvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SampleSvc.java
@@ -4,11 +4,7 @@ import lombok.Data;
 import net.sourceforge.cobertura.CoverageIgnore;
 import uk.gov.ons.ctp.common.rest.RestUtilityConfig;
 
-/**
- * App config POJO for Sample service access - host/location and endpoint
- * locations
- *
- */
+/** App config POJO for Sample service access - host/location and endpoint locations */
 @CoverageIgnore
 @Data
 public class SampleSvc {

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/ScheduleSettings.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/ScheduleSettings.java
@@ -3,15 +3,12 @@ package uk.gov.ons.ctp.response.collection.exercise.config;
 import lombok.Data;
 import net.sourceforge.cobertura.CoverageIgnore;
 
-/**
- * Config POJO for Scheduled threads
- *
- */
+/** Config POJO for Scheduled threads */
 @CoverageIgnore
 @Data
 public class ScheduleSettings {
-    private String validationScheduleDelayMilliSeconds;
-    private Integer validationScheduleRetrievalMax;
-    private String distributionScheduleDelayMilliSeconds;
-    private Integer distributionScheduleRetrievalMax;
+  private String validationScheduleDelayMilliSeconds;
+  private Integer validationScheduleRetrievalMax;
+  private String distributionScheduleDelayMilliSeconds;
+  private Integer distributionScheduleRetrievalMax;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SurveySvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SurveySvc.java
@@ -4,11 +4,7 @@ import lombok.Data;
 import net.sourceforge.cobertura.CoverageIgnore;
 import uk.gov.ons.ctp.common.rest.RestUtilityConfig;
 
-/**
- * App config POJO for Survey service access - host/location and endpoint
- * locations
- *
- */
+/** App config POJO for Survey service access - host/location and endpoint locations */
 @CoverageIgnore
 @Data
 public class SurveySvc {

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SwaggerConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SwaggerConfig.java
@@ -14,24 +14,18 @@ import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 import uk.gov.ons.ctp.response.collection.exercise.endpoint.CollectionExerciseEndpoint;
 
-
-
-/**
- * Config POJO for Swagger UI
- */
+/** Config POJO for Swagger UI */
 @CoverageIgnore
 @Configuration
 @EnableSwagger2
-@ComponentScan(basePackageClasses = {
-        CollectionExerciseEndpoint.class
-})
+@ComponentScan(basePackageClasses = {CollectionExerciseEndpoint.class})
 public class SwaggerConfig {
 
-  @Autowired
-  private AppConfig appConfig;
+  @Autowired private AppConfig appConfig;
 
   /**
    * Creates Docket for Swagger UI
+   *
    * @return docket detailing Swagger details
    */
   @Bean
@@ -39,7 +33,8 @@ public class SwaggerConfig {
 
     SwaggerSettings swaggerSettings = appConfig.getSwaggerSettings();
 
-    ApiInfo apiInfo = new ApiInfoBuilder()
+    ApiInfo apiInfo =
+        new ApiInfoBuilder()
             .title(swaggerSettings.getTitle())
             .description(swaggerSettings.getDescription())
             .version(swaggerSettings.getVersion())
@@ -54,12 +49,13 @@ public class SwaggerConfig {
     }
 
     return new Docket(DocumentationType.SWAGGER_2)
-            .groupName(swaggerSettings.getGroupName())
-            .apiInfo(apiInfo)
-            .select()
-            .apis(RequestHandlerSelectors.basePackage("uk.gov.ons.ctp.response.collection.exercise.endpoint"))
-            .paths(pathSelector::test)
-            .build();
+        .groupName(swaggerSettings.getGroupName())
+        .apiInfo(apiInfo)
+        .select()
+        .apis(
+            RequestHandlerSelectors.basePackage(
+                "uk.gov.ons.ctp.response.collection.exercise.endpoint"))
+        .paths(pathSelector::test)
+        .build();
   }
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SwaggerSettings.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SwaggerSettings.java
@@ -3,9 +3,7 @@ package uk.gov.ons.ctp.response.collection.exercise.config;
 import lombok.Data;
 import net.sourceforge.cobertura.CoverageIgnore;
 
-/**
- * Config POJO for Swagger UI Generation
- */
+/** Config POJO for Swagger UI Generation */
 @CoverageIgnore
 @Data
 public class SwaggerSettings {
@@ -15,5 +13,4 @@ public class SwaggerSettings {
   private String title;
   private String description;
   private String version;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributionScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributionScheduler.java
@@ -1,42 +1,32 @@
 package uk.gov.ons.ctp.response.collection.exercise.distribution;
 
 import java.util.List;
-
+import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import net.sourceforge.cobertura.CoverageIgnore;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
 
-/**
- * Schedule Publish of sample units in VALIDATED state
- *
- */
+/** Schedule Publish of sample units in VALIDATED state */
 @CoverageIgnore
 @Component
 public class SampleUnitDistributionScheduler {
 
-  @Autowired
-  private CollectionExerciseRepository collectRepo;
+  @Autowired private CollectionExerciseRepository collectRepo;
 
-  @Autowired
-  private SampleService sampleService;
+  @Autowired private SampleService sampleService;
 
-  /**
-   * Carry out publish according to configured fixed delay.
-   */
+  /** Carry out publish according to configured fixed delay. */
   @Scheduled(fixedDelayString = "#{appConfig.schedules.distributionScheduleDelayMilliSeconds}")
   public void scheduleDistribution() {
-    List<CollectionExercise> exercises = collectRepo
-        .findByState(CollectionExerciseDTO.CollectionExerciseState.VALIDATED);
+    List<CollectionExercise> exercises =
+        collectRepo.findByState(CollectionExerciseDTO.CollectionExerciseState.VALIDATED);
 
-    for (CollectionExercise aCollectionExercise : exercises) {
-      sampleService.distributeSampleUnits(aCollectionExercise);
+    for (CollectionExercise collectionExercise : exercises) {
+      sampleService.distributeSampleUnits(collectionExercise);
     }
   }
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CaseType.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CaseType.java
@@ -2,23 +2,20 @@ package uk.gov.ons.ctp.response.collection.exercise.domain;
 
 import java.util.UUID;
 
-/**
- * CaseType Interface for CaseTypeDefault and CaseTypeOverride
- */
-
-
+/** CaseType Interface for CaseTypeDefault and CaseTypeOverride */
 public interface CaseType {
 
   /**
    * Gets SampleUnitType Foreign Key
+   *
    * @return sampleUnitTypeFK
    */
   String getSampleUnitTypeFK();
 
   /**
    * Gets ActionPlan Id
+   *
    * @return actionPlanId
    */
   UUID getActionPlanId();
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CaseTypeDefault.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CaseTypeDefault.java
@@ -1,5 +1,12 @@
 package uk.gov.ons.ctp.response.collection.exercise.domain;
 
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -7,17 +14,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Table;
-import java.util.UUID;
-
-/**
- * Domain model object.
- */
+/** Domain model object. */
 @Entity
 @Builder
 @Data
@@ -27,16 +24,18 @@ import java.util.UUID;
 public class CaseTypeDefault implements CaseType {
 
   @Id
-  @GenericGenerator(name = "casetypedefaultseq_gen", strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-          parameters = {
-                  @Parameter(name = "sequence_name", value = "collectionexercise.casetypedefaultseq"),
-                  @Parameter(name = "increment_size", value = "1")
-          })
+  @GenericGenerator(
+      name = "casetypedefaultseq_gen",
+      strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+      parameters = {
+        @Parameter(name = "sequence_name", value = "collectionexercise.casetypedefaultseq"),
+        @Parameter(name = "increment_size", value = "1")
+      })
   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "casetypedefaultseq_gen")
   @Column(name = "casetypedefaultpk")
   private Integer caseTypeDefaultPK;
 
-  @Column(name="survey_uuid")
+  @Column(name = "survey_uuid")
   private UUID surveyId;
 
   @Column(name = "actionplanid")
@@ -44,5 +43,4 @@ public class CaseTypeDefault implements CaseType {
 
   @Column(name = "sampleunittypefk")
   private String sampleUnitTypeFK;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CaseTypeOverride.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CaseTypeOverride.java
@@ -1,5 +1,13 @@
 package uk.gov.ons.ctp.response.collection.exercise.domain;
 
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -7,18 +15,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Table;
-import java.util.UUID;
-
-/**
- * Domain model object.
- */
+/** Domain model object. */
 @Entity
 @Builder
 @Data
@@ -28,11 +25,13 @@ import java.util.UUID;
 public class CaseTypeOverride implements CaseType {
 
   @Id
-  @GenericGenerator(name = "casetypeoverrideseq_gen", strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-          parameters = {
-                  @Parameter(name = "sequence_name", value = "collectionexercise.casetypeoverrideseq"),
-                  @Parameter(name = "increment_size", value = "1")
-          })
+  @GenericGenerator(
+      name = "casetypeoverrideseq_gen",
+      strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+      parameters = {
+        @Parameter(name = "sequence_name", value = "collectionexercise.casetypeoverrideseq"),
+        @Parameter(name = "increment_size", value = "1")
+      })
   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "casetypeoverrideseq_gen")
   @Column(name = "casetypeoverridepk")
   private Integer caseTypeOverridePK;
@@ -50,10 +49,15 @@ public class CaseTypeOverride implements CaseType {
   @Override
   public String toString() {
     return "CaseTypeOverride{"
-            + "sampleUnitTypeFK='" + sampleUnitTypeFK + '\''
-            + ", actionPlanId=" + actionPlanId
-            + ", caseTypeOverridePK=" + caseTypeOverridePK
-            + ", exerciseFK=" + exerciseFK
-            + '}';
+        + "sampleUnitTypeFK='"
+        + sampleUnitTypeFK
+        + '\''
+        + ", actionPlanId="
+        + actionPlanId
+        + ", caseTypeOverridePK="
+        + caseTypeOverridePK
+        + ", exerciseFK="
+        + exerciseFK
+        + '}';
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CollectionExercise.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CollectionExercise.java
@@ -1,12 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
-
+import java.sql.Timestamp;
+import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -14,15 +9,15 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import java.sql.Timestamp;
-import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 
-/**
- * Domain model object.
- */
+/** Domain model object. */
 @Entity
 @Data
 @AllArgsConstructor
@@ -33,11 +28,13 @@ public class CollectionExercise {
   private UUID id;
 
   @Id
-  @GenericGenerator(name = "exerciseseq_gen", strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-          parameters = {
-      @Parameter(name = "sequence_name", value = "collectionexercise.exercisepkseq"),
-      @Parameter(name = "increment_size", value = "1")
-  })
+  @GenericGenerator(
+      name = "exerciseseq_gen",
+      strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+      parameters = {
+        @Parameter(name = "sequence_name", value = "collectionexercise.exercisepkseq"),
+        @Parameter(name = "increment_size", value = "1")
+      })
   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "exerciseseq_gen")
   @Column(name = "exercisepk")
   private Integer exercisePK;
@@ -93,7 +90,6 @@ public class CollectionExercise {
   @Column(name = "deleted")
   private Boolean deleted;
 
-  @Column(name="survey_uuid")
+  @Column(name = "survey_uuid")
   private UUID surveyId;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/Event.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/Event.java
@@ -1,28 +1,22 @@
 package uk.gov.ons.ctp.response.collection.exercise.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
-
+import java.sql.Timestamp;
+import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import java.sql.Timestamp;
-import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
-/**
- * Domain model object.
- */
+/** Domain model object. */
 @Entity
 @Data
 @AllArgsConstructor
@@ -33,16 +27,18 @@ public class Event {
   private UUID id;
 
   @Id
-  @GenericGenerator(name = "eventseq_gen", strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-          parameters = {
-      @Parameter(name = "sequence_name", value = "collectionexercise.eventpkseq"),
-      @Parameter(name = "increment_size", value = "1")
-  })
+  @GenericGenerator(
+      name = "eventseq_gen",
+      strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+      parameters = {
+        @Parameter(name = "sequence_name", value = "collectionexercise.eventpkseq"),
+        @Parameter(name = "increment_size", value = "1")
+      })
   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eventseq_gen")
   @Column(name = "eventpk")
   private Integer eventPK;
 
-  @Column(name="tag", length = 20)
+  @Column(name = "tag", length = 20)
   private String tag;
 
   @Column(name = "timestamp")
@@ -57,7 +53,6 @@ public class Event {
 
   private Boolean deleted = false;
 
-  @Column(name="message_sent")
+  @Column(name = "message_sent")
   private Timestamp messageSent;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/ExerciseSampleUnit.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/ExerciseSampleUnit.java
@@ -1,12 +1,6 @@
 package uk.gov.ons.ctp.response.collection.exercise.domain;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import net.sourceforge.cobertura.CoverageIgnore;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
-
+import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -17,11 +11,14 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import java.util.UUID;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import net.sourceforge.cobertura.CoverageIgnore;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 
-/**
- * Domain model object for sample units.
- */
+/** Domain model object for sample units. */
 @CoverageIgnore
 @Entity
 @Data
@@ -30,11 +27,13 @@ import java.util.UUID;
 public class ExerciseSampleUnit {
 
   @Id
-  @GenericGenerator(name = "sampleunitseq_gen", strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-          parameters = {
-      @Parameter(name = "sequence_name", value = "collectionexercise.sampleunitpkseq"),
-      @Parameter(name = "increment_size", value = "1")
-  })
+  @GenericGenerator(
+      name = "sampleunitseq_gen",
+      strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+      parameters = {
+        @Parameter(name = "sequence_name", value = "collectionexercise.sampleunitpkseq"),
+        @Parameter(name = "increment_size", value = "1")
+      })
   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sampleunitseq_gen")
   @Column(name = "sampleunitpk")
   private Integer sampleUnitPK;
@@ -43,10 +42,10 @@ public class ExerciseSampleUnit {
   @JoinColumn(name = "sampleunitgroupfk", referencedColumnName = "sampleunitgrouppk")
   private ExerciseSampleUnitGroup sampleUnitGroup;
 
-  @Column (name = "collectioninstrumentid")
+  @Column(name = "collectioninstrumentid")
   private UUID collectionInstrumentId;
 
-  @Column (name = "partyid")
+  @Column(name = "partyid")
   private UUID partyId;
 
   @Column(name = "sampleunitref")
@@ -55,5 +54,4 @@ public class ExerciseSampleUnit {
   @Enumerated(EnumType.STRING)
   @Column(name = "sampleunittypefk")
   private SampleUnitDTO.SampleUnitType sampleUnitType;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/ExerciseSampleUnitGroup.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/ExerciseSampleUnitGroup.java
@@ -1,12 +1,6 @@
 package uk.gov.ons.ctp.response.collection.exercise.domain;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import net.sourceforge.cobertura.CoverageIgnore;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
-
+import java.sql.Timestamp;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -17,11 +11,14 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import java.sql.Timestamp;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import net.sourceforge.cobertura.CoverageIgnore;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
 
-/**
- * Domain model object for sample unit groups.
- */
+/** Domain model object for sample unit groups. */
 @CoverageIgnore
 @Entity
 @Data
@@ -30,11 +27,13 @@ import java.sql.Timestamp;
 public class ExerciseSampleUnitGroup {
 
   @Id
-  @GenericGenerator(name = "sampleunitgroupseq_gen", strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-          parameters = {
-      @Parameter(name = "sequence_name", value = "collectionexercise.sampleunitgrouppkseq"),
-      @Parameter(name = "increment_size", value = "1")
-  })
+  @GenericGenerator(
+      name = "sampleunitgroupseq_gen",
+      strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+      parameters = {
+        @Parameter(name = "sequence_name", value = "collectionexercise.sampleunitgrouppkseq"),
+        @Parameter(name = "increment_size", value = "1")
+      })
   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sampleunitgroupseq_gen")
   @Column(name = "sampleunitgrouppk")
   private Integer sampleUnitGroupPK;
@@ -54,5 +53,4 @@ public class ExerciseSampleUnitGroup {
 
   @Column(name = "modifieddatetime")
   private Timestamp modifiedDateTime;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/SampleLink.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/SampleLink.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.response.collection.exercise.domain;
 
 import java.util.UUID;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -10,13 +9,11 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import net.sourceforge.cobertura.CoverageIgnore;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO.SampleLinkState;
 
 @CoverageIgnore
@@ -28,11 +25,13 @@ public class SampleLink {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "samplelinkseq_gen")
-  @GenericGenerator(name = "samplelinkseq_gen", strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-          parameters = {
-      @Parameter(name = "sequence_name", value = "collectionexercise.samplelinkpkseq"),
-      @Parameter(name = "increment_size", value = "1")
-  })
+  @GenericGenerator(
+      name = "samplelinkseq_gen",
+      strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+      parameters = {
+        @Parameter(name = "sequence_name", value = "collectionexercise.samplelinkpkseq"),
+        @Parameter(name = "increment_size", value = "1")
+      })
   @Column(name = "samplelinkpk")
   private Integer sampleLinkPK;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -1,5 +1,23 @@
 package uk.gov.ons.ctp.response.collection.exercise.endpoint;
 
+import static java.util.stream.Collectors.joining;
+
+import java.net.URI;
+import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
 import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.apache.commons.lang3.StringUtils;
@@ -38,684 +56,709 @@ import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
 import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Valid;
-import javax.validation.Validation;
-import javax.validation.ValidatorFactory;
-import java.net.URI;
-import java.text.ParseException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.joining;
-
-/**
- * The REST endpoint controller for Collection Exercises.
- */
+/** The REST endpoint controller for Collection Exercises. */
 @RestController
 @RequestMapping(value = "/collectionexercises", produces = "application/json")
 @Slf4j
 public class CollectionExerciseEndpoint {
 
-    private static final String RETURN_COLLECTIONEXERCISENOTFOUND =
-            "Collection Exercise not found for collection exercise Id";
-    private static final String RETURN_SURVEYNOTFOUND = "Survey not found for survey Id";
-    private static final ValidatorFactory VALIDATOR_FACTORY = Validation.buildDefaultValidatorFactory();
+  private static final String RETURN_COLLECTIONEXERCISENOTFOUND =
+      "Collection Exercise not found for collection exercise Id";
+  private static final String RETURN_SURVEYNOTFOUND = "Survey not found for survey Id";
+  private static final ValidatorFactory VALIDATOR_FACTORY =
+      Validation.buildDefaultValidatorFactory();
 
-    private CollectionExerciseService collectionExerciseService;
+  private CollectionExerciseService collectionExerciseService;
 
-    private SurveyService surveyService;
+  private SurveyService surveyService;
 
-    private SampleService sampleService;
+  private SampleService sampleService;
 
-    private EventService eventService;
+  private EventService eventService;
 
-    private MapperFacade mapperFacade;
+  private MapperFacade mapperFacade;
 
-    private Scheduler scheduler;
+  private Scheduler scheduler;
 
-    @Autowired
-    public CollectionExerciseEndpoint(CollectionExerciseService collectionExerciseService,
-                                      SurveyService surveyService,
-                                      SampleService sampleService,
-                                      EventService eventService,
-                                      @Qualifier("collectionExerciseBeanMapper") MapperFacade mapperFacade,
-                                      Scheduler scheduler) {
-        this.collectionExerciseService = collectionExerciseService;
-        this.surveyService = surveyService;
-        this.sampleService = sampleService;
-        this.eventService = eventService;
-        this.mapperFacade = mapperFacade;
-        this.scheduler = scheduler;
-    }
+  @Autowired
+  public CollectionExerciseEndpoint(
+      CollectionExerciseService collectionExerciseService,
+      SurveyService surveyService,
+      SampleService sampleService,
+      EventService eventService,
+      @Qualifier("collectionExerciseBeanMapper") MapperFacade mapperFacade,
+      Scheduler scheduler) {
+    this.collectionExerciseService = collectionExerciseService;
+    this.surveyService = surveyService;
+    this.sampleService = sampleService;
+    this.eventService = eventService;
+    this.mapperFacade = mapperFacade;
+    this.scheduler = scheduler;
+  }
 
-    /**
-     * Method to return a useful message from a ConstraintViolation
-     *
-     * @param cv a constraint violation
-     * @return a human readable message
-     */
-    private static String getMessageForConstraintViolation(final ConstraintViolation<?> cv) {
-        return cv.getPropertyPath() + " " + cv.getMessage();
-    }
+  /**
+   * Method to return a useful message from a ConstraintViolation
+   *
+   * @param cv a constraint violation
+   * @return a human readable message
+   */
+  private static String getMessageForConstraintViolation(final ConstraintViolation<?> cv) {
+    return cv.getPropertyPath() + " " + cv.getMessage();
+  }
 
-    /**
-     * GET to find collection exercises from the collection exercise service for
-     * the given survey Id.
-     *
-     * @param id survey Id for which to trigger delivery of collection exercises
-     * @return list of collection exercises associated to survey
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/survey/{id}", method = RequestMethod.GET)
-    public ResponseEntity<List<CollectionExerciseDTO>> getCollectionExercisesForSurvey(
-            @PathVariable("id") final UUID id) throws CTPException {
+  /**
+   * GET to find collection exercises from the collection exercise service for the given survey Id.
+   *
+   * @param id survey Id for which to trigger delivery of collection exercises
+   * @return list of collection exercises associated to survey
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/survey/{id}", method = RequestMethod.GET)
+  public ResponseEntity<List<CollectionExerciseDTO>> getCollectionExercisesForSurvey(
+      @PathVariable("id") final UUID id) throws CTPException {
 
-        SurveyDTO survey = surveyService.findSurvey(id);
+    SurveyDTO survey = surveyService.findSurvey(id);
 
-        List<CollectionExerciseDTO> collectionExerciseSummaryDTOList;
+    List<CollectionExerciseDTO> collectionExerciseSummaryDTOList;
 
-        if (survey == null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("%s %s", RETURN_SURVEYNOTFOUND, id));
-        } else {
-            log.debug("Entering collection exercise fetch with survey Id {}", id);
-            List<CollectionExercise> collectionExerciseList = collectionExerciseService
-                    .findCollectionExercisesForSurvey(survey);
-            collectionExerciseSummaryDTOList = collectionExerciseList
-                    .stream()
-                    .map(collex -> getCollectionExerciseDTO(collex))
-                    .collect(Collectors.toList());
-            if (collectionExerciseList.isEmpty()) {
-                return ResponseEntity.noContent().build();
-            }
-        }
-
-        return ResponseEntity.ok(collectionExerciseSummaryDTOList);
-    }
-
-    /**
-     * GET to find collection exercise from the collection exercise service for
-     * the given collection exercise Id.
-     *
-     * @param id collection exercise Id for which to trigger delivery of
-     *           collection exercise
-     * @return collection exercise associated to collection exercise id
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}", method = RequestMethod.GET)
-    public ResponseEntity<CollectionExerciseDTO> getCollectionExercise(@PathVariable("id") final UUID id)
-            throws CTPException {
-        log.debug("Entering collection exercise fetch with collection exercise Id {}", id);
-        CollectionExercise collectionExercise = collectionExerciseService.findCollectionExercise(id);
-        if (collectionExercise == null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("%s %s", RETURN_COLLECTIONEXERCISENOTFOUND, id));
-        }
-
-        CollectionExerciseDTO collectionExerciseDTO = getCollectionExerciseDTO(collectionExercise);
-
-        return ResponseEntity.ok(collectionExerciseDTO);
-    }
-
-    /**
-     * GET endpoint to return a list of all collection exercises
-     *
-     * @return a list of all Collection Exercises
-     */
-    @RequestMapping(method = RequestMethod.GET)
-    public ResponseEntity<List<CollectionExerciseDTO>> getAllCollectionExercises() {
-        log.debug("Entering fetch all collection exercise");
-        List<CollectionExercise> collectionExercises = collectionExerciseService.findAllCollectionExercise();
-        List<CollectionExerciseDTO> result = new ArrayList<>();
-
-        for (CollectionExercise collectionExercise : collectionExercises) {
-            CollectionExerciseDTO collectionExerciseDTO = getCollectionExerciseDTO(collectionExercise);
-            result.add(collectionExerciseDTO);
-        }
-        return ResponseEntity.ok(result);
-    }
-
-    /**
-     * PUT request to update a collection exercise
-     *
-     * @param id        Collection exercise Id to update
-     * @param collexDto a DTO containing survey id, name, user description and exercise ref
-     * @return 200 if all is ok, 400 for bad request, 409 for conflict
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}", method = RequestMethod.PUT)
-    public ResponseEntity<?> updateCollectionExercise(
-            @PathVariable("id") final UUID id,
-            final @Validated(CollectionExerciseDTO.PutValidation.class) @RequestBody CollectionExerciseDTO collexDto)
-            throws CTPException {
-        log.info("Updating collection exercise {}", id);
-
-        this.collectionExerciseService.updateCollectionExercise(id, collexDto);
-
-        return ResponseEntity.ok().build();
-    }
-
-    /**
-     * A method to manually validate the constraints on a CollectionExerciseDTO.  The reason this is needed is for
-     * validating PUTs to subresources.  As these are the literal field values and not a JSON document it's difficult
-     * to get Spring to validate these automatically. Hence the need for some kind of manual validation
-     *
-     * @param collexDto The collection exercise data to validate
-     * @throws CTPException thrown if constraint violation
-     */
-    private void validateConstraints(final CollectionExerciseDTO collexDto) throws CTPException {
-        javax.validation.Validator validator = VALIDATOR_FACTORY.getValidator();
-        Set<ConstraintViolation<CollectionExerciseDTO>> result = validator.validate(collexDto,
-                CollectionExerciseDTO.PatchValidation.class);
-
-        if (result.size() > 0) {
-            String errorMessage =
-                    result
-                            .stream()
-                            .map(CollectionExerciseEndpoint::getMessageForConstraintViolation)
-                            .collect(joining(","));
-
-            throw new CTPException(CTPException.Fault.BAD_REQUEST, errorMessage);
-        }
-    }
-
-    /**
-     * Utility method to wrap partial update of a collection exercise
-     *
-     * @param id        the uuid of the collection exercise to update
-     * @param collexDto a dto containing some or all of the data to update
-     * @return 200 if all is ok, 400 for bad request, 409 for conflict
-     * @throws CTPException thrown if constraint violation etc
-     */
-    private ResponseEntity<?> patchCollectionExercise(final UUID id, final CollectionExerciseDTO collexDto)
-            throws CTPException {
-        validateConstraints(collexDto);
-
-        this.collectionExerciseService.patchCollectionExercise(id, collexDto);
-        return ResponseEntity.ok().build();
-    }
-
-    /**
-     * PUT request to update a collection exercise scheduledStartDateTime
-     *
-     * @param id             Collection exercise Id to update
-     * @param scheduledStart new value for exercise ref
-     * @return 200 if all is ok, 400 for bad request, 409 for conflict
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}/scheduledStart", method = RequestMethod.PUT, consumes = "text/plain")
-    public ResponseEntity<?> patchCollectionExerciseScheduledStart(
-            @PathVariable("id") final UUID id,
-            final @RequestBody String scheduledStart)
-            throws CTPException {
-        log.info("Updating collection exercise {}, setting scheduledStartDateTime to {}", id, scheduledStart);
-        CollectionExerciseDTO collexDto = new CollectionExerciseDTO();
-
-        try {
-            LocalDateTime date = LocalDateTime.parse(scheduledStart,
-                    DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSX", Locale.ROOT));
-            collexDto.setScheduledStartDateTime(java.sql.Timestamp.valueOf(date));
-
-            return patchCollectionExercise(id, collexDto);
-        } catch (DateTimeParseException e) {
-            throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format("Unparseable date %s (%s)",
-                    scheduledStart, e.getLocalizedMessage()));
-        }
-    }
-
-    /**
-     * PUT request to update a collection exercise exerciseRef
-     *
-     * @param id          Collection exercise Id to update
-     * @param exerciseRef new value for exercise ref
-     * @return 200 if all is ok, 400 for bad request, 409 for conflict
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}/exerciseRef", method = RequestMethod.PUT, consumes = "text/plain")
-    public ResponseEntity<?> patchCollectionExerciseExerciseRef(
-            @PathVariable("id") final UUID id,
-            final @RequestBody String exerciseRef)
-            throws CTPException {
-        log.info("Updating collection exercise {}, setting exerciseRef to {}", id, exerciseRef);
-        CollectionExerciseDTO collexDto = new CollectionExerciseDTO();
-        collexDto.setExerciseRef(exerciseRef);
-
-        return patchCollectionExercise(id, collexDto);
-    }
-
-    /**
-     * PUT request to update a collection exercise name
-     *
-     * @param id   Collection exercise Id to update
-     * @param name new value for name
-     * @return 200 if all is ok, 400 for bad request, 409 for conflict
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}/name", method = RequestMethod.PUT, consumes = "text/plain")
-    public ResponseEntity<?> patchCollectionExerciseName(
-            @PathVariable("id") final UUID id,
-            final @RequestBody String name)
-            throws CTPException {
-        log.info("Updating collection exercise {}, setting name to {}", id, name);
-        CollectionExerciseDTO collexDto = new CollectionExerciseDTO();
-        collexDto.setName(name);
-
-        return patchCollectionExercise(id, collexDto);
-    }
-
-    /**
-     * PUT request to update a collection exercise userDescription
-     *
-     * @param id              Collection exercise Id to update
-     * @param userDescription new value for user description
-     * @return 200 if all is ok, 400 for bad request, 409 for conflict
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}/userDescription", method = RequestMethod.PUT, consumes = "text/plain")
-    public ResponseEntity<?> patchCollectionExerciseUserDescription(
-            @PathVariable("id") final UUID id,
-            final @RequestBody String userDescription)
-            throws CTPException {
-        log.info("Updating collection exercise {}, setting userDescription to {}", id, userDescription);
-        CollectionExerciseDTO collexDto = new CollectionExerciseDTO();
-        collexDto.setUserDescription(userDescription);
-
-        return patchCollectionExercise(id, collexDto);
-    }
-
-    /**
-     * PUT request to update a collection exercise userDescription
-     *
-     * @param id       Collection exercise Id to update
-     * @param surveyId The new survey to associate with this collection exercise
-     * @return 200 if all is ok, 400 for bad request, 409 for conflict
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}/surveyId", method = RequestMethod.PUT, consumes = "text/plain")
-    public ResponseEntity<?> patchCollectionExerciseSurveyId(
-            @PathVariable("id") final UUID id,
-            final @RequestBody String surveyId)
-            throws CTPException {
-        log.info("Updating collection exercise {}, setting surveyId to {}", id, surveyId);
-        try {
-            UUID.fromString(surveyId);
-        } catch (IllegalArgumentException e) {
-            throw new CTPException(CTPException.Fault.BAD_REQUEST, e);
-        }
-
-        CollectionExerciseDTO collexDto = new CollectionExerciseDTO();
-        collexDto.setSurveyId(surveyId);
-
-        return patchCollectionExercise(id, collexDto);
-    }
-
-    /**
-     * POST request to create a collection exercise
-     * Also creates required action plans and casetypeoverrides
-     *
-     * @param collex A dto containing the data about the collection exercise
-     * @return 201 if all is ok, 400 for bad request, 409 for conflict
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(method = RequestMethod.POST)
-    public ResponseEntity<?> createCollectionExercise(
-            final @Validated(CollectionExerciseDTO.PostValidation.class) @RequestBody CollectionExerciseDTO collex)
-            throws CTPException {
-        log.info("Creating collection exercise, ExerciseRef: {}, SurveyRef: {}",
-                collex.getExerciseRef(), collex.getSurveyRef());
-        String surveyId = collex.getSurveyId();
-        String surveyRef = collex.getSurveyRef();
-        SurveyDTO survey;
-
-        // Retrieve survey from survey service if it exists
-        if (!StringUtils.isBlank(surveyId)) {
-            survey = this.surveyService.findSurvey(UUID.fromString(collex.getSurveyId()));
-        } else if (!StringUtils.isBlank(surveyRef)) {
-            survey = this.surveyService.findSurveyByRef(surveyRef);
-            // Downstream expects the surveyId to be present so add it now
-            collex.setSurveyId(survey.getId());
-        } else {
-            throw new CTPException(CTPException.Fault.BAD_REQUEST, "No survey specified");
-        }
-        if (survey == null) {
-            throw new CTPException(CTPException.Fault.BAD_REQUEST, "Invalid survey: " + surveyId);
-        }
-
-        // Check if collection exercise already exists
-        CollectionExercise existing = this.collectionExerciseService.findCollectionExercise(
-                collex.getExerciseRef(), survey);
-        if (existing != null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_VERSION_CONFLICT,
-                    String.format("Collection exercise already exists, ExerciseRef: %s, SurveyRef: %s",
-                            collex.getExerciseRef(), surveyRef));
-        }
-
-        CollectionExercise newCollex = this.collectionExerciseService.createCollectionExercise(collex, survey);
-
-        URI location = ServletUriComponentsBuilder
-                .fromCurrentRequest().path("/{id}")
-                .buildAndExpand(newCollex.getId()).toUri();
-        log.info("Successfully created collection exercise, CollectionExerciseId: {}", newCollex.getId());
-        return ResponseEntity.created(location).build();
-    }
-
-    /**
-     * DELETE request which deletes a collection exercise
-     *
-     * @param id Collection exercise Id to delete
-     * @return the collection exercise that was to be deleted
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
-    public ResponseEntity<CollectionExercise> deleteCollectionExercise(@PathVariable("id") final UUID id)
-            throws CTPException {
-        log.info("Deleting collection exercise {}", id);
-        this.collectionExerciseService.deleteCollectionExercise(id);
-
-        return ResponseEntity.accepted().build();
-    }
-
-    /**
-     * PUT request for linking an array of sample summaries to a collection
-     * exercise
-     *
-     * @param collectionExerciseId the collection exercise to link sample
-     *                             summaries to
-     * @param linkSampleSummaryDTO the array of all sample summaries to link to
-     *                             the collection exercise, including summaries previously linked as
-     *                             all currently linked summaries are removed from the table
-     * @param bindingResult        the bindingResult used to validate requests
-     * @return list of the newly linked collection exercises and sample summaries
-     * @throws InvalidRequestException if binding errors
-     * @throws CTPException            on resource not found
-     */
-    @RequestMapping(value = "/link/{collectionExerciseId}", method = RequestMethod.PUT, consumes = "application/json")
-    public ResponseEntity<LinkedSampleSummariesDTO> linkSampleSummary(
-            @PathVariable("collectionExerciseId") final UUID collectionExerciseId,
-            @RequestBody(required = false) @Valid final LinkSampleSummaryDTO linkSampleSummaryDTO,
-            BindingResult bindingResult) throws InvalidRequestException, CTPException {
-        log.debug("Entering linkSampleSummary with collectionExerciseID {}", collectionExerciseId);
-
-        if (bindingResult.hasErrors()) {
-            throw new InvalidRequestException("Binding errors for execute action plan: ", bindingResult);
-        }
-
-        CollectionExercise collectionExercise = collectionExerciseService.findCollectionExercise(collectionExerciseId);
-        if (collectionExercise == null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("%s %s", RETURN_COLLECTIONEXERCISENOTFOUND, collectionExerciseId));
-        }
-
-        List<SampleLink> linkSampleSummaryToCollectionExercise = collectionExerciseService
-                .linkSampleSummaryToCollectionExercise(collectionExerciseId,
-                        linkSampleSummaryDTO.getSampleSummaryIds());
-        LinkedSampleSummariesDTO result = new LinkedSampleSummariesDTO();
-
-        if (linkSampleSummaryToCollectionExercise != null) {
-            List<UUID> summaryIds = new ArrayList<UUID>();
-            for (SampleLink sampleLink : linkSampleSummaryToCollectionExercise) {
-                summaryIds.add(sampleLink.getSampleSummaryId());
-            }
-            result.setSampleSummaryIds(summaryIds);
-
-            result.setCollectionExerciseId(linkSampleSummaryToCollectionExercise.get(0).getCollectionExerciseId());
-        }
-        return ResponseEntity.ok(result);
-
-    }
-
-    /**
-     * Endpoint to return the list of samples linked to a collection exercise
-     *
-     * @param collectionExerciseId the collection exercise for which the links are required
-     * @return a list of sample summaries linked to the collection exercise
-     */
-    @RequestMapping(value = "/link/{collectionExerciseId}", method = RequestMethod.GET,
-            produces = "application/vnd.ons.sdc.samplelink.v1+json")
-    public ResponseEntity<List<SampleLinkDTO>> getSampleLinks(
-            @PathVariable("collectionExerciseId") final UUID collectionExerciseId) {
-        log.debug("Getting linked sample summaries for {}", collectionExerciseId);
-        List<SampleLink> sampleLinks = this.collectionExerciseService.findLinkedSampleSummaries(collectionExerciseId);
-        List<SampleLinkDTO> sampleLinkList = mapperFacade.mapAsList(sampleLinks, SampleLinkDTO.class);
-
-        return ResponseEntity.ok(sampleLinkList);
-    }
-
-    /**
-     * for unlinking sample summary from a collection exercise
-     *
-     * @param collectionExerciseId the collection exercise to unlink from sample
-     * @param sampleSummaryId      the collection exercise to unlink from collection exercise
-     * @return noContent response
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/unlink/{collectionExerciseId}/sample/{sampleSummaryId}", method = RequestMethod.DELETE)
-    public ResponseEntity<?> unlinkSampleSummary(
-            @PathVariable("collectionExerciseId") final UUID collectionExerciseId,
-            @PathVariable("sampleSummaryId") final UUID sampleSummaryId) throws CTPException {
-        log.debug("Entering unlinkSampleSummary with collectionExerciseID {} and sampleSummaryId {}",
-                collectionExerciseId, sampleSummaryId);
-
-        CollectionExercise collectionExercise = collectionExerciseService.findCollectionExercise(collectionExerciseId);
-        if (collectionExercise == null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("%s %s", RETURN_COLLECTIONEXERCISENOTFOUND, collectionExerciseId));
-        }
-
-        collectionExerciseService.removeSampleSummaryLink(sampleSummaryId, collectionExerciseId);
-
+    if (survey == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND, String.format("%s %s", RETURN_SURVEYNOTFOUND, id));
+    } else {
+      log.debug("Entering collection exercise fetch with survey Id {}", id);
+      List<CollectionExercise> collectionExerciseList =
+          collectionExerciseService.findCollectionExercisesForSurvey(survey);
+      collectionExerciseSummaryDTOList =
+          collectionExerciseList
+              .stream()
+              .map(collex -> getCollectionExerciseDTO(collex))
+              .collect(Collectors.toList());
+      if (collectionExerciseList.isEmpty()) {
         return ResponseEntity.noContent().build();
-
+      }
     }
 
-    /**
-     * return a list of UUIDs for the sample summaries linked to a specific
-     * collection exercise
-     *
-     * @param collectionExerciseId the id of the collection exercise to get linked
-     *                             sample summaries for
-     * @return list of UUIDs of linked sample summaries
-     * @throws CTPException if no collection exercise found for UUID
-     */
-    @RequestMapping(value = "link/{collectionExerciseId}", method = RequestMethod.GET)
-    public ResponseEntity<List<UUID>> requestLinkedSampleSummaries(
-            @PathVariable("collectionExerciseId") final UUID collectionExerciseId) throws CTPException {
-        log.debug("Getting sample summaries linked to collectionExerciseId {}", collectionExerciseId);
+    return ResponseEntity.ok(collectionExerciseSummaryDTOList);
+  }
 
-        CollectionExercise collectionExercise = collectionExerciseService.findCollectionExercise(collectionExerciseId);
-        if (collectionExercise == null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("%s %s", RETURN_COLLECTIONEXERCISENOTFOUND, collectionExerciseId));
-        }
-
-        List<SampleLink> result = collectionExerciseService.findLinkedSampleSummaries(collectionExerciseId);
-        if (CollectionUtils.isEmpty(result)) {
-            return ResponseEntity.noContent().build();
-        }
-
-        List<UUID> output = new ArrayList<UUID>();
-        for (SampleLink link : result) {
-            output.add(link.getSampleSummaryId());
-        }
-        return ResponseEntity.ok(output);
+  /**
+   * GET to find collection exercise from the collection exercise service for the given collection
+   * exercise Id.
+   *
+   * @param id collection exercise Id for which to trigger delivery of collection exercise
+   * @return collection exercise associated to collection exercise id
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/{id}", method = RequestMethod.GET)
+  public ResponseEntity<CollectionExerciseDTO> getCollectionExercise(
+      @PathVariable("id") final UUID id) throws CTPException {
+    log.debug("Entering collection exercise fetch with collection exercise Id {}", id);
+    CollectionExercise collectionExercise = collectionExerciseService.findCollectionExercise(id);
+    if (collectionExercise == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format("%s %s", RETURN_COLLECTIONEXERCISENOTFOUND, id));
     }
 
-    /**
-     * adds the case types and surveyId to the CollectionExerciseDTO
-     *
-     * @param collectionExercise the collection exercise to find the associated
-     *                           case types and surveyIds for
-     * @return a CollectionExerciseDTO of the collection exercise with case types
-     * and surveyId added which is output by the endpoints
-     */
-    private CollectionExerciseDTO getCollectionExerciseDTO(final CollectionExercise collectionExercise) {
-        Collection<CaseType> caseTypeList = collectionExerciseService.getCaseTypesList(collectionExercise);
-        List<CaseTypeDTO> caseTypeDTOList = mapperFacade.mapAsList(caseTypeList, CaseTypeDTO.class);
+    CollectionExerciseDTO collectionExerciseDTO = getCollectionExerciseDTO(collectionExercise);
 
-        CollectionExerciseDTO collectionExerciseDTO = mapperFacade.map(collectionExercise, CollectionExerciseDTO.class);
-        collectionExerciseDTO.setCaseTypes(caseTypeDTOList);
-        // NOTE: this method used to fail (NPE) if the survey did not exist in the local database.  Now the survey id
-        // is not validated and passed on verbatim
-        collectionExerciseDTO.setSurveyId(collectionExercise.getSurveyId().toString());
+    return ResponseEntity.ok(collectionExerciseDTO);
+  }
 
-        // If we are in the failed validation state, then there should be validation error so go look them up.
-        // We don't do this for all the states as this is a non-trivial database operation.
-        // Note: this code here will suppress any validation errors that are present in the other states
-        // (shouldn't happen but ...)
-        if (collectionExercise.getState() == CollectionExerciseDTO.CollectionExerciseState.FAILEDVALIDATION) {
-            SampleUnitValidationErrorDTO[] errors = this.sampleService.getValidationErrors(collectionExercise.getId());
+  /**
+   * GET endpoint to return a list of all collection exercises
+   *
+   * @return a list of all Collection Exercises
+   */
+  @RequestMapping(method = RequestMethod.GET)
+  public ResponseEntity<List<CollectionExerciseDTO>> getAllCollectionExercises() {
+    log.debug("Entering fetch all collection exercise");
+    List<CollectionExercise> collectionExercises =
+        collectionExerciseService.findAllCollectionExercise();
+    List<CollectionExerciseDTO> result = new ArrayList<>();
 
-            collectionExerciseDTO.setValidationErrors(errors);
-        }
+    for (CollectionExercise collectionExercise : collectionExercises) {
+      CollectionExerciseDTO collectionExerciseDTO = getCollectionExerciseDTO(collectionExercise);
+      result.add(collectionExerciseDTO);
+    }
+    return ResponseEntity.ok(result);
+  }
 
-        return collectionExerciseDTO;
+  /**
+   * PUT request to update a collection exercise
+   *
+   * @param id Collection exercise Id to update
+   * @param collexDto a DTO containing survey id, name, user description and exercise ref
+   * @return 200 if all is ok, 400 for bad request, 409 for conflict
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/{id}", method = RequestMethod.PUT)
+  public ResponseEntity<?> updateCollectionExercise(
+      @PathVariable("id") final UUID id,
+      final @Validated(CollectionExerciseDTO.PutValidation.class) @RequestBody CollectionExerciseDTO
+              collexDto)
+      throws CTPException {
+    log.info("Updating collection exercise {}", id);
+
+    this.collectionExerciseService.updateCollectionExercise(id, collexDto);
+
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * A method to manually validate the constraints on a CollectionExerciseDTO. The reason this is
+   * needed is for validating PUTs to subresources. As these are the literal field values and not a
+   * JSON document it's difficult to get Spring to validate these automatically. Hence the need for
+   * some kind of manual validation
+   *
+   * @param collexDto The collection exercise data to validate
+   * @throws CTPException thrown if constraint violation
+   */
+  private void validateConstraints(final CollectionExerciseDTO collexDto) throws CTPException {
+    javax.validation.Validator validator = VALIDATOR_FACTORY.getValidator();
+    Set<ConstraintViolation<CollectionExerciseDTO>> result =
+        validator.validate(collexDto, CollectionExerciseDTO.PatchValidation.class);
+
+    if (result.size() > 0) {
+      String errorMessage =
+          result
+              .stream()
+              .map(CollectionExerciseEndpoint::getMessageForConstraintViolation)
+              .collect(joining(","));
+
+      throw new CTPException(CTPException.Fault.BAD_REQUEST, errorMessage);
+    }
+  }
+
+  /**
+   * Utility method to wrap partial update of a collection exercise
+   *
+   * @param id the uuid of the collection exercise to update
+   * @param collexDto a dto containing some or all of the data to update
+   * @return 200 if all is ok, 400 for bad request, 409 for conflict
+   * @throws CTPException thrown if constraint violation etc
+   */
+  private ResponseEntity<?> patchCollectionExercise(
+      final UUID id, final CollectionExerciseDTO collexDto) throws CTPException {
+    validateConstraints(collexDto);
+
+    this.collectionExerciseService.patchCollectionExercise(id, collexDto);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * PUT request to update a collection exercise scheduledStartDateTime
+   *
+   * @param id Collection exercise Id to update
+   * @param scheduledStart new value for exercise ref
+   * @return 200 if all is ok, 400 for bad request, 409 for conflict
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(
+      value = "/{id}/scheduledStart",
+      method = RequestMethod.PUT,
+      consumes = "text/plain")
+  public ResponseEntity<?> patchCollectionExerciseScheduledStart(
+      @PathVariable("id") final UUID id, final @RequestBody String scheduledStart)
+      throws CTPException {
+    log.info(
+        "Updating collection exercise {}, setting scheduledStartDateTime to {}",
+        id,
+        scheduledStart);
+    CollectionExerciseDTO collexDto = new CollectionExerciseDTO();
+
+    try {
+      LocalDateTime date =
+          LocalDateTime.parse(
+              scheduledStart,
+              DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSX", Locale.ROOT));
+      collexDto.setScheduledStartDateTime(java.sql.Timestamp.valueOf(date));
+
+      return patchCollectionExercise(id, collexDto);
+    } catch (DateTimeParseException e) {
+      throw new CTPException(
+          CTPException.Fault.BAD_REQUEST,
+          String.format("Unparseable date %s (%s)", scheduledStart, e.getLocalizedMessage()));
+    }
+  }
+
+  /**
+   * PUT request to update a collection exercise exerciseRef
+   *
+   * @param id Collection exercise Id to update
+   * @param exerciseRef new value for exercise ref
+   * @return 200 if all is ok, 400 for bad request, 409 for conflict
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/{id}/exerciseRef", method = RequestMethod.PUT, consumes = "text/plain")
+  public ResponseEntity<?> patchCollectionExerciseExerciseRef(
+      @PathVariable("id") final UUID id, final @RequestBody String exerciseRef)
+      throws CTPException {
+    log.info("Updating collection exercise {}, setting exerciseRef to {}", id, exerciseRef);
+    CollectionExerciseDTO collexDto = new CollectionExerciseDTO();
+    collexDto.setExerciseRef(exerciseRef);
+
+    return patchCollectionExercise(id, collexDto);
+  }
+
+  /**
+   * PUT request to update a collection exercise name
+   *
+   * @param id Collection exercise Id to update
+   * @param name new value for name
+   * @return 200 if all is ok, 400 for bad request, 409 for conflict
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/{id}/name", method = RequestMethod.PUT, consumes = "text/plain")
+  public ResponseEntity<?> patchCollectionExerciseName(
+      @PathVariable("id") final UUID id, final @RequestBody String name) throws CTPException {
+    log.info("Updating collection exercise {}, setting name to {}", id, name);
+    CollectionExerciseDTO collexDto = new CollectionExerciseDTO();
+    collexDto.setName(name);
+
+    return patchCollectionExercise(id, collexDto);
+  }
+
+  /**
+   * PUT request to update a collection exercise userDescription
+   *
+   * @param id Collection exercise Id to update
+   * @param userDescription new value for user description
+   * @return 200 if all is ok, 400 for bad request, 409 for conflict
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(
+      value = "/{id}/userDescription",
+      method = RequestMethod.PUT,
+      consumes = "text/plain")
+  public ResponseEntity<?> patchCollectionExerciseUserDescription(
+      @PathVariable("id") final UUID id, final @RequestBody String userDescription)
+      throws CTPException {
+    log.info("Updating collection exercise {}, setting userDescription to {}", id, userDescription);
+    CollectionExerciseDTO collexDto = new CollectionExerciseDTO();
+    collexDto.setUserDescription(userDescription);
+
+    return patchCollectionExercise(id, collexDto);
+  }
+
+  /**
+   * PUT request to update a collection exercise userDescription
+   *
+   * @param id Collection exercise Id to update
+   * @param surveyId The new survey to associate with this collection exercise
+   * @return 200 if all is ok, 400 for bad request, 409 for conflict
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/{id}/surveyId", method = RequestMethod.PUT, consumes = "text/plain")
+  public ResponseEntity<?> patchCollectionExerciseSurveyId(
+      @PathVariable("id") final UUID id, final @RequestBody String surveyId) throws CTPException {
+    log.info("Updating collection exercise {}, setting surveyId to {}", id, surveyId);
+    try {
+      UUID.fromString(surveyId);
+    } catch (IllegalArgumentException e) {
+      throw new CTPException(CTPException.Fault.BAD_REQUEST, e);
     }
 
-    @RequestMapping(value = "/{id}/events", method = RequestMethod.POST)
-    public ResponseEntity<?> createCollectionExerciseEvent(
-            @PathVariable("id") final UUID id,
-            final @RequestBody EventDTO eventDto)
-            throws CTPException {
-        log.info("Creating event {} for collection exercise {}", eventDto.getTag(), id);
+    CollectionExerciseDTO collexDto = new CollectionExerciseDTO();
+    collexDto.setSurveyId(surveyId);
 
-        eventDto.setCollectionExerciseId(id);
+    return patchCollectionExercise(id, collexDto);
+  }
 
-        Event newEvent = eventService.createEvent(eventDto);
+  /**
+   * POST request to create a collection exercise Also creates required action plans and
+   * casetypeoverrides
+   *
+   * @param collex A dto containing the data about the collection exercise
+   * @return 201 if all is ok, 400 for bad request, 409 for conflict
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(method = RequestMethod.POST)
+  public ResponseEntity<?> createCollectionExercise(
+      final @Validated(CollectionExerciseDTO.PostValidation.class) @RequestBody
+          CollectionExerciseDTO collex)
+      throws CTPException {
+    log.info(
+        "Creating collection exercise, ExerciseRef: {}, SurveyRef: {}",
+        collex.getExerciseRef(),
+        collex.getSurveyRef());
+    String surveyId = collex.getSurveyId();
+    String surveyRef = collex.getSurveyRef();
+    SurveyDTO survey;
 
-        URI location = ServletUriComponentsBuilder
-                .fromCurrentRequest().path("/{id}/events/{tag}")
-                .buildAndExpand(newEvent.getId(), newEvent.getTag()).toUri();
-
-        try {
-            SchedulerConfiguration.scheduleEvent(this.scheduler, newEvent);
-        } catch (SchedulerException e) {
-            log.error("Failed to schedule event: " + newEvent);
-        }
-
-        return ResponseEntity.created(location).build();
+    // Retrieve survey from survey service if it exists
+    if (!StringUtils.isBlank(surveyId)) {
+      survey = this.surveyService.findSurvey(UUID.fromString(collex.getSurveyId()));
+    } else if (!StringUtils.isBlank(surveyRef)) {
+      survey = this.surveyService.findSurveyByRef(surveyRef);
+      // Downstream expects the surveyId to be present so add it now
+      collex.setSurveyId(survey.getId());
+    } else {
+      throw new CTPException(CTPException.Fault.BAD_REQUEST, "No survey specified");
+    }
+    if (survey == null) {
+      throw new CTPException(CTPException.Fault.BAD_REQUEST, "Invalid survey: " + surveyId);
     }
 
-
-    @RequestMapping(value = "/{id}/events", method = RequestMethod.GET)
-    public ResponseEntity<List<EventDTO>> getCollectionExerciseEvents(
-            @PathVariable("id") final UUID id)
-            throws CTPException {
-        List<EventDTO> result =
-                this.eventService.getEvents(id).stream().map(
-                        EventService::createEventDTOFromEvent).collect(Collectors.toList());
-
-        return ResponseEntity.ok(result);
+    // Check if collection exercise already exists
+    CollectionExercise existing =
+        this.collectionExerciseService.findCollectionExercise(collex.getExerciseRef(), survey);
+    if (existing != null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_VERSION_CONFLICT,
+          String.format(
+              "Collection exercise already exists, ExerciseRef: %s, SurveyRef: %s",
+              collex.getExerciseRef(), surveyRef));
     }
 
-    /**
-     * PUT request to update a collection event date
-     *
-     * @param id  Collection exercise Id
-     * @param tag collection exercise event tag
-     * @return 200 if all is ok, 400 for bad request, 409 for conflict
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}/events/{tag}", method = RequestMethod.PUT, consumes = "text/plain")
-    public ResponseEntity<?> updateEventDate(
-            @PathVariable("id") final UUID id,
-            @PathVariable("tag") final String tag,
-            final @RequestBody String date)
-            throws CTPException {
+    CollectionExercise newCollex =
+        this.collectionExerciseService.createCollectionExercise(collex, survey);
 
-        log.info("Adding collection exercise {}, setting date to {}", id, date);
+    URI location =
+        ServletUriComponentsBuilder.fromCurrentRequest()
+            .path("/{id}")
+            .buildAndExpand(newCollex.getId())
+            .toUri();
+    log.info(
+        "Successfully created collection exercise, CollectionExerciseId: {}", newCollex.getId());
+    return ResponseEntity.created(location).build();
+  }
 
-        try {
-            MultiIsoDateFormat dateParser = new MultiIsoDateFormat();
-            eventService.updateEvent(id, tag, dateParser.parse(date));
-            return ResponseEntity.noContent().build();
-        } catch (ParseException e) {
-            throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format("Unparseable date %s (%s)", date,
-                    e.getLocalizedMessage()));
-        }
+  /**
+   * DELETE request which deletes a collection exercise
+   *
+   * @param id Collection exercise Id to delete
+   * @return the collection exercise that was to be deleted
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
+  public ResponseEntity<CollectionExercise> deleteCollectionExercise(
+      @PathVariable("id") final UUID id) throws CTPException {
+    log.info("Deleting collection exercise {}", id);
+    this.collectionExerciseService.deleteCollectionExercise(id);
+
+    return ResponseEntity.accepted().build();
+  }
+
+  /**
+   * PUT request for linking an array of sample summaries to a collection exercise
+   *
+   * @param collectionExerciseId the collection exercise to link sample summaries to
+   * @param linkSampleSummaryDTO the array of all sample summaries to link to the collection
+   *     exercise, including summaries previously linked as all currently linked summaries are
+   *     removed from the table
+   * @param bindingResult the bindingResult used to validate requests
+   * @return list of the newly linked collection exercises and sample summaries
+   * @throws InvalidRequestException if binding errors
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(
+      value = "/link/{collectionExerciseId}",
+      method = RequestMethod.PUT,
+      consumes = "application/json")
+  public ResponseEntity<LinkedSampleSummariesDTO> linkSampleSummary(
+      @PathVariable("collectionExerciseId") final UUID collectionExerciseId,
+      @RequestBody(required = false) @Valid final LinkSampleSummaryDTO linkSampleSummaryDTO,
+      BindingResult bindingResult)
+      throws InvalidRequestException, CTPException {
+    log.debug("Entering linkSampleSummary with collectionExerciseID {}", collectionExerciseId);
+
+    if (bindingResult.hasErrors()) {
+      throw new InvalidRequestException("Binding errors for execute action plan: ", bindingResult);
     }
 
-
-    /**
-     * GET to find event from the collection exercise service for
-     * the given event tag collection Id.
-     *
-     * @param id  collection exercise id
-     * @param tag collection exercise event tag
-     * @return event associated to collection exercise
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}/events/{tag}", method = RequestMethod.GET)
-    public ResponseEntity<Event> getEvent(@PathVariable("id") final UUID id, @PathVariable("tag") final String tag)
-            throws CTPException {
-        log.debug("Entering Event fetch with event id {}, event tag {} ", id, tag);
-
-        Event event = eventService.getEvent(id, tag);
-
-        return ResponseEntity.ok(event);
+    CollectionExercise collectionExercise =
+        collectionExerciseService.findCollectionExercise(collectionExerciseId);
+    if (collectionExercise == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format("%s %s", RETURN_COLLECTIONEXERCISENOTFOUND, collectionExerciseId));
     }
 
+    List<SampleLink> linkSampleSummaryToCollectionExercise =
+        collectionExerciseService.linkSampleSummaryToCollectionExercise(
+            collectionExerciseId, linkSampleSummaryDTO.getSampleSummaryIds());
+    LinkedSampleSummariesDTO result = new LinkedSampleSummariesDTO();
 
-    /**
-     * DELETE request to delete a collection exercise event
-     *
-     * @param id  Collection exercise Id
-     * @param tag collection exercise event tag
-     * @return the collection exercise event that was to be deleted
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}/events/{tag}", method = RequestMethod.DELETE)
-    public ResponseEntity<Event> deleteCollectionExerciseEvent(@PathVariable("id") final UUID id,
-                                                               @PathVariable("tag") final String tag)
-            throws CTPException {
-        log.info("Deleting collection exercise event id {}, event tag ", id, tag);
+    if (linkSampleSummaryToCollectionExercise != null) {
+      List<UUID> summaryIds = new ArrayList<UUID>();
+      for (SampleLink sampleLink : linkSampleSummaryToCollectionExercise) {
+        summaryIds.add(sampleLink.getSampleSummaryId());
+      }
+      result.setSampleSummaryIds(summaryIds);
 
-        eventService.deleteEvent(id, tag);
+      result.setCollectionExerciseId(
+          linkSampleSummaryToCollectionExercise.get(0).getCollectionExerciseId());
+    }
+    return ResponseEntity.ok(result);
+  }
 
-        return ResponseEntity.noContent().build();
+  /**
+   * Endpoint to return the list of samples linked to a collection exercise
+   *
+   * @param collectionExerciseId the collection exercise for which the links are required
+   * @return a list of sample summaries linked to the collection exercise
+   */
+  @RequestMapping(
+      value = "/link/{collectionExerciseId}",
+      method = RequestMethod.GET,
+      produces = "application/vnd.ons.sdc.samplelink.v1+json")
+  public ResponseEntity<List<SampleLinkDTO>> getSampleLinks(
+      @PathVariable("collectionExerciseId") final UUID collectionExerciseId) {
+    log.debug("Getting linked sample summaries for {}", collectionExerciseId);
+    List<SampleLink> sampleLinks =
+        this.collectionExerciseService.findLinkedSampleSummaries(collectionExerciseId);
+    List<SampleLinkDTO> sampleLinkList = mapperFacade.mapAsList(sampleLinks, SampleLinkDTO.class);
+
+    return ResponseEntity.ok(sampleLinkList);
+  }
+
+  /**
+   * for unlinking sample summary from a collection exercise
+   *
+   * @param collectionExerciseId the collection exercise to unlink from sample
+   * @param sampleSummaryId the collection exercise to unlink from collection exercise
+   * @return noContent response
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(
+      value = "/unlink/{collectionExerciseId}/sample/{sampleSummaryId}",
+      method = RequestMethod.DELETE)
+  public ResponseEntity<?> unlinkSampleSummary(
+      @PathVariable("collectionExerciseId") final UUID collectionExerciseId,
+      @PathVariable("sampleSummaryId") final UUID sampleSummaryId)
+      throws CTPException {
+    log.debug(
+        "Entering unlinkSampleSummary with collectionExerciseID {} and sampleSummaryId {}",
+        collectionExerciseId,
+        sampleSummaryId);
+
+    CollectionExercise collectionExercise =
+        collectionExerciseService.findCollectionExercise(collectionExerciseId);
+    if (collectionExercise == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format("%s %s", RETURN_COLLECTIONEXERCISENOTFOUND, collectionExerciseId));
     }
 
-    /**
-     * Get's the list of all scheduled events from quartz (i.e. it's not the list of events as stored in the database,
-     * it's the actual jobs scheduled in quartz)
-     * @return the list of events derived from quartz jobs
-     * @throws SchedulerException thrown if issues getting data from quartz
-     */
-    @RequestMapping(value = "/events/scheduled", method = RequestMethod.GET)
-    public ResponseEntity<List<EventDTO>> getAllScheduledEvents() throws SchedulerException {
-        List<EventDTO> scheduledEvents = SchedulerConfiguration.getAllScheduledEvents(this.scheduler);
+    collectionExerciseService.removeSampleSummaryLink(sampleSummaryId, collectionExerciseId);
 
-        return ResponseEntity.ok(scheduledEvents);
+    return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * return a list of UUIDs for the sample summaries linked to a specific collection exercise
+   *
+   * @param collectionExerciseId the id of the collection exercise to get linked sample summaries
+   *     for
+   * @return list of UUIDs of linked sample summaries
+   * @throws CTPException if no collection exercise found for UUID
+   */
+  @RequestMapping(value = "link/{collectionExerciseId}", method = RequestMethod.GET)
+  public ResponseEntity<List<UUID>> requestLinkedSampleSummaries(
+      @PathVariable("collectionExerciseId") final UUID collectionExerciseId) throws CTPException {
+    log.debug("Getting sample summaries linked to collectionExerciseId {}", collectionExerciseId);
+
+    CollectionExercise collectionExercise =
+        collectionExerciseService.findCollectionExercise(collectionExerciseId);
+    if (collectionExercise == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format("%s %s", RETURN_COLLECTIONEXERCISENOTFOUND, collectionExerciseId));
     }
 
-    /**
-     * Endpoint to get a collection exercise by exercise ref and survey ref
-     *
-     * @param exerciseRef the exercise ref
-     * @param surveyRef   the survey ref
-     * @return 200 with collection exercise body if found, otherwise 404
-     * @throws CTPException
-     */
-    @RequestMapping(value = "/{exerciseRef}/survey/{surveyRef}", method = RequestMethod.GET)
-    public ResponseEntity<CollectionExerciseDTO> getCollectionExercisesForSurvey(
-            @PathVariable("exerciseRef") final String exerciseRef, @PathVariable("surveyRef") final String surveyRef)
-            throws CTPException {
-        CollectionExercise collex = this.collectionExerciseService.findCollectionExercise(surveyRef, exerciseRef);
-
-        if (collex == null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("Cannot find collection exercise for survey %s and period %s", surveyRef,
-                            exerciseRef));
-        } else {
-            return ResponseEntity.ok(getCollectionExerciseDTO(collex));
-        }
+    List<SampleLink> result =
+        collectionExerciseService.findLinkedSampleSummaries(collectionExerciseId);
+    if (CollectionUtils.isEmpty(result)) {
+      return ResponseEntity.noContent().build();
     }
+
+    List<UUID> output = new ArrayList<UUID>();
+    for (SampleLink link : result) {
+      output.add(link.getSampleSummaryId());
+    }
+    return ResponseEntity.ok(output);
+  }
+
+  /**
+   * adds the case types and surveyId to the CollectionExerciseDTO
+   *
+   * @param collectionExercise the collection exercise to find the associated case types and
+   *     surveyIds for
+   * @return a CollectionExerciseDTO of the collection exercise with case types and surveyId added
+   *     which is output by the endpoints
+   */
+  private CollectionExerciseDTO getCollectionExerciseDTO(
+      final CollectionExercise collectionExercise) {
+    Collection<CaseType> caseTypeList =
+        collectionExerciseService.getCaseTypesList(collectionExercise);
+    List<CaseTypeDTO> caseTypeDTOList = mapperFacade.mapAsList(caseTypeList, CaseTypeDTO.class);
+
+    CollectionExerciseDTO collectionExerciseDTO =
+        mapperFacade.map(collectionExercise, CollectionExerciseDTO.class);
+    collectionExerciseDTO.setCaseTypes(caseTypeDTOList);
+    // NOTE: this method used to fail (NPE) if the survey did not exist in the local database.  Now
+    // the survey id
+    // is not validated and passed on verbatim
+    collectionExerciseDTO.setSurveyId(collectionExercise.getSurveyId().toString());
+
+    // If we are in the failed validation state, then there should be validation error so go look
+    // them up.
+    // We don't do this for all the states as this is a non-trivial database operation.
+    // Note: this code here will suppress any validation errors that are present in the other states
+    // (shouldn't happen but ...)
+    if (collectionExercise.getState()
+        == CollectionExerciseDTO.CollectionExerciseState.FAILEDVALIDATION) {
+      SampleUnitValidationErrorDTO[] errors =
+          this.sampleService.getValidationErrors(collectionExercise.getId());
+
+      collectionExerciseDTO.setValidationErrors(errors);
+    }
+
+    return collectionExerciseDTO;
+  }
+
+  @RequestMapping(value = "/{id}/events", method = RequestMethod.POST)
+  public ResponseEntity<?> createCollectionExerciseEvent(
+      @PathVariable("id") final UUID id, final @RequestBody EventDTO eventDto) throws CTPException {
+    log.info("Creating event {} for collection exercise {}", eventDto.getTag(), id);
+
+    eventDto.setCollectionExerciseId(id);
+
+    Event newEvent = eventService.createEvent(eventDto);
+
+    URI location =
+        ServletUriComponentsBuilder.fromCurrentRequest()
+            .path("/{id}/events/{tag}")
+            .buildAndExpand(newEvent.getId(), newEvent.getTag())
+            .toUri();
+
+    try {
+      SchedulerConfiguration.scheduleEvent(this.scheduler, newEvent);
+    } catch (SchedulerException e) {
+      log.error("Failed to schedule event: " + newEvent);
+    }
+
+    return ResponseEntity.created(location).build();
+  }
+
+  @RequestMapping(value = "/{id}/events", method = RequestMethod.GET)
+  public ResponseEntity<List<EventDTO>> getCollectionExerciseEvents(
+      @PathVariable("id") final UUID id) throws CTPException {
+    List<EventDTO> result =
+        this.eventService
+            .getEvents(id)
+            .stream()
+            .map(EventService::createEventDTOFromEvent)
+            .collect(Collectors.toList());
+
+    return ResponseEntity.ok(result);
+  }
+
+  /**
+   * PUT request to update a collection event date
+   *
+   * @param id Collection exercise Id
+   * @param tag collection exercise event tag
+   * @return 200 if all is ok, 400 for bad request, 409 for conflict
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/{id}/events/{tag}", method = RequestMethod.PUT, consumes = "text/plain")
+  public ResponseEntity<?> updateEventDate(
+      @PathVariable("id") final UUID id,
+      @PathVariable("tag") final String tag,
+      final @RequestBody String date)
+      throws CTPException {
+
+    log.info("Adding collection exercise {}, setting date to {}", id, date);
+
+    try {
+      MultiIsoDateFormat dateParser = new MultiIsoDateFormat();
+      eventService.updateEvent(id, tag, dateParser.parse(date));
+      return ResponseEntity.noContent().build();
+    } catch (ParseException e) {
+      throw new CTPException(
+          CTPException.Fault.BAD_REQUEST,
+          String.format("Unparseable date %s (%s)", date, e.getLocalizedMessage()));
+    }
+  }
+
+  /**
+   * GET to find event from the collection exercise service for the given event tag collection Id.
+   *
+   * @param id collection exercise id
+   * @param tag collection exercise event tag
+   * @return event associated to collection exercise
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/{id}/events/{tag}", method = RequestMethod.GET)
+  public ResponseEntity<Event> getEvent(
+      @PathVariable("id") final UUID id, @PathVariable("tag") final String tag)
+      throws CTPException {
+    log.debug("Entering Event fetch with event id {}, event tag {} ", id, tag);
+
+    Event event = eventService.getEvent(id, tag);
+
+    return ResponseEntity.ok(event);
+  }
+
+  /**
+   * DELETE request to delete a collection exercise event
+   *
+   * @param id Collection exercise Id
+   * @param tag collection exercise event tag
+   * @return the collection exercise event that was to be deleted
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/{id}/events/{tag}", method = RequestMethod.DELETE)
+  public ResponseEntity<Event> deleteCollectionExerciseEvent(
+      @PathVariable("id") final UUID id, @PathVariable("tag") final String tag)
+      throws CTPException {
+    log.info("Deleting collection exercise event id {}, event tag ", id, tag);
+
+    eventService.deleteEvent(id, tag);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * Get's the list of all scheduled events from quartz (i.e. it's not the list of events as stored
+   * in the database, it's the actual jobs scheduled in quartz)
+   *
+   * @return the list of events derived from quartz jobs
+   * @throws SchedulerException thrown if issues getting data from quartz
+   */
+  @RequestMapping(value = "/events/scheduled", method = RequestMethod.GET)
+  public ResponseEntity<List<EventDTO>> getAllScheduledEvents() throws SchedulerException {
+    List<EventDTO> scheduledEvents = SchedulerConfiguration.getAllScheduledEvents(this.scheduler);
+
+    return ResponseEntity.ok(scheduledEvents);
+  }
+
+  /**
+   * Endpoint to get a collection exercise by exercise ref and survey ref
+   *
+   * @param exerciseRef the exercise ref
+   * @param surveyRef the survey ref
+   * @return 200 with collection exercise body if found, otherwise 404
+   * @throws CTPException
+   */
+  @RequestMapping(value = "/{exerciseRef}/survey/{surveyRef}", method = RequestMethod.GET)
+  public ResponseEntity<CollectionExerciseDTO> getCollectionExercisesForSurveyAndExerciseRef(
+      @PathVariable("exerciseRef") final String exerciseRef,
+      @PathVariable("surveyRef") final String surveyRef)
+      throws CTPException {
+    CollectionExercise collex =
+        this.collectionExerciseService.findCollectionExercise(surveyRef, exerciseRef);
+
+    if (collex == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format(
+              "Cannot find collection exercise for survey %s and period %s",
+              surveyRef, exerciseRef));
+    } else {
+      return ResponseEntity.ok(getCollectionExerciseDTO(collex));
+    }
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseExecutionEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseExecutionEndpoint.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.collection.exercise.endpoint;
 
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -11,40 +12,33 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 
-import java.util.UUID;
-
-/**
- * The REST endpoint controller for Collection Exercises.
- */
+/** The REST endpoint controller for Collection Exercises. */
 @RestController
 @RequestMapping(value = "/collectionexerciseexecution", produces = "application/json")
 @Slf4j
 public class CollectionExerciseExecutionEndpoint {
 
-    private static final String RETURN_SAMPLENOTFOUND = "Sample not found for collection exercise Id";
+  private static final String RETURN_SAMPLENOTFOUND = "Sample not found for collection exercise Id";
 
-    @Autowired
-    private SampleService sampleService;
+  @Autowired private SampleService sampleService;
 
-    /**
-     * PUT to manually trigger the request of the sample units from the sample
-     * service for the given collection exercise Id.
-     *
-     * @param id Collection exercise Id for which to trigger delivery of sample
-     *          units
-     * @return total sample units to be delivered.
-     * @throws CTPException on resource not found
-     */
-    @RequestMapping(value = "/{id}", method = RequestMethod.POST)
-    public ResponseEntity<SampleUnitsRequestDTO> requestSampleUnits(@PathVariable("id") final UUID id)
-            throws CTPException {
-        log.debug("Entering collection exercise fetch with Id {}", id);
-        SampleUnitsRequestDTO requestDTO = sampleService.requestSampleUnits(id);
-        if (requestDTO == null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("%s %s", RETURN_SAMPLENOTFOUND, id));
-        }
-        return ResponseEntity.ok(requestDTO);
+  /**
+   * PUT to manually trigger the request of the sample units from the sample service for the given
+   * collection exercise Id.
+   *
+   * @param id Collection exercise Id for which to trigger delivery of sample units
+   * @return total sample units to be delivered.
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/{id}", method = RequestMethod.POST)
+  public ResponseEntity<SampleUnitsRequestDTO> requestSampleUnits(@PathVariable("id") final UUID id)
+      throws CTPException {
+    log.debug("Entering collection exercise fetch with Id {}", id);
+    SampleUnitsRequestDTO requestDTO = sampleService.requestSampleUnits(id);
+    if (requestDTO == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND, String.format("%s %s", RETURN_SAMPLENOTFOUND, id));
     }
-
+    return ResponseEntity.ok(requestDTO);
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/CollectionExerciseEventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/CollectionExerciseEventPublisher.java
@@ -1,17 +1,18 @@
 package uk.gov.ons.ctp.response.collection.exercise.message;
 
 import uk.gov.ons.ctp.common.error.CTPException;
-import uk.gov.ons.ctp.response.collection.exercise.message.dto.EventMessageDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
-
-import java.util.Date;
-import java.util.UUID;
 
 public interface CollectionExerciseEventPublisher {
 
-    enum MessageType {
-        EventElapsed, EventCreated, EventUpdated, EventDeleted
-    }
+  enum MessageType {
+    EventElapsed,
+    EventCreated,
+    EventUpdated,
+    EventDeleted
+  }
 
-    void publishCollectionExerciseEvent(CollectionExerciseEventPublisher.MessageType messageType, EventDTO messageDto) throws CTPException ;
+  void publishCollectionExerciseEvent(
+      CollectionExerciseEventPublisher.MessageType messageType, EventDTO messageDto)
+      throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleUnitPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleUnitPublisher.java
@@ -2,10 +2,7 @@ package uk.gov.ons.ctp.response.collection.exercise.message;
 
 import uk.gov.ons.ctp.response.casesvc.message.sampleunitnotification.SampleUnitParent;
 
-/**
- * Service responsible for publishing  Sample Units to the case service.
- *
- */
+/** Service responsible for publishing Sample Units to the case service. */
 public interface SampleUnitPublisher {
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleUnitReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleUnitReceiver.java
@@ -4,8 +4,8 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
 /**
- * Interface for the receipt of sample unit messages from the Spring Integration
- * inbound message queue
+ * Interface for the receipt of sample unit messages from the Spring Integration inbound message
+ * queue
  */
 public interface SampleUnitReceiver {
 
@@ -16,5 +16,4 @@ public interface SampleUnitReceiver {
    * @throws CTPException when collection exercise state transition error
    */
   void acceptSampleUnit(SampleUnit sampleUnit) throws CTPException;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/CollectionInstrumentMessageDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/CollectionInstrumentMessageDTO.java
@@ -2,23 +2,22 @@ package uk.gov.ons.ctp.response.collection.exercise.message.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
-
 import java.util.UUID;
+import lombok.Data;
 
 @Data
 public class CollectionInstrumentMessageDTO {
-    private String action;
-    private UUID exerciseId;
-    private UUID instrumentId;
+  private String action;
+  private UUID exerciseId;
+  private UUID instrumentId;
 
-    @JsonCreator
-    public CollectionInstrumentMessageDTO(
-            @JsonProperty("action") String action,
-            @JsonProperty("exercise_id") String exerciseId,
-            @JsonProperty("instrument_id") String instrumentId){
-        this.action = action;
-        this.exerciseId = UUID.fromString(exerciseId);
-        this.instrumentId = UUID.fromString(instrumentId);
-    }
+  @JsonCreator
+  public CollectionInstrumentMessageDTO(
+      @JsonProperty("action") String action,
+      @JsonProperty("exercise_id") String exerciseId,
+      @JsonProperty("instrument_id") String instrumentId) {
+    this.action = action;
+    this.exerciseId = UUID.fromString(exerciseId);
+    this.instrumentId = UUID.fromString(instrumentId);
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/EventMessageDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/EventMessageDTO.java
@@ -6,14 +6,14 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 
 @Data
 public class EventMessageDTO {
-    private EventDTO event;
+  private EventDTO event;
 
-    private CollectionExerciseEventPublisher.MessageType messageType;
+  private CollectionExerciseEventPublisher.MessageType messageType;
 
-    public EventMessageDTO() { }
+  public EventMessageDTO() {}
 
-    public EventMessageDTO(CollectionExerciseEventPublisher.MessageType messageType, EventDTO event) {
-        this.event = event;
-        this.messageType = messageType;
-    }
+  public EventMessageDTO(CollectionExerciseEventPublisher.MessageType messageType, EventDTO event) {
+    this.event = event;
+    this.messageType = messageType;
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventInboundReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventInboundReceiver.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
@@ -12,75 +13,78 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
-import java.util.UUID;
-
 /**
- * Class to hold service activator method to handle incoming collection exercise event lifecycle messages
+ * Class to hold service activator method to handle incoming collection exercise event lifecycle
+ * messages
  */
 @MessageEndpoint
 @Slf4j
 public class CollectionExerciseEventInboundReceiver {
 
-    @Autowired
-    private CollectionExerciseService collectionExerciseService;
+  @Autowired private CollectionExerciseService collectionExerciseService;
 
-    /**
-     * Service activator method - if it's a go_live event and it's EventElapsed then send a GO_LIVE event to the
-     * collection exercise to push it into the LIVE state
-     *
-     * @param message an event message
-     */
-    @ServiceActivator(inputChannel = "cemInMessage")
-    public void handleEventMessage(final EventMessageDTO message) {
-        EventDTO event = message.getEvent();
-        CollectionExerciseEventPublisher.MessageType messageType = message.getMessageType();
-        String tagString = event.getTag();
-        EventService.Tag tag;
+  /**
+   * Service activator method - if it's a go_live event and it's EventElapsed then send a GO_LIVE
+   * event to the collection exercise to push it into the LIVE state
+   *
+   * @param message an event message
+   */
+  @ServiceActivator(inputChannel = "cemInMessage")
+  public void handleEventMessage(final EventMessageDTO message) {
+    EventDTO event = message.getEvent();
+    CollectionExerciseEventPublisher.MessageType messageType = message.getMessageType();
+    String tagString = event.getTag();
+    EventService.Tag tag;
 
-        try {
-            tag = EventService.Tag.valueOf(tagString);
+    try {
+      tag = EventService.Tag.valueOf(tagString);
 
-            // If it's a go_live EventElapsed then attempt to transition the state of the collection exercise to live
-            if (tag == EventService.Tag.go_live
-                    && messageType == CollectionExerciseEventPublisher.MessageType.EventElapsed) {
-                UUID collexId = event.getCollectionExerciseId();
+      // If it's a go_live EventElapsed then attempt to transition the state of the collection
+      // exercise to live
+      if (tag == EventService.Tag.go_live
+          && messageType == CollectionExerciseEventPublisher.MessageType.EventElapsed) {
+        UUID collexId = event.getCollectionExerciseId();
 
-                transitionCollectionExerciseToLive(collexId);
-            } else {
-                logIgnoreMessage(message);
-            }
-        } catch (IllegalArgumentException e) {
-            // This means that the event isn't one of the mandatory events that is represented in the enum - which is
-            // fine.
-            logIgnoreMessage(message);
-        }
+        transitionCollectionExerciseToLive(collexId);
+      } else {
+        logIgnoreMessage(message);
+      }
+    } catch (IllegalArgumentException e) {
+      // This means that the event isn't one of the mandatory events that is represented in the enum
+      // - which is
+      // fine.
+      logIgnoreMessage(message);
     }
+  }
 
-    /**
-     * Logs a message stating the event message is being ignored as it's not go_live/EventElapsed
-     *
-     * @param message the event message being ignored
-     */
-    private void logIgnoreMessage(final EventMessageDTO message) {
-        EventDTO event = message.getEvent();
+  /**
+   * Logs a message stating the event message is being ignored as it's not go_live/EventElapsed
+   *
+   * @param message the event message being ignored
+   */
+  private void logIgnoreMessage(final EventMessageDTO message) {
+    EventDTO event = message.getEvent();
 
-        log.info("Ignoring event message {}/{} - not {}/{}", event.getTag(), message.getMessageType(),
-                EventService.Tag.go_live.name(), CollectionExerciseEventPublisher.MessageType.EventElapsed.name());
+    log.info(
+        "Ignoring event message {}/{} - not {}/{}",
+        event.getTag(),
+        message.getMessageType(),
+        EventService.Tag.go_live.name(),
+        CollectionExerciseEventPublisher.MessageType.EventElapsed.name());
+  }
+
+  /**
+   * Sends a GO_LIVE event to the state machine for a collection exercise
+   *
+   * @param collexId the UUID of the collection exercise
+   */
+  private void transitionCollectionExerciseToLive(final UUID collexId) {
+    try {
+      this.collectionExerciseService.transitionCollectionExercise(
+          collexId, CollectionExerciseDTO.CollectionExerciseEvent.GO_LIVE);
+      log.info("Set collection exercise {} to LIVE state", collexId);
+    } catch (CTPException e) {
+      log.error("Failed to set collection exercise {} to LIVE state - {}", collexId, e);
     }
-
-    /**
-     * Sends a GO_LIVE event to the state machine for a collection exercise
-     *
-     * @param collexId the UUID of the collection exercise
-     */
-    private void transitionCollectionExerciseToLive(final UUID collexId) {
-        try {
-            this.collectionExerciseService.transitionCollectionExercise(collexId,
-                    CollectionExerciseDTO.CollectionExerciseEvent.GO_LIVE);
-            log.info("Set collection exercise {} to LIVE state", collexId);
-        } catch (CTPException e) {
-            log.error("Failed to set collection exercise {} to LIVE state - {}", collexId, e);
-        }
-    }
-
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventPublisherImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventPublisherImpl.java
@@ -8,52 +8,46 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.error.CTPException;
-import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEventPublisher;
 import uk.gov.ons.ctp.response.collection.exercise.message.dto.EventMessageDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
-import java.util.Date;
-import java.util.UUID;
-
 @Component
 @Slf4j
 public class CollectionExerciseEventPublisherImpl implements CollectionExerciseEventPublisher {
 
-    @Autowired
-    private EventService eventService;
+  @Autowired private EventService eventService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
-    @Qualifier("collexEventTemplate")
-    @Autowired
-    private RabbitTemplate rabbitTemplate;
+  @Qualifier("collexEventTemplate")
+  @Autowired
+  private RabbitTemplate rabbitTemplate;
 
-    @Override
-    public void publishCollectionExerciseEvent(MessageType messageType, EventDTO eventDto) throws CTPException {
-        EventMessageDTO messageDto = new EventMessageDTO(messageType, eventDto);
+  @Override
+  public void publishCollectionExerciseEvent(MessageType messageType, EventDTO eventDto)
+      throws CTPException {
+    EventMessageDTO messageDto = new EventMessageDTO(messageType, eventDto);
 
-        try {
-            String message = this.objectMapper.writeValueAsString(messageDto);
-            this.rabbitTemplate.convertAndSend(message);
-            if (messageType == MessageType.EventElapsed) {
-                this.eventService.setEventMessageSent(eventDto.getId());
-            }
-        } catch (CTPException e) {
-            String message = String.format("Failed to set event %s as message sent", eventDto.getId());
+    try {
+      String message = this.objectMapper.writeValueAsString(messageDto);
+      this.rabbitTemplate.convertAndSend(message);
+      if (messageType == MessageType.EventElapsed) {
+        this.eventService.setEventMessageSent(eventDto.getId());
+      }
+    } catch (CTPException e) {
+      String message = String.format("Failed to set event %s as message sent", eventDto.getId());
 
-            log.error(message);
+      log.error(message);
 
-            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, message);
-        } catch (JsonProcessingException e) {
-            String message = String.format("Failed to serialise event %s to json", eventDto);
+      throw new CTPException(CTPException.Fault.SYSTEM_ERROR, message);
+    } catch (JsonProcessingException e) {
+      String message = String.format("Failed to serialise event %s to json", eventDto);
 
-            log.error(message);
+      log.error(message);
 
-            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, message);
-        }
+      throw new CTPException(CTPException.Fault.SYSTEM_ERROR, message);
     }
-
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionInstrumentLoadedReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionInstrumentLoadedReceiver.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
@@ -8,21 +9,18 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.message.dto.CollectionInstrumentMessageDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 
-import java.util.UUID;
-
 @MessageEndpoint
 @Slf4j
 public class CollectionInstrumentLoadedReceiver {
 
-    @Autowired
-    private CollectionExerciseService collectionExerciseService;
+  @Autowired private CollectionExerciseService collectionExerciseService;
 
-    @ServiceActivator(inputChannel = "ciMessageDto")
-    public void acceptSampleUnit(CollectionInstrumentMessageDTO message) throws CTPException {
-        log.info("json: {}", message);
+  @ServiceActivator(inputChannel = "ciMessageDto")
+  public void acceptSampleUnit(CollectionInstrumentMessageDTO message) throws CTPException {
+    log.info("json: {}", message);
 
-        UUID collexId = message.getExerciseId();
+    UUID collexId = message.getExerciseId();
 
-        this.collectionExerciseService.transitionScheduleCollectionExerciseToReadyToReview(collexId);
-    }
+    this.collectionExerciseService.transitionScheduleCollectionExerciseToReadyToReview(collexId);
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandler.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -7,63 +9,63 @@ import org.springframework.messaging.MessageHandlingException;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.message.dto.CollectionInstrumentMessageDTO;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
- * Error handling class containing service activator method to convert MessageHandlingException into a map
- * that's more friendly to posting as messages
+ * Error handling class containing service activator method to convert MessageHandlingException into
+ * a map that's more friendly to posting as messages
  */
 @MessageEndpoint
 @Slf4j
 public class ExceptionHandler {
 
-    /**
-     * Service activator method that accepts a MessageHandlingException, pulls out the important bits and returns
-     * them as a map suitable for posting as a Rabbit message or logging.  It pulls messages from the ciErrorChannel
-     * Spring integration channel and the results get posted to the ciErrorCleanChannel
-     *
-     * @param e a message handling exception
-     * @return a map containing details of the collection exercise & instument if available and the error message
-     */
-    @ServiceActivator(inputChannel = "ciErrorChannel", outputChannel = "ciErrorCleanChannel")
-    public Map<ResultKey, String> handleException(final MessageHandlingException e) {
-        Map<ResultKey, String> result = new HashMap<>();
+  /**
+   * Service activator method that accepts a MessageHandlingException, pulls out the important bits
+   * and returns them as a map suitable for posting as a Rabbit message or logging. It pulls
+   * messages from the ciErrorChannel Spring integration channel and the results get posted to the
+   * ciErrorCleanChannel
+   *
+   * @param e a message handling exception
+   * @return a map containing details of the collection exercise & instument if available and the
+   *     error message
+   */
+  @ServiceActivator(inputChannel = "ciErrorChannel", outputChannel = "ciErrorCleanChannel")
+  public Map<ResultKey, String> handleException(final MessageHandlingException e) {
+    Map<ResultKey, String> result = new HashMap<>();
 
-        // Exceptions thrown in error handlers are really annoying so check all incoming data THOROUGHLY
-        if (e != null) {
-            if (e.getFailedMessage() != null) {
-                Object payload = e.getFailedMessage().getPayload();
+    // Exceptions thrown in error handlers are really annoying so check all incoming data THOROUGHLY
+    if (e != null) {
+      if (e.getFailedMessage() != null) {
+        Object payload = e.getFailedMessage().getPayload();
 
-                if (payload != null && payload instanceof CollectionInstrumentMessageDTO) {
-                    CollectionInstrumentMessageDTO dto = (CollectionInstrumentMessageDTO) payload;
+        if (payload != null && payload instanceof CollectionInstrumentMessageDTO) {
+          CollectionInstrumentMessageDTO dto = (CollectionInstrumentMessageDTO) payload;
 
-                    result.put(ResultKey.collectionExercise, dto.getExerciseId().toString());
-                    result.put(ResultKey.collectionInstrument, dto.getInstrumentId().toString());
-                }
-            }
-            Throwable t = e.getCause();
+          result.put(ResultKey.collectionExercise, dto.getExerciseId().toString());
+          result.put(ResultKey.collectionInstrument, dto.getInstrumentId().toString());
+        }
+      }
+      Throwable t = e.getCause();
 
-            if (t != null) {
-                if (t instanceof CTPException) {
-                    CTPException ctpException = (CTPException) t;
+      if (t != null) {
+        if (t instanceof CTPException) {
+          CTPException ctpException = (CTPException) t;
 
-                    result.put(ResultKey.errorType, ctpException.getFault().name());
-                    result.put(ResultKey.errorTimestamp, Long.toString(ctpException.getTimestamp()));
-                }
-
-                result.put(ResultKey.errorMessage, t.getLocalizedMessage());
-            }
+          result.put(ResultKey.errorType, ctpException.getFault().name());
+          result.put(ResultKey.errorTimestamp, Long.toString(ctpException.getTimestamp()));
         }
 
-        return result;
+        result.put(ResultKey.errorMessage, t.getLocalizedMessage());
+      }
     }
 
-    /**
-     * Definition of fields that appear in error message sent to DLQ
-     */
-    enum ResultKey {
-        collectionExercise, collectionInstrument, errorType, errorMessage, errorTimestamp
-    }
+    return result;
+  }
 
+  /** Definition of fields that appear in error message sent to DLQ */
+  enum ResultKey {
+    collectionExercise,
+    collectionInstrument,
+    errorType,
+    errorMessage,
+    errorTimestamp
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUnitPublisherImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUnitPublisherImpl.java
@@ -1,20 +1,15 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
+import lombok.extern.slf4j.Slf4j;
+import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.annotation.MessageEndpoint;
-
-import lombok.extern.slf4j.Slf4j;
-import net.sourceforge.cobertura.CoverageIgnore;
 import uk.gov.ons.ctp.response.casesvc.message.sampleunitnotification.SampleUnitParent;
 import uk.gov.ons.ctp.response.collection.exercise.message.SampleUnitPublisher;
 
-/**
- * Service implementation responsible for publishing a sampleUnit message to the
- * case service.
- *
- */
+/** Service implementation responsible for publishing a sampleUnit message to the case service. */
 @CoverageIgnore
 @MessageEndpoint
 @Slf4j
@@ -26,9 +21,10 @@ public class SampleUnitPublisherImpl implements SampleUnitPublisher {
 
   @Override
   public void sendSampleUnit(SampleUnitParent sampleUnit) {
-    log.debug("Entering sendSampleUnit for SampleUnitRef {}, SampleUnitType {} ", sampleUnit.getSampleUnitRef(),
+    log.debug(
+        "Entering sendSampleUnit for SampleUnitRef {}, SampleUnitType {} ",
+        sampleUnit.getSampleUnitRef(),
         sampleUnit.getSampleUnitType());
     rabbitTemplate.convertAndSend(sampleUnit);
   }
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUnitReceiverImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUnitReceiverImpl.java
@@ -4,23 +4,20 @@ import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
-
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.message.SampleUnitReceiver;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
 /**
- * Service implementation responsible for receipt of sample units. See Spring
- * Integration flow for details of inbound queue.
- *
+ * Service implementation responsible for receipt of sample units. See Spring Integration flow for
+ * details of inbound queue.
  */
 @CoverageIgnore
 @MessageEndpoint
 public class SampleUnitReceiverImpl implements SampleUnitReceiver {
 
-  @Autowired
-  private SampleService sampleService;
+  @Autowired private SampleService sampleService;
 
   // TODO CTPA-1340
   @Override

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CaseTypeDefaultRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CaseTypeDefaultRepository.java
@@ -1,15 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.repository;
 
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeDefault;
 
-import java.util.List;
-import java.util.UUID;
-
-/**
- * Spring JPA Repository for CaseTypeDefault
- *
- */
+/** Spring JPA Repository for CaseTypeDefault */
 public interface CaseTypeDefaultRepository extends JpaRepository<CaseTypeDefault, UUID> {
 
   /**
@@ -28,5 +24,4 @@ public interface CaseTypeDefaultRepository extends JpaRepository<CaseTypeDefault
    * @return list of associated casetypedefaults.
    */
   CaseTypeDefault findTopBySurveyIdAndSampleUnitTypeFK(UUID surveyUuid, String sampleUnitType);
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CaseTypeOverrideRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CaseTypeOverrideRepository.java
@@ -1,15 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.repository;
 
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
 
-import java.util.List;
-import java.util.UUID;
-
-/**
- * Spring JPA Repository for CaseTypeOverride
- *
- */
+/** Spring JPA Repository for CaseTypeOverride */
 public interface CaseTypeOverrideRepository extends JpaRepository<CaseTypeOverride, UUID> {
 
   /**
@@ -20,6 +16,6 @@ public interface CaseTypeOverrideRepository extends JpaRepository<CaseTypeOverri
    */
   List<CaseTypeOverride> findByExerciseFK(Integer collectionExercisePK);
 
-  CaseTypeOverride findTopByExerciseFKAndSampleUnitTypeFK(Integer collectionExercisePK, String sampleUnitType);
-
+  CaseTypeOverride findTopByExerciseFKAndSampleUnitTypeFK(
+      Integer collectionExercisePK, String sampleUnitType);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
@@ -1,18 +1,14 @@
 package uk.gov.ons.ctp.response.collection.exercise.repository;
 
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 
-import java.util.List;
-import java.util.UUID;
-
-/**
- * Spring JPA Repository for Collection Exercise
- *
- */
+/** Spring JPA Repository for Collection Exercise */
 public interface CollectionExerciseRepository extends JpaRepository<CollectionExercise, Integer> {
 
   /**
@@ -35,8 +31,7 @@ public interface CollectionExerciseRepository extends JpaRepository<CollectionEx
   List<CollectionExercise> findBySurveyId(UUID surveyUuid);
 
   /**
-   * Query repository for list of collection exercises associated with a certain
-   * state.
+   * Query repository for list of collection exercises associated with a certain state.
    *
    * @param state for which to return Collection Exercises.
    * @return collection exercises in the requested state.
@@ -44,22 +39,30 @@ public interface CollectionExerciseRepository extends JpaRepository<CollectionEx
   List<CollectionExercise> findByState(CollectionExerciseDTO.CollectionExerciseState state);
 
   /**
-   * Query repository for active actionPlanId (default or override) for SampleUnitType for
-   * Survey of if overridden for SampleUnitType for CollectionExercise.
+   * Query repository for active actionPlanId (default or override) for SampleUnitType for Survey of
+   * if overridden for SampleUnitType for CollectionExercise.
    *
    * @param exercisefk of CollectionExercise.
    * @param sampleunittypefk of SampleUnitType.
    * @param surveyuuid uuid of Survey.
    * @return ActiveActionPlanId
    */
-  @Query(value = "SELECT CASE WHEN r.actionplanid IS NULL THEN CAST(df.actionplanid AS VARCHAR) ELSE "
-          + "CAST(r.actionplanid AS VARCHAR) END as to_use FROM (SELECT o.* FROM collectionexercise.casetypeoverride o "
-          + "WHERE o.exercisefk = :p_exercisefk AND o.sampleunittypefk = :p_sampleunittypefk) r "
-          + "RIGHT OUTER JOIN (SELECT d.* FROM collectionexercise.casetypedefault d WHERE d.survey_uuid = :p_surveyuuid "
-          + "AND d.sampleunittypefk = :p_sampleunittypefk) df ON r.sampleunittypeFK = df.sampleunittypeFK;",
-          nativeQuery = true)
-  String getActiveActionPlanId(@Param("p_exercisefk") Integer exercisefk,
-      @Param("p_sampleunittypefk") String sampleunittypefk, @Param("p_surveyuuid") UUID surveyuuid);
+  @Query(
+      value =
+          "SELECT CASE WHEN r.actionplanid IS NULL THEN CAST(df.actionplanid AS VARCHAR) ELSE "
+              + "CAST(r.actionplanid AS VARCHAR) END as to_use FROM (SELECT o.* "
+              + "FROM collectionexercise.casetypeoverride o "
+              + "WHERE o.exercisefk = :p_exercisefk "
+              + "AND o.sampleunittypefk = :p_sampleunittypefk) r "
+              + "RIGHT OUTER JOIN (SELECT d.* FROM collectionexercise.casetypedefault d "
+              + "WHERE d.survey_uuid = :p_surveyuuid "
+              + "AND d.sampleunittypefk = :p_sampleunittypefk) df "
+              + "ON r.sampleunittypeFK = df.sampleunittypeFK;",
+      nativeQuery = true)
+  String getActiveActionPlanId(
+      @Param("p_exercisefk") Integer exercisefk,
+      @Param("p_sampleunittypefk") String sampleunittypefk,
+      @Param("p_surveyuuid") UUID surveyuuid);
 
   /**
    * Query repository for list of collection exercises associated with a certain party ID.
@@ -67,15 +70,20 @@ public interface CollectionExerciseRepository extends JpaRepository<CollectionEx
    * @param partyid for which to return Collection Exercises.
    * @return collection exercises for party ID.
    */
-  @Query(value = "select ce.id, ce.exercisepk, ce.name, ce.scheduledstartdatetime, ce.scheduledexecutiondatetime, "
-          + "ce.scheduledreturndatetime, ce.scheduledenddatetime, ce.periodstartdatetime, ce.periodenddatetime, "
-          + "ce.actualexecutiondatetime, ce.actualpublishdatetime, ce.executedby, ce.statefk, ce.samplesize, "
-          + "ce.exerciseref, ce.user_description, ce.created, ce.updated, ce.deleted, ce.survey_uuid "
-          + "from collectionexercise.collectionexercise ce "
-          + "inner join collectionexercise.sampleunitgroup sg "
-          + "on ce.exercisepk = sg.exercisefk "
-          + "inner join collectionexercise.sampleunit su "
-          + "on sg.sampleunitgrouppk = su.sampleunitgroupfk "
-          + "where su.partyid = :p_partyid ;", nativeQuery = true)
+  @Query(
+      value =
+          "select ce.id, ce.exercisepk, ce.name, ce.scheduledstartdatetime, "
+              + "ce.scheduledexecutiondatetime, ce.scheduledreturndatetime, "
+              + "ce.scheduledenddatetime, ce.periodstartdatetime, ce.periodenddatetime, "
+              + "ce.actualexecutiondatetime, ce.actualpublishdatetime, ce.executedby, ce.statefk, "
+              + "ce.samplesize, ce.exerciseref, ce.user_description, ce.created, ce.updated, "
+              + "ce.deleted, ce.survey_uuid "
+              + "from collectionexercise.collectionexercise ce "
+              + "inner join collectionexercise.sampleunitgroup sg "
+              + "on ce.exercisepk = sg.exercisefk "
+              + "inner join collectionexercise.sampleunit su "
+              + "on sg.sampleunitgrouppk = su.sampleunitgroupfk "
+              + "where su.partyid = :p_partyid ;",
+      nativeQuery = true)
   List<CollectionExercise> findByPartyId(@Param("p_partyid") UUID partyid);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/EventRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/EventRepository.java
@@ -1,27 +1,31 @@
 package uk.gov.ons.ctp.response.collection.exercise.repository;
 
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 
-import java.util.List;
-import java.util.UUID;
-
 public interface EventRepository extends JpaRepository<Event, Integer> {
-    Event findOneById(UUID id);
-    List<Event> findByCollectionExercise(CollectionExercise collex);
-    Event findOneByCollectionExerciseAndTag(CollectionExercise collex, String tag);
-    List<Event> findByCollectionExerciseId(UUID collexId);
+  Event findOneById(UUID id);
 
-    /**
-     * Find events where elapsed message has already been sent
-     * @return the list of matching events
-     */
-    List<Event> findByMessageSentNotNull();
+  List<Event> findByCollectionExercise(CollectionExercise collex);
 
-    /**
-     * Find events where elapsed message has not been sent
-     * @return the list of matching events
-     */
-    List<Event> findByMessageSentNull();
+  Event findOneByCollectionExerciseAndTag(CollectionExercise collex, String tag);
+
+  List<Event> findByCollectionExerciseId(UUID collexId);
+
+  /**
+   * Find events where elapsed message has already been sent
+   *
+   * @return the list of matching events
+   */
+  List<Event> findByMessageSentNotNull();
+
+  /**
+   * Find events where elapsed message has not been sent
+   *
+   * @return the list of matching events
+   */
+  List<Event> findByMessageSentNull();
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleLinkRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleLinkRepository.java
@@ -2,14 +2,10 @@ package uk.gov.ons.ctp.response.collection.exercise.repository;
 
 import java.util.List;
 import java.util.UUID;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 
-/**
- * JPA Data Repository.
- */
+/** JPA Data Repository. */
 public interface SampleLinkRepository extends JpaRepository<SampleLink, Integer> {
 
   /**
@@ -25,7 +21,8 @@ public interface SampleLinkRepository extends JpaRepository<SampleLink, Integer>
    * @param sampleSummaryId the UUID of the sample to delete link for
    * @param collectionExerciseId the UUID of the collection exercise to delete link for
    */
-  void deleteBySampleSummaryIdAndCollectionExerciseId(UUID sampleSummaryId, UUID collectionExerciseId);
+  void deleteBySampleSummaryIdAndCollectionExerciseId(
+      UUID sampleSummaryId, UUID collectionExerciseId);
 
   /**
    * find sample summaries linked to collection exercise

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitGroupRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitGroupRepository.java
@@ -1,19 +1,14 @@
 package uk.gov.ons.ctp.response.collection.exercise.repository;
 
 import java.util.List;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO;
 
-/**
- * Spring JPA Repository for ExerciseSampleUnitGroup
- *
- */
+/** Spring JPA Repository for ExerciseSampleUnitGroup */
 @Repository
 public interface SampleUnitGroupRepository extends JpaRepository<ExerciseSampleUnitGroup, Integer> {
 
@@ -24,40 +19,40 @@ public interface SampleUnitGroupRepository extends JpaRepository<ExerciseSampleU
    * @param exercise CollectionExercise for which to provide count.
    * @return count of SampleUnitGroups in provided state.
    */
-  Long countByStateFKAndCollectionExercise(SampleUnitGroupDTO.SampleUnitGroupState state, CollectionExercise exercise);
+  Long countByStateFKAndCollectionExercise(
+      SampleUnitGroupDTO.SampleUnitGroupState state, CollectionExercise exercise);
 
   /**
-   * Query repository for SampleUnitGroups by state and belonging to a list of
-   * collection exercises. Order by CreatedDateTime ascending.
+   * Query repository for SampleUnitGroups by state and belonging to a list of collection exercises.
+   * Order by CreatedDateTime ascending.
    *
    * @param state filter criteria.
    * @param exercises for which to return SampleUnitGroups.
    * @param excludedGroups SampleUnitGroupPKs to exclude from results.
-   * @param pageable Spring JPA pageable object used to return required number
-   *          of results.
-   * @return returns requested number of SampleUnitGroups for state within
-   *         requested exercises.
+   * @param pageable Spring JPA pageable object used to return required number of results.
+   * @return returns requested number of SampleUnitGroups for state within requested exercises.
    */
-  List<ExerciseSampleUnitGroup> findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
-      SampleUnitGroupDTO.SampleUnitGroupState state,
-      List<CollectionExercise> exercises,
-      List<Integer> excludedGroups,
-      Pageable pageable);
+  List<ExerciseSampleUnitGroup>
+      findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
+          SampleUnitGroupDTO.SampleUnitGroupState state,
+          List<CollectionExercise> exercises,
+          List<Integer> excludedGroups,
+          Pageable pageable);
 
   /**
-   * Query repository for SampleUnitGroups by state and belonging to a
-   * collection exercise. Order by ModifiedDateTime ascending.
+   * Query repository for SampleUnitGroups by state and belonging to a collection exercise. Order by
+   * ModifiedDateTime ascending.
    *
    * @param state filter criteria.
    * @param exercise for which to return SampleUnitGroups.
    * @param excludedGroups SampleUnitGroupPKs to exclude from results.
-   * @param pageable Spring JPA pageable object used to return required number
-   *          of results.
+   * @param pageable Spring JPA pageable object used to return required number of results.
    * @return returns all SampleUnitGroups for state within requested exercise.
    */
-  List<ExerciseSampleUnitGroup> findByStateFKAndCollectionExerciseAndSampleUnitGroupPKNotInOrderByModifiedDateTimeAsc(
-      SampleUnitGroupDTO.SampleUnitGroupState state,
-      CollectionExercise exercise,
-      List<Integer> excludedGroups,
-      Pageable pageable);
+  List<ExerciseSampleUnitGroup>
+      findByStateFKAndCollectionExerciseAndSampleUnitGroupPKNotInOrderByModifiedDateTimeAsc(
+          SampleUnitGroupDTO.SampleUnitGroupState state,
+          CollectionExercise exercise,
+          List<Integer> excludedGroups,
+          Pageable pageable);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepository.java
@@ -2,40 +2,39 @@ package uk.gov.ons.ctp.response.collection.exercise.repository;
 
 import java.util.List;
 import java.util.UUID;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
 
-/**
- * JPA repository for SampleUnit entities
- */
+/** JPA repository for SampleUnit entities */
 @Repository
 public interface SampleUnitRepository extends JpaRepository<ExerciseSampleUnit, Integer> {
 
   /**
-   * Check repository for SampleUnit existence. May exist in different
-   * CollectionExercise.
+   * Check repository for SampleUnit existence. May exist in different CollectionExercise.
    *
    * @param id CollectionExercise id of which the sample unit to check is a part.
    * @param sampleUnitRef to check for existence of sample unit.
    * @param sampleUnitTypeFK to check for existence of sample unit.
    * @return boolean whether exists
    */
-  @Query(value = "select exists (select 1 from "
-      + "collectionexercise.sampleunit su, "
-      + "collectionexercise.sampleunitgroup sg "
-      + "where su.sampleunitgroupfk = sg.sampleunitgrouppk and "
-      + "sg.exercisefk = :p_exercisefk and "
-      + "su.sampleunitref = :p_sampleunitref and "
-      + "su.sampleunittypefk = :p_sampleunittypefk);", nativeQuery = true)
-  boolean tupleExists(@Param("p_exercisefk") Integer id, @Param("p_sampleunitref") String sampleUnitRef,
+  @Query(
+      value =
+          "select exists (select 1 from "
+              + "collectionexercise.sampleunit su, "
+              + "collectionexercise.sampleunitgroup sg "
+              + "where su.sampleunitgroupfk = sg.sampleunitgrouppk and "
+              + "sg.exercisefk = :p_exercisefk and "
+              + "su.sampleunitref = :p_sampleunitref and "
+              + "su.sampleunittypefk = :p_sampleunittypefk);",
+      nativeQuery = true)
+  boolean tupleExists(
+      @Param("p_exercisefk") Integer id,
+      @Param("p_sampleunitref") String sampleUnitRef,
       @Param("p_sampleunittypefk") String sampleUnitTypeFK);
-
 
   /**
    * Count the number of SampleUnits for the CollectionExercise.
@@ -43,34 +42,43 @@ public interface SampleUnitRepository extends JpaRepository<ExerciseSampleUnit, 
    * @param id of CollectionExercise for which to count SampleUnits.
    * @return int of SampleUnit total for given exercisePK.
    */
-  @Query(value = "select count(*) from "
-      + "collectionexercise.sampleunit su, "
-      + "collectionexercise.sampleunitgroup sg "
-      + "where sg.exercisefk = :p_exercisefk and "
-      + "su.sampleunitgroupfk = sg.sampleunitgrouppk;", nativeQuery = true)
+  @Query(
+      value =
+          "select count(*) from "
+              + "collectionexercise.sampleunit su, "
+              + "collectionexercise.sampleunitgroup sg "
+              + "where sg.exercisefk = :p_exercisefk and "
+              + "su.sampleunitgroupfk = sg.sampleunitgrouppk;",
+      nativeQuery = true)
   int totalByExercisePK(@Param("p_exercisefk") Integer id);
 
   /**
    * Query repository for SampleUnits belonging to a SampleUnitGroup.
    *
-   *  @param sampleUnitGroup to which the SampleUnits belong.
-   *  @return List<ExerciseSampleUnit> SampleUnits belonging to SampleUnitGroup
+   * @param sampleUnitGroup to which the SampleUnits belong.
+   * @return List<ExerciseSampleUnit> SampleUnits belonging to SampleUnitGroup
    */
   List<ExerciseSampleUnit> findBySampleUnitGroup(ExerciseSampleUnitGroup sampleUnitGroup);
 
   /**
    * Find sample units containing validation errors for a given collection exercise
+   *
    * @param collectionExerciseId a collection exercise
    * @return a list of sample units containing valdation errors
    */
-  @Query(value = "select su.sampleunitpk, "
-          + "su.sampleunitgroupfk, "
-          + "su.collectioninstrumentid, su.partyid, su.sampleunitref, su.sampleunittypefk "
-          + "from collectionexercise.sampleunit su "
-          + "inner join collectionexercise.sampleunitgroup sug on su.sampleunitgroupfk = sug.sampleunitgrouppk "
-          + "inner join collectionexercise.collectionexercise ce on sug.exercisefk = ce.exercisepk "
-          + "where sug.statefk = 'FAILEDVALIDATION' "
-          + "and ce.id = :p_exerciseId", nativeQuery = true)
-  List<ExerciseSampleUnit> findInvalidByCollectionExercise(@Param("p_exerciseId") UUID collectionExerciseId);
-
+  @Query(
+      value =
+          "select su.sampleunitpk, "
+              + "su.sampleunitgroupfk, "
+              + "su.collectioninstrumentid, su.partyid, su.sampleunitref, su.sampleunittypefk "
+              + "from collectionexercise.sampleunit su "
+              + "inner join collectionexercise.sampleunitgroup sug "
+              + "on su.sampleunitgroupfk = sug.sampleunitgrouppk "
+              + "inner join collectionexercise.collectionexercise ce "
+              + "on sug.exercisefk = ce.exercisepk "
+              + "where sug.statefk = 'FAILEDVALIDATION' "
+              + "and ce.id = :p_exerciseId",
+      nativeQuery = true)
+  List<ExerciseSampleUnit> findInvalidByCollectionExercise(
+      @Param("p_exerciseId") UUID collectionExerciseId);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/schedule/AutoWiringSpringBeanJobFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/schedule/AutoWiringSpringBeanJobFactory.java
@@ -9,23 +9,24 @@ import org.springframework.scheduling.quartz.SpringBeanJobFactory;
 
 /**
  * Adds auto-wiring support to quartz jobs.
+ *
  * @see "https://gist.github.com/jelies/5085593"
  */
-public final class AutoWiringSpringBeanJobFactory extends SpringBeanJobFactory implements ApplicationContextAware {
+public final class AutoWiringSpringBeanJobFactory extends SpringBeanJobFactory
+    implements ApplicationContextAware {
 
-    private transient AutowireCapableBeanFactory beanFactory;
+  private transient AutowireCapableBeanFactory beanFactory;
 
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 
-        beanFactory = applicationContext.getAutowireCapableBeanFactory();
-    }
+    beanFactory = applicationContext.getAutowireCapableBeanFactory();
+  }
 
-    @Override
-    protected Object createJobInstance(final TriggerFiredBundle bundle) throws Exception {
+  @Override
+  protected Object createJobInstance(final TriggerFiredBundle bundle) throws Exception {
 
-        final Object job = super.createJobInstance(bundle);
-        beanFactory.autowireBean(job);
-        return job;
-    }
-
+    final Object job = super.createJobInstance(bundle);
+    beanFactory.autowireBean(job);
+    return job;
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/schedule/EventJob.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/schedule/EventJob.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.schedule;
 
+import java.util.Date;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
@@ -11,38 +13,36 @@ import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEventPublisher;
 import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
-import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
-
-import java.util.Date;
-import java.util.UUID;
 
 @Component
 @Slf4j
 public class EventJob implements Job {
-    @Autowired
-    private CollectionExerciseEventPublisher eventPublisher;
+  @Autowired private CollectionExerciseEventPublisher eventPublisher;
 
-    @Override
-    public void execute(JobExecutionContext jec) throws JobExecutionException {
-        JobDetail jobDetail = jec.getJobDetail();
-        JobDataMap dataMap = jobDetail.getJobDataMap();
-        String tag = dataMap.getString(SchedulerConfiguration.DataKey.tag.name());
-        UUID collexId = UUID.fromString(dataMap.getString(SchedulerConfiguration.DataKey.collectionExercise.name()));
-        UUID eventId = UUID.fromString(dataMap.getString(SchedulerConfiguration.DataKey.id.name()));
-        Date date = new Date(dataMap.getLong(SchedulerConfiguration.DataKey.timestamp.name()));
-        log.info("Executing event: {} - {} - {}", tag, collexId, date);
+  @Override
+  public void execute(JobExecutionContext jec) throws JobExecutionException {
+    JobDetail jobDetail = jec.getJobDetail();
+    JobDataMap dataMap = jobDetail.getJobDataMap();
+    String tag = dataMap.getString(SchedulerConfiguration.DataKey.tag.name());
+    UUID collexId =
+        UUID.fromString(
+            dataMap.getString(SchedulerConfiguration.DataKey.collectionExercise.name()));
+    UUID eventId = UUID.fromString(dataMap.getString(SchedulerConfiguration.DataKey.id.name()));
+    Date date = new Date(dataMap.getLong(SchedulerConfiguration.DataKey.timestamp.name()));
+    log.info("Executing event: {} - {} - {}", tag, collexId, date);
 
-        try {
-            EventDTO event = new EventDTO();
-            event.setId(eventId);
-            event.setCollectionExerciseId(collexId);
-            event.setTag(tag);
-            event.setTimestamp(date);
+    try {
+      EventDTO event = new EventDTO();
+      event.setId(eventId);
+      event.setCollectionExerciseId(collexId);
+      event.setTag(tag);
+      event.setTimestamp(date);
 
-            this.eventPublisher.publishCollectionExerciseEvent(CollectionExerciseEventPublisher.MessageType.EventElapsed, event);
-        } catch (CTPException e) {
-            String message = String.format("Error publishing collection exercise event %s", eventId);
-            throw new JobExecutionException(message, e);
-        }
+      this.eventPublisher.publishCollectionExerciseEvent(
+          CollectionExerciseEventPublisher.MessageType.EventElapsed, event);
+    } catch (CTPException e) {
+      String message = String.format("Error publishing collection exercise event %s", eventId);
+      throw new JobExecutionException(message, e);
     }
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/schedule/SchedulerConfiguration.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/schedule/SchedulerConfiguration.java
@@ -1,5 +1,15 @@
 package uk.gov.ons.ctp.response.collection.exercise.schedule;
 
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.TriggerBuilder.newTrigger;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobDataMap;
@@ -22,245 +32,246 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
-import javax.annotation.PostConstruct;
-import java.io.IOException;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static org.quartz.JobBuilder.newJob;
-import static org.quartz.TriggerBuilder.newTrigger;
-
 @Configuration
 @Slf4j
 public class SchedulerConfiguration {
 
-    @Autowired
-    private EventService eventService;
+  @Autowired private EventService eventService;
 
-    @Autowired
-    private ApplicationContext applicationContext;
+  @Autowired private ApplicationContext applicationContext;
 
-    /**
-     * Method to schedule a collection exercise event
-     *
-     * @param scheduler a Quartz scheduler (can be autowired)
-     * @param event     the collection exercise event to schedule
-     * @return the date and time the event is scheduled for
-     * @throws SchedulerException thrown if an error occurred scheduling event
-     */
-    public static Date scheduleEvent(final Scheduler scheduler, final Event event) throws SchedulerException {
-        EventJobTriggerDetail detail = new EventJobTriggerDetail(event);
-        JobKey jobKey = detail.getJobDetail().getKey();
+  /**
+   * Method to schedule a collection exercise event
+   *
+   * @param scheduler a Quartz scheduler (can be autowired)
+   * @param event the collection exercise event to schedule
+   * @return the date and time the event is scheduled for
+   * @throws SchedulerException thrown if an error occurred scheduling event
+   */
+  public static Date scheduleEvent(final Scheduler scheduler, final Event event)
+      throws SchedulerException {
+    EventJobTriggerDetail detail = new EventJobTriggerDetail(event);
+    JobKey jobKey = detail.getJobDetail().getKey();
 
-        if (scheduler.checkExists(jobKey)) {
-            scheduler.deleteJob(jobKey);
-        }
-
-        return scheduler.scheduleJob(detail.getJobDetail(), detail.getTrigger());
+    if (scheduler.checkExists(jobKey)) {
+      scheduler.deleteJob(jobKey);
     }
 
-    /**
-     * Method to unschedule a collection exercise event
-     *
-     * @param scheduler a Quartz scheduler (can be autowired)
-     * @param event     the collection exercise event to unschedule
-     * @return true if the event was unscheduled, false otherwise
-     * @throws SchedulerException thrown if an error occurred unscheduling event
-     */
-    public static boolean unscheduleEvent(final Scheduler scheduler, final Event event) throws SchedulerException {
-        EventJobTriggerDetail detail = new EventJobTriggerDetail(event);
-        JobKey jobKey = detail.getJobDetail().getKey();
+    return scheduler.scheduleJob(detail.getJobDetail(), detail.getTrigger());
+  }
 
-        return scheduler.deleteJob(jobKey);
+  /**
+   * Method to unschedule a collection exercise event
+   *
+   * @param scheduler a Quartz scheduler (can be autowired)
+   * @param event the collection exercise event to unschedule
+   * @return true if the event was unscheduled, false otherwise
+   * @throws SchedulerException thrown if an error occurred unscheduling event
+   */
+  public static boolean unscheduleEvent(final Scheduler scheduler, final Event event)
+      throws SchedulerException {
+    EventJobTriggerDetail detail = new EventJobTriggerDetail(event);
+    JobKey jobKey = detail.getJobDetail().getKey();
+
+    return scheduler.deleteJob(jobKey);
+  }
+
+  /**
+   * Utility method to generate a JobKey from a collection exercise id and an event
+   *
+   * @param collexId a collection exercise id
+   * @param event an event
+   * @return a String that can be used as a JobKey
+   */
+  public static String getJobKey(final UUID collexId, final Event event) {
+    return getJobKey(collexId, event.getTag());
+  }
+
+  /**
+   * Utility method to generate a JobKey from a collection exercise id and an event tag
+   *
+   * @param collexId a collection exercise id
+   * @param eventTag an event tag
+   * @return a String that can be used as a JobKey
+   */
+  public static String getJobKey(final UUID collexId, final String eventTag) {
+    String jobKey = eventTag + ":" + collexId.toString();
+
+    return jobKey;
+  }
+
+  /**
+   * Creates a new event DTO from a quartz job
+   *
+   * @param scheduler the scheduler containing the job
+   * @param jobKey the key for the quartz job
+   * @return a new EventDTO
+   */
+  private static EventDTO getEventDTOFromJobKey(final Scheduler scheduler, final JobKey jobKey) {
+    try {
+      EventDTO result = new EventDTO();
+      JobDetail detail = scheduler.getJobDetail(jobKey);
+      JobDataMap jobDataMap = detail.getJobDataMap();
+
+      String tagStr = jobDataMap.getString(DataKey.tag.name());
+      result.setTag(tagStr);
+
+      String collexIdStr = jobDataMap.getString(DataKey.collectionExercise.name());
+      UUID collexId = UUID.fromString(collexIdStr);
+      result.setCollectionExerciseId(collexId);
+
+      String eventIdStr = jobDataMap.getString(DataKey.id.name());
+      result.setId(UUID.fromString(eventIdStr));
+
+      Trigger trigger = scheduler.getTrigger(TriggerKey.triggerKey(getJobKey(collexId, tagStr)));
+      result.setTimestamp(trigger.getStartTime());
+
+      return result;
+    } catch (SchedulerException e) {
+      log.error("Failed to get event information for job with key {} - {}", jobKey, e.getMessage());
+
+      return null;
     }
+  }
 
-    /**
-     * Utility method to generate a JobKey from a collection exercise id and an event
-     *
-     * @param collexId a collection exercise id
-     * @param event    an event
-     * @return a String that can be used as a JobKey
-     */
-    public static String getJobKey(final UUID collexId, final Event event) {
-        return getJobKey(collexId, event.getTag());
+  /**
+   * Gets EventDTOs for all the quartz jobs associated with a group name
+   *
+   * @param scheduler the scheduler containing the group
+   * @param groupName the name of the group in question
+   * @return a list of EventDTOs representing the jobs in the group
+   */
+  private static List<EventDTO> getEventDTOsFromJobGroupName(
+      final Scheduler scheduler, final String groupName) {
+    try {
+      return scheduler
+          .getJobKeys(GroupMatcher.jobGroupEquals(groupName))
+          .stream()
+          .map(jobKey -> getEventDTOFromJobKey(scheduler, jobKey))
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
+    } catch (SchedulerException e) {
+      log.error("Failed to get job keys for group {} - {}", groupName, e.getMessage());
+
+      return null;
     }
+  }
 
-    /**
-     * Utility method to generate a JobKey from a collection exercise id and an event tag
-     *
-     * @param collexId a collection exercise id
-     * @param eventTag an event tag
-     * @return a String that can be used as a JobKey
-     */
-    public static String getJobKey(final UUID collexId, final String eventTag) {
-        String jobKey = eventTag + ":" + collexId.toString();
+  /**
+   * Returns all the events scheduled in the supplied quartz scheduler
+   *
+   * @param scheduler the scheduler to get the events for
+   * @return a list of EventDTO
+   */
+  public static List<EventDTO> getAllScheduledEvents(final Scheduler scheduler)
+      throws SchedulerException {
+    return scheduler
+        .getJobGroupNames()
+        .stream()
+        .map(name -> getEventDTOsFromJobGroupName(scheduler, name))
+        .filter(Objects::nonNull)
+        .flatMap(List::stream)
+        .collect(Collectors.toList());
+  }
 
-        return jobKey;
-    }
+  @PostConstruct
+  public void init() {
+    log.info("Hello world from Quartz...");
+  }
 
-    /**
-     * Creates a new event DTO from a quartz job
-     *
-     * @param scheduler the scheduler containing the job
-     * @param jobKey    the key for the quartz job
-     * @return a new EventDTO
-     */
-    private static EventDTO getEventDTOFromJobKey(final Scheduler scheduler, final JobKey jobKey) {
-        try {
-            EventDTO result = new EventDTO();
-            JobDetail detail = scheduler.getJobDetail(jobKey);
-            JobDataMap jobDataMap = detail.getJobDataMap();
+  @Bean
+  public SpringBeanJobFactory springBeanJobFactory() {
+    AutoWiringSpringBeanJobFactory jobFactory = new AutoWiringSpringBeanJobFactory();
+    log.debug("Configuring Job factory");
 
-            String tagStr = jobDataMap.getString(DataKey.tag.name());
-            result.setTag(tagStr);
+    jobFactory.setApplicationContext(applicationContext);
+    return jobFactory;
+  }
 
-            String collexIdStr = jobDataMap.getString(DataKey.collectionExercise.name());
-            UUID collexId = UUID.fromString(collexIdStr);
-            result.setCollectionExerciseId(collexId);
+  /**
+   * Schedules within quartz all the collection exercise events for which a message has not already
+   * been sent
+   *
+   * @param scheduler the scheduler to use to schedule the events
+   */
+  protected void scheduleOutstandingEvents(final Scheduler scheduler) {
+    List<Event> outstandingEvents = this.eventService.getOutstandingEvents();
 
-            String eventIdStr = jobDataMap.getString(DataKey.id.name());
-            result.setId(UUID.fromString(eventIdStr));
-
-            Trigger trigger = scheduler.getTrigger(TriggerKey.triggerKey(getJobKey(collexId, tagStr)));
-            result.setTimestamp(trigger.getStartTime());
-
-            return result;
-        } catch (SchedulerException e) {
-            log.error("Failed to get event information for job with key {} - {}", jobKey, e.getMessage());
-
-            return null;
-        }
-    }
-
-    /**
-     * Gets EventDTOs for all the quartz jobs associated with a group name
-     * @param scheduler the scheduler containing the group
-     * @param groupName the name of the group in question
-     * @return a list of EventDTOs representing the jobs in the group
-     */
-    private static List<EventDTO> getEventDTOsFromJobGroupName(final Scheduler scheduler, final String groupName) {
-        try {
-            return scheduler
-                    .getJobKeys(GroupMatcher.jobGroupEquals(groupName))
-                    .stream()
-                    .map(jobKey -> getEventDTOFromJobKey(scheduler, jobKey))
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
-        } catch (SchedulerException e) {
-            log.error("Failed to get job keys for group {} - {}", groupName, e.getMessage());
-
-            return null;
-        }
-    }
-
-    /**
-     * Returns all the events scheduled in the supplied quartz scheduler
-     *
-     * @param scheduler the scheduler to get the events for
-     * @return a list of EventDTO
-     */
-    public static List<EventDTO> getAllScheduledEvents(final Scheduler scheduler) throws SchedulerException {
-        return scheduler.getJobGroupNames()
-                .stream()
-                .map(name -> getEventDTOsFromJobGroupName(scheduler, name))
-                .filter(Objects::nonNull)
-                .flatMap(List::stream)
-                .collect(Collectors.toList());
-    }
-
-    @PostConstruct
-    public void init() {
-        log.info("Hello world from Quartz...");
-    }
-
-    @Bean
-    public SpringBeanJobFactory springBeanJobFactory() {
-        AutoWiringSpringBeanJobFactory jobFactory = new AutoWiringSpringBeanJobFactory();
-        log.debug("Configuring Job factory");
-
-        jobFactory.setApplicationContext(applicationContext);
-        return jobFactory;
-    }
-
-    /**
-     * Schedules within quartz all the collection exercise events for which a message has not already been sent
-     *
-     * @param scheduler the scheduler to use to schedule the events
-     */
-    protected void scheduleOutstandingEvents(final Scheduler scheduler) {
-        List<Event> outstandingEvents = this.eventService.getOutstandingEvents();
-
-        outstandingEvents.stream().forEach(e -> {
-            try {
+    outstandingEvents
+        .stream()
+        .forEach(
+            e -> {
+              try {
                 scheduleEvent(scheduler, e);
-            } catch (SchedulerException e1) {
+              } catch (SchedulerException e1) {
                 throw new RuntimeException(e1);
-            }
-        });
+              }
+            });
+  }
+
+  @Bean
+  public Scheduler scheduler() throws SchedulerException, IOException {
+    // Force creation of the fanout exchange before any jobs are scheduled
+    fanout();
+
+    StdSchedulerFactory factory = new StdSchedulerFactory();
+    factory.initialize(new ClassPathResource("quartz.properties").getInputStream());
+
+    log.debug("Getting a handle to the Scheduler");
+    Scheduler scheduler = factory.getScheduler();
+    scheduler.setJobFactory(springBeanJobFactory());
+
+    scheduleOutstandingEvents(scheduler);
+
+    log.debug("Starting Scheduler threads");
+    scheduler.start();
+    return scheduler;
+  }
+
+  @Bean
+  public FanoutExchange fanout() {
+    return new FanoutExchange("collex-event-message-outbound-exchange");
+  }
+
+  public enum DataKey {
+    tag,
+    collectionExercise,
+    id,
+    eventPk,
+    timestamp
+  }
+
+  @Data
+  private static class EventJobTriggerDetail {
+    private Trigger trigger;
+    private JobDetail jobDetail;
+
+    public EventJobTriggerDetail(final Event event) {
+      UUID collexId = event.getCollectionExercise().getId();
+      String jobKey = getJobKey(collexId, event);
+      JobDetail job =
+          newJob()
+              .ofType(EventJob.class)
+              .withIdentity(JobKey.jobKey(jobKey))
+              .withDescription("Executing event " + jobKey + " at " + event.getTimestamp())
+              .usingJobData(DataKey.tag.name(), event.getTag())
+              .usingJobData(
+                  DataKey.collectionExercise.name(),
+                  event.getCollectionExercise().getId().toString())
+              .usingJobData(DataKey.id.name(), event.getId().toString())
+              .usingJobData(DataKey.eventPk.name(), event.getEventPK())
+              .usingJobData(DataKey.timestamp.name(), event.getTimestamp().getTime())
+              .build();
+      Trigger trigger =
+          newTrigger()
+              .forJob(job)
+              .withIdentity(TriggerKey.triggerKey(jobKey))
+              .withDescription("Triggering event " + jobKey + " at " + event.getTimestamp())
+              .startAt(new Date(event.getTimestamp().getTime()))
+              .build();
+
+      this.trigger = trigger;
+      this.jobDetail = job;
     }
-
-    @Bean
-    public Scheduler scheduler() throws SchedulerException, IOException {
-        // Force creation of the fanout exchange before any jobs are scheduled
-        fanout();
-
-        StdSchedulerFactory factory = new StdSchedulerFactory();
-        factory.initialize(new ClassPathResource("quartz.properties").getInputStream());
-
-        log.debug("Getting a handle to the Scheduler");
-        Scheduler scheduler = factory.getScheduler();
-        scheduler.setJobFactory(springBeanJobFactory());
-
-        scheduleOutstandingEvents(scheduler);
-
-        log.debug("Starting Scheduler threads");
-        scheduler.start();
-        return scheduler;
-    }
-
-    @Bean
-    public FanoutExchange fanout() {
-        return new FanoutExchange("collex-event-message-outbound-exchange");
-    }
-
-    public enum DataKey {
-        tag,
-        collectionExercise,
-        id,
-        eventPk,
-        timestamp
-    }
-
-    @Data
-    private static class EventJobTriggerDetail {
-        private Trigger trigger;
-        private JobDetail jobDetail;
-
-        public EventJobTriggerDetail(final Event event) {
-            UUID collexId = event.getCollectionExercise().getId();
-            String jobKey = getJobKey(collexId, event);
-            JobDetail job = newJob()
-                    .ofType(EventJob.class)
-                    .withIdentity(JobKey.jobKey(jobKey))
-                    .withDescription("Executing event " + jobKey + " at " + event.getTimestamp())
-                    .usingJobData(DataKey.tag.name(), event.getTag())
-                    .usingJobData(DataKey.collectionExercise.name(), event.getCollectionExercise().getId().toString())
-                    .usingJobData(DataKey.id.name(), event.getId().toString())
-                    .usingJobData(DataKey.eventPk.name(), event.getEventPK())
-                    .usingJobData(DataKey.timestamp.name(), event.getTimestamp().getTime())
-                    .build();
-            Trigger trigger = newTrigger()
-                    .forJob(job)
-                    .withIdentity(TriggerKey.triggerKey(jobKey))
-                    .withDescription("Triggering event " + jobKey + " at " + event.getTimestamp())
-                    .startAt(new Date(event.getTimestamp().getTime()))
-                    .build();
-
-            this.trigger = trigger;
-            this.jobDetail = job;
-        }
-    }
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
@@ -3,7 +3,6 @@ package uk.gov.ons.ctp.response.collection.exercise.service;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
-
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseType;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
@@ -11,15 +10,11 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
-/**
- * Service responsible for dealing with collection exercises
- *
- */
+/** Service responsible for dealing with collection exercises */
 public interface CollectionExerciseService {
 
   /**
-   * Find a list of collection exercises associated to a survey from the
-   * Collection Exercise Service
+   * Find a list of collection exercises associated to a survey from the Collection Exercise Service
    *
    * @param survey the survey for which to find collection exercises
    * @return the associated collection exercises.
@@ -27,8 +22,7 @@ public interface CollectionExerciseService {
   List<CollectionExercise> findCollectionExercisesForSurvey(SurveyDTO survey);
 
   /**
-   * Find a list of collection exercises associated to a party from the
-   * Collection Exercise Service
+   * Find a list of collection exercises associated to a party from the Collection Exercise Service
    *
    * @param id the party id for which to find collection exercises
    * @return the associated collection exercises.
@@ -36,13 +30,41 @@ public interface CollectionExerciseService {
   List<CollectionExercise> findCollectionExercisesForParty(UUID id);
 
   /**
-   * Find a collection exercise associated to a collection exercise Id from the
-   * Collection Exercise Service
+   * Find a collection exercise associated to a collection exercise Id from the Collection Exercise
+   * Service
    *
    * @param id the collection exercise Id for which to find collection exercise
    * @return the associated collection exercise.
    */
   CollectionExercise findCollectionExercise(UUID id);
+
+  /**
+   * Find a collection exercise from a survey ref (e.g. 221) and a collection exercise ref (e.g.
+   * 201808)
+   *
+   * @param surveyRef the survey ref
+   * @param exerciseRef the collection exercise ref
+   * @return the specified collection exercise or null if not found
+   */
+  CollectionExercise findCollectionExercise(String surveyRef, String exerciseRef);
+
+  /**
+   * Gets collection exercise with given exerciseRef and survey (should be no more than 1)
+   *
+   * @param exerciseRef the exerciseRef (period) of the collection exercise
+   * @param survey the survey the collection exercise is associated with
+   * @return the collection exercise if it exists, null otherwise
+   */
+  CollectionExercise findCollectionExercise(String exerciseRef, SurveyDTO survey);
+
+  /**
+   * Gets collection exercise with given exerciseRef and survey uuid (should be no more than 1)
+   *
+   * @param exerciseRef the exerciseRef (period) of the collection exercise
+   * @param surveyId the uuid of the survey the collection exercise is associated with
+   * @return the collection exercise if it exists, null otherwise
+   */
+  CollectionExercise findCollectionExercise(String exerciseRef, UUID surveyId);
 
   /**
    * Find all Collection Exercises
@@ -52,46 +74,35 @@ public interface CollectionExerciseService {
   List<CollectionExercise> findAllCollectionExercise();
 
   /**
-   * Find a collection exercise from a survey ref (e.g. 221) and a collection exercise ref (e.g. 201808)
-   * @param surveyRef the survey ref
-   * @param exerciseRef the collection exercise ref
-   * @return the specified collection exercise or null if not found
-   */
-  CollectionExercise findCollectionExercise(String surveyRef, String exerciseRef);
-
-  /**
    * find a list of all sample summary linked to a collection exercise
    *
-   * @param id the collection exercise Id to find the linked sample summaries
-   *          for
+   * @param id the collection exercise Id to find the linked sample summaries for
    * @return list of linked sample summary
    */
   List<SampleLink> findLinkedSampleSummaries(UUID id);
 
   /**
-   * Find case types associated to a collection exercise from the Collection
-   * Exercise Service
+   * Find case types associated to a collection exercise from the Collection Exercise Service
    *
-   * @param collectionExercise the collection exercise for which to find case
-   *          types
+   * @param collectionExercise the collection exercise for which to find case types
    * @return the associated case type DTOs.
    */
   Collection<CaseType> getCaseTypesList(CollectionExercise collectionExercise);
 
   /**
-   * Delete existing SampleSummary links for input CollectionExercise then link
-   * all SampleSummaries in list to CollectionExercise
+   * Delete existing SampleSummary links for input CollectionExercise then link all SampleSummaries
+   * in list to CollectionExercise
    *
    * @param collectionExerciseId the Id of the CollectionExercise to link to
    * @param sampleSummaryIds the list of Ids of the SampleSummaries to be linked
-   * @return linkedSummaries the list of CollectionExercises and the linked
-   *         SampleSummaries
+   * @return linkedSummaries the list of CollectionExercises and the linked SampleSummaries
    */
-  List<SampleLink> linkSampleSummaryToCollectionExercise(UUID collectionExerciseId,
-      List<UUID> sampleSummaryIds);
+  List<SampleLink> linkSampleSummaryToCollectionExercise(
+      UUID collectionExerciseId, List<UUID> sampleSummaryIds);
 
   /**
    * Create a collection exercise
+   *
    * @param collex the data to create the collection exercise from
    * @param survey representation of survey for collection exercise
    * @return a new CollectionExercise object
@@ -99,31 +110,18 @@ public interface CollectionExerciseService {
   CollectionExercise createCollectionExercise(CollectionExerciseDTO collex, SurveyDTO survey);
 
   /**
-   * Gets collection exercise with given exerciseRef and survey (should be no more than 1)
-   * @param exerciseRef the exerciseRef (period) of the collection exercise
-   * @param survey the survey the collection exercise is associated with
-   * @return the collection exercise if it exists, null otherwise
-   */
-  CollectionExercise  findCollectionExercise(String exerciseRef, SurveyDTO survey);
-
-  /**
-   * Gets collection exercise with given exerciseRef and survey uuid (should be no more than 1)
-   * @param exerciseRef the exerciseRef (period) of the collection exercise
-   * @param surveyId the uuid of the survey the collection exercise is associated with
-   * @return the collection exercise if it exists, null otherwise
-   */
-  CollectionExercise  findCollectionExercise(String exerciseRef, UUID surveyId);
-
-  /**
    * Update a collection exercise
+   *
    * @param collex the updated collection exercise
    * @param id the id of the collection exercise to update
    * @return the updated CollectionExercise object
    */
-  CollectionExercise updateCollectionExercise(UUID id, CollectionExerciseDTO collex) throws CTPException;
+  CollectionExercise updateCollectionExercise(UUID id, CollectionExerciseDTO collex)
+      throws CTPException;
 
   /**
    * Update a collection exercise
+   *
    * @param collex the updated collection exercise
    * @return the updated CollectionExercise object
    */
@@ -131,15 +129,18 @@ public interface CollectionExerciseService {
 
   /**
    * Patch a collection exercise
+   *
    * @param id the id of the collection exercise to patch
    * @param collex the patch data
    * @return the patched CollectionExercise object
    * @throws CTPException thrown if error occurs
    */
-  CollectionExercise patchCollectionExercise(UUID id, CollectionExerciseDTO collex) throws CTPException;
+  CollectionExercise patchCollectionExercise(UUID id, CollectionExerciseDTO collex)
+      throws CTPException;
 
   /**
    * Delete a collection exercise
+   *
    * @param id the id of the collection exercise to delete
    * @return the updated CollectionExercise object
    * @throws CTPException thrown if error occurs
@@ -148,6 +149,7 @@ public interface CollectionExerciseService {
 
   /**
    * Undelete a collection exercise
+   *
    * @param id the id of the collection exercise to delete
    * @return the updated CollectionExercise object
    * @throws CTPException thrown if error occurs
@@ -156,6 +158,7 @@ public interface CollectionExerciseService {
 
   /**
    * Find all collection exercises with a given state
+   *
    * @param state the state to find
    * @return a list of collection exercises with the given state
    */
@@ -163,37 +166,44 @@ public interface CollectionExerciseService {
 
   /**
    * Utility method to transition a collection exercise to a new state
+   *
    * @param collex a collection exercise
    * @param event a collection exercise event
    * @throws CTPException thrown if the specified event is not valid for the current state
    */
-  void transitionCollectionExercise(CollectionExercise collex, CollectionExerciseDTO.CollectionExerciseEvent event)
-          throws CTPException;
+  void transitionCollectionExercise(
+      CollectionExercise collex, CollectionExerciseDTO.CollectionExerciseEvent event)
+      throws CTPException;
 
   /**
    * Utility method to transition a collection exercise to a new state
+   *
    * @param collectionExerciseId a collection exercise UUID
    * @param event a collection exercise event
-   * @throws CTPException thrown if the specified event is not valid for the current state or a collection exercise
-   *                      with the given id cannot be found
+   * @throws CTPException thrown if the specified event is not valid for the current state or a
+   *     collection exercise with the given id cannot be found
    */
-  void transitionCollectionExercise(UUID collectionExerciseId, CollectionExerciseDTO.CollectionExerciseEvent event)
-          throws CTPException;
+  void transitionCollectionExercise(
+      UUID collectionExerciseId, CollectionExerciseDTO.CollectionExerciseEvent event)
+      throws CTPException;
 
   /**
-   * Transition scheduled collection exercises with collection instruments and samples to
-   * {@link CollectionExerciseDTO.CollectionExerciseState#READY_FOR_REVIEW}
+   * Transition scheduled collection exercises with collection instruments and samples to {@link
+   * CollectionExerciseDTO.CollectionExerciseState#READY_FOR_REVIEW}
    */
-  void transitionScheduleCollectionExerciseToReadyToReview(UUID collectionExerciseId) throws CTPException;
+  void transitionScheduleCollectionExerciseToReadyToReview(UUID collectionExerciseId)
+      throws CTPException;
 
   /**
-   * Transition scheduled collection exercises with collection instruments and samples to
-   * {@link CollectionExerciseDTO.CollectionExerciseState#READY_FOR_REVIEW}
+   * Transition scheduled collection exercises with collection instruments and samples to {@link
+   * CollectionExerciseDTO.CollectionExerciseState#READY_FOR_REVIEW}
    */
-  void transitionScheduleCollectionExerciseToReadyToReview(CollectionExercise collectionExercise) throws CTPException;
+  void transitionScheduleCollectionExerciseToReadyToReview(CollectionExercise collectionExercise)
+      throws CTPException;
 
   /**
    * Delete SampleSummary link
+   *
    * @param sampleSummaryId a sample summary uuid
    * @param collectionExerciseId a collection exercise uuid
    * @throws CTPException thrown if transition fails

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventChangeHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventChangeHandler.java
@@ -5,17 +5,19 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEventPublisher;
 
 /**
- * An interface to implement if you want to perform some action when a collection exercise event is updated,
- * created or deleted.
- * WARNING: All implementation of this interface are autowired into the EventServiceImpl and get used for real
+ * An interface to implement if you want to perform some action when a collection exercise event is
+ * updated, created or deleted. WARNING: All implementation of this interface are autowired into the
+ * EventServiceImpl and get used for real
  */
 @FunctionalInterface
 public interface EventChangeHandler {
-    /**
-     * The method that is called when a collection exercise event is created, updated or deleted
-     * @param change the type of change that occurred
-     * @param event the event to which the change occurred
-     * @throws CTPException thrown if an error occurs
-     */
-    void handleEventLifecycle(CollectionExerciseEventPublisher.MessageType change, Event event) throws CTPException;
+  /**
+   * The method that is called when a collection exercise event is created, updated or deleted
+   *
+   * @param change the type of change that occurred
+   * @param event the event to which the change occurred
+   * @throws CTPException thrown if an error occurs
+   */
+  void handleEventLifecycle(CollectionExerciseEventPublisher.MessageType change, Event event)
+      throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
@@ -1,69 +1,82 @@
 package uk.gov.ons.ctp.response.collection.exercise.service;
 
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 
-import java.util.List;
-import java.util.UUID;
-import java.util.Date;
-
 public interface EventService {
 
-    /**
-     * An enum to represent the collection exercise events that are mandatory for all surveys
-     */
-    enum Tag {
-        mps(true), go_live(true), return_by(true), exercise_end(true), reminder(false), reminder2(false),
-        reminder3(false), ref_period_start(false), ref_period_end(false), employment_date(false) ;
+  /** An enum to represent the collection exercise events that are mandatory for all surveys */
+  enum Tag {
+    mps(true),
+    go_live(true),
+    return_by(true),
+    exercise_end(true),
+    reminder(false),
+    reminder2(false),
+    reminder3(false),
+    ref_period_start(false),
+    ref_period_end(false),
+    employment_date(false);
 
-        Tag(final boolean mandatory){
-            this.mandatory = mandatory;
-        }
-
-        public boolean isMandatory(){
-            return mandatory;
-        }
-
-        private boolean mandatory;
+    Tag(final boolean mandatory) {
+      this.mandatory = mandatory;
     }
 
-    Event createEvent(EventDTO eventDto) throws CTPException;
-
-    List<Event> getEvents(UUID collexId) throws CTPException;
-
-    static EventDTO createEventDTOFromEvent(Event event){
-        EventDTO dto = new EventDTO();
-
-        dto.setCollectionExerciseId(event.getCollectionExercise().getId());
-        dto.setId(event.getId());
-        dto.setTag(event.getTag());
-        dto.setTimestamp(event.getTimestamp());
-
-        return dto;
+    public boolean isMandatory() {
+      return mandatory;
     }
 
-    Event updateEvent(UUID collexUuid, String tag, Date date) throws CTPException;
-    Event getEvent(UUID collexUuid, String tag) throws CTPException;
-    Event getEvent(UUID eventId) throws CTPException;
-    Event deleteEvent(UUID collexUuid, String tag) throws CTPException;
-    List<Event> getOutstandingEvents();
-    void setEventMessageSent(UUID eventId) throws CTPException;
-    void clearEventMessageSent(UUID eventId) throws CTPException;
-    boolean isScheduled(UUID collexUuid) throws CTPException;
+    private boolean mandatory;
+  }
 
-    /**
-     * Unschedule a collection exercise event
-     * @param event the event to unshchedule
-     * @throws CTPException thrown if error occurred unscheduling event
-     */
-    void unscheduleEvent(Event event) throws CTPException;
+  Event createEvent(EventDTO eventDto) throws CTPException;
 
-    /**
-     * Schedule a collection exercise event
-     * @param event the event to shchedule
-     * @throws CTPException thrown if error occurred scheduling event
-     */
-    void scheduleEvent(Event event) throws CTPException;
+  List<Event> getEvents(UUID collexId) throws CTPException;
 
+  static EventDTO createEventDTOFromEvent(Event event) {
+    EventDTO dto = new EventDTO();
+
+    dto.setCollectionExerciseId(event.getCollectionExercise().getId());
+    dto.setId(event.getId());
+    dto.setTag(event.getTag());
+    dto.setTimestamp(event.getTimestamp());
+
+    return dto;
+  }
+
+  Event updateEvent(UUID collexUuid, String tag, Date date) throws CTPException;
+
+  Event getEvent(UUID collexUuid, String tag) throws CTPException;
+
+  Event getEvent(UUID eventId) throws CTPException;
+
+  Event deleteEvent(UUID collexUuid, String tag) throws CTPException;
+
+  List<Event> getOutstandingEvents();
+
+  void setEventMessageSent(UUID eventId) throws CTPException;
+
+  void clearEventMessageSent(UUID eventId) throws CTPException;
+
+  boolean isScheduled(UUID collexUuid) throws CTPException;
+
+  /**
+   * Unschedule a collection exercise event
+   *
+   * @param event the event to unshchedule
+   * @throws CTPException thrown if error occurred unscheduling event
+   */
+  void unscheduleEvent(Event event) throws CTPException;
+
+  /**
+   * Schedule a collection exercise event
+   *
+   * @param event the event to shchedule
+   * @throws CTPException thrown if error occurred scheduling event
+   */
+  void scheduleEvent(Event event) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/ExerciseSampleUnitGroupService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/ExerciseSampleUnitGroupService.java
@@ -1,18 +1,13 @@
 package uk.gov.ons.ctp.response.collection.exercise.service;
 
 import java.util.List;
-
 import org.springframework.data.domain.Pageable;
-
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO;
 
-/**
- * Service responsible for dealing with stored ExerciseSampleUnitGroups.
- *
- */
+/** Service responsible for dealing with stored ExerciseSampleUnitGroups. */
 public interface ExerciseSampleUnitGroupService {
 
   /**
@@ -22,25 +17,25 @@ public interface ExerciseSampleUnitGroupService {
    * @param exercise CollectionExercise for which to provide count.
    * @return count of SampleUnitGroups in provided state.
    */
-  Long countByStateFKAndCollectionExercise(SampleUnitGroupDTO.SampleUnitGroupState state, CollectionExercise exercise);
+  Long countByStateFKAndCollectionExercise(
+      SampleUnitGroupDTO.SampleUnitGroupState state, CollectionExercise exercise);
 
   /**
-   * Query repository for SampleUnitGroups by state and belonging to a list of
-   * collection exercises. Order by CreatedDateTime ascending.
+   * Query repository for SampleUnitGroups by state and belonging to a list of collection exercises.
+   * Order by CreatedDateTime ascending.
    *
    * @param state filter criteria.
    * @param exercises for which to return SampleUnitGroups.
    * @param excludedGroups SampleUnitGroupPKs to exclude from results.
-   * @param pageable Spring JPA pageable object used to return required number
-   *          of results.
-   * @return returns requested number of SampleUnitGroups for state within
-   *         requested exercises.
+   * @param pageable Spring JPA pageable object used to return required number of results.
+   * @return returns requested number of SampleUnitGroups for state within requested exercises.
    */
-  List<ExerciseSampleUnitGroup> findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
-      SampleUnitGroupDTO.SampleUnitGroupState state,
-      List<CollectionExercise> exercises,
-      List<Integer> excludedGroups,
-      Pageable pageable);
+  List<ExerciseSampleUnitGroup>
+      findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
+          SampleUnitGroupDTO.SampleUnitGroupState state,
+          List<CollectionExercise> exercises,
+          List<Integer> excludedGroups,
+          Pageable pageable);
 
   /**
    * To store ExerciseSampleUnitGroup and associated ExerciseSampleUnits
@@ -49,6 +44,6 @@ public interface ExerciseSampleUnitGroupService {
    * @param sampleUnits associated sampleUnitGroup to be stored.
    * @return the stored ExerciseSampleUnitGroup
    */
-  ExerciseSampleUnitGroup storeExerciseSampleUnitGroup(ExerciseSampleUnitGroup sampleUnitGroup,
-      List<ExerciseSampleUnit> sampleUnits);
+  ExerciseSampleUnitGroup storeExerciseSampleUnitGroup(
+      ExerciseSampleUnitGroup sampleUnitGroup, List<ExerciseSampleUnit> sampleUnits);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/ExerciseSampleUnitService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/ExerciseSampleUnitService.java
@@ -1,14 +1,10 @@
 package uk.gov.ons.ctp.response.collection.exercise.service;
 
 import java.util.List;
-
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
 
-/**
- * Service responsible for dealing with stored ExerciseSampleUnits.
- *
- */
+/** Service responsible for dealing with stored ExerciseSampleUnits. */
 public interface ExerciseSampleUnitService {
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
@@ -2,7 +2,6 @@ package uk.gov.ons.ctp.response.collection.exercise.service;
 
 import java.util.List;
 import java.util.UUID;
-
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
@@ -11,15 +10,11 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitVali
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
-/**
- * Service responsible for dealing with samples
- *
- */
+/** Service responsible for dealing with samples */
 public interface SampleService {
 
   /**
-   * Request the delivery of sample units from the Sample Service via a message
-   * queue.
+   * Request the delivery of sample units from the Sample Service via a message queue.
    *
    * @param id the Collection Exercise Id for which to request sample units.
    * @return the total number of sample units in the collection exercise.
@@ -36,10 +31,7 @@ public interface SampleService {
    */
   ExerciseSampleUnit acceptSampleUnit(SampleUnit sampleUnit) throws CTPException;
 
-  /**
-   * Validate SampleUnits
-   *
-   */
+  /** Validate SampleUnits */
   void validateSampleUnits();
 
   /**
@@ -49,9 +41,9 @@ public interface SampleService {
    */
   void distributeSampleUnits(CollectionExercise exercise);
 
-
   /**
    * Get the sample unit validation errors for a given collection exercise
+   *
    * @param collectionExerciseId a collection exercise
    * @return an array of validation errors
    */
@@ -59,6 +51,7 @@ public interface SampleService {
 
   /**
    * Gets a list of sample links for a given sample summary
+   *
    * @param sampleSummaryId the id of the sample summary to find sample links for
    * @return a list of sample links
    */
@@ -66,6 +59,7 @@ public interface SampleService {
 
   /**
    * Method to save a sample link
+   *
    * @param sampleLink the sample link to save
    * @return the updated sample link
    */

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SurveyService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SurveyService.java
@@ -1,14 +1,10 @@
 package uk.gov.ons.ctp.response.collection.exercise.service;
 
+import java.util.UUID;
 import org.springframework.web.client.RestClientException;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
-import java.util.UUID;
-
-/**
- * Service responsible for dealing with samples
- *
- */
+/** Service responsible for dealing with samples */
 public interface SurveyService {
 
   /**
@@ -22,10 +18,10 @@ public interface SurveyService {
 
   /**
    * Request a survey by reference
+   *
    * @param surveyRef surveyRef to request the survey
    * @return the survey object
    * @throws RestClientException when failing to connect to survey service
    */
   SurveyDTO findSurveyByRef(String surveyRef) throws RestClientException;
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -1,5 +1,16 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
@@ -27,637 +38,698 @@ import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseSer
 import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
-import javax.transaction.Transactional;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-/**
- * The implementation of the SampleService
- */
+/** The implementation of the SampleService */
 @Service
 @Slf4j
 public class CollectionExerciseServiceImpl implements CollectionExerciseService {
 
-    private CaseTypeDefaultRepository caseTypeDefaultRepo;
+  private CaseTypeDefaultRepository caseTypeDefaultRepo;
 
-    private CaseTypeOverrideRepository caseTypeOverrideRepo;
+  private CaseTypeOverrideRepository caseTypeOverrideRepo;
 
-    private CollectionExerciseRepository collectRepo;
+  private CollectionExerciseRepository collectRepo;
 
-    private ActionSvcClient actionSvcClient;
+  private ActionSvcClient actionSvcClient;
 
-    private CollectionInstrumentSvcClient collectionInstrumentSvcClient;
+  private CollectionInstrumentSvcClient collectionInstrumentSvcClient;
 
-    private SampleLinkRepository sampleLinkRepository;
+  private SampleLinkRepository sampleLinkRepository;
 
-    private SurveyService surveyService;
+  private SurveyService surveyService;
 
-    private StateTransitionManager<CollectionExerciseDTO.CollectionExerciseState,
-            CollectionExerciseDTO.CollectionExerciseEvent> collectionExerciseTransitionState;
+  private StateTransitionManager<
+          CollectionExerciseDTO.CollectionExerciseState,
+          CollectionExerciseDTO.CollectionExerciseEvent>
+      collectionExerciseTransitionState;
 
+  @Autowired
+  public CollectionExerciseServiceImpl(
+      CaseTypeDefaultRepository caseTypeDefaultRepo,
+      CaseTypeOverrideRepository caseTypeOverrideRepo,
+      CollectionExerciseRepository collectRepo,
+      SampleLinkRepository sampleLinkRepository,
+      ActionSvcClient actionSvcClient,
+      CollectionInstrumentSvcClient collectionInstrumentSvcClient,
+      SurveyService surveyService,
+      @Qualifier("collectionExercise")
+          StateTransitionManager<
+                  CollectionExerciseDTO.CollectionExerciseState,
+                  CollectionExerciseDTO.CollectionExerciseEvent>
+              collectionExerciseTransitionState) {
+    this.caseTypeOverrideRepo = caseTypeOverrideRepo;
+    this.caseTypeDefaultRepo = caseTypeDefaultRepo;
+    this.collectRepo = collectRepo;
+    this.sampleLinkRepository = sampleLinkRepository;
+    this.actionSvcClient = actionSvcClient;
+    this.collectionInstrumentSvcClient = collectionInstrumentSvcClient;
+    this.surveyService = surveyService;
+    this.collectionExerciseTransitionState = collectionExerciseTransitionState;
+  }
 
-    @Autowired
-    public CollectionExerciseServiceImpl(
-            CaseTypeDefaultRepository caseTypeDefaultRepo,
-            CaseTypeOverrideRepository caseTypeOverrideRepo,
-            CollectionExerciseRepository collectRepo,
-            SampleLinkRepository sampleLinkRepository,
-            ActionSvcClient actionSvcClient,
-            CollectionInstrumentSvcClient collectionInstrumentSvcClient,
-            SurveyService surveyService,
-            @Qualifier("collectionExercise") StateTransitionManager
-                    <CollectionExerciseDTO.CollectionExerciseState, CollectionExerciseDTO.CollectionExerciseEvent>
-                    collectionExerciseTransitionState) {
-        this.caseTypeOverrideRepo = caseTypeOverrideRepo;
-        this.caseTypeDefaultRepo = caseTypeDefaultRepo;
-        this.collectRepo = collectRepo;
-        this.sampleLinkRepository = sampleLinkRepository;
-        this.actionSvcClient = actionSvcClient;
-        this.collectionInstrumentSvcClient = collectionInstrumentSvcClient;
-        this.surveyService = surveyService;
-        this.collectionExerciseTransitionState = collectionExerciseTransitionState;
+  @Override
+  public List<CollectionExercise> findCollectionExercisesForSurvey(SurveyDTO survey) {
+    return this.collectRepo.findBySurveyId(UUID.fromString(survey.getId()));
+  }
+
+  @Override
+  public List<CollectionExercise> findCollectionExercisesForParty(final UUID id) {
+    return this.collectRepo.findByPartyId(id);
+  }
+
+  @Override
+  public CollectionExercise findCollectionExercise(UUID id) {
+
+    return collectRepo.findOneById(id);
+  }
+
+  @Override
+  public CollectionExercise findCollectionExercise(String surveyRef, String exerciseRef) {
+    CollectionExercise collex = null;
+    SurveyDTO survey = this.surveyService.findSurveyByRef(surveyRef);
+
+    if (survey != null) {
+      collex = findCollectionExercise(exerciseRef, survey);
     }
 
+    return collex;
+  }
 
-    @Override
-    public List<CollectionExercise> findCollectionExercisesForSurvey(SurveyDTO survey) {
-        return this.collectRepo.findBySurveyId(UUID.fromString(survey.getId()));
+  @Override
+  public CollectionExercise findCollectionExercise(String exerciseRef, SurveyDTO survey) {
+    List<CollectionExercise> existing =
+        this.collectRepo.findByExerciseRefAndSurveyId(exerciseRef, UUID.fromString(survey.getId()));
+
+    switch (existing.size()) {
+      case 0:
+        return null;
+      default:
+        return existing.get(0);
+    }
+  }
+
+  @Override
+  public CollectionExercise findCollectionExercise(String exerciseRef, UUID surveyId) {
+    List<CollectionExercise> existing =
+        this.collectRepo.findByExerciseRefAndSurveyId(exerciseRef, surveyId);
+
+    switch (existing.size()) {
+      case 0:
+        return null;
+      default:
+        return existing.get(0);
+    }
+  }
+
+  @Override
+  public List<SampleLink> findLinkedSampleSummaries(UUID id) {
+    return sampleLinkRepository.findByCollectionExerciseId(id);
+  }
+
+  @Override
+  public List<CollectionExercise> findAllCollectionExercise() {
+    return collectRepo.findAll();
+  }
+
+  @Override
+  public Collection<CaseType> getCaseTypesList(CollectionExercise collectionExercise) {
+
+    List<CaseTypeDefault> caseTypeDefaultList =
+        caseTypeDefaultRepo.findBySurveyId(collectionExercise.getSurveyId());
+
+    List<CaseTypeOverride> caseTypeOverrideList =
+        caseTypeOverrideRepo.findByExerciseFK(collectionExercise.getExercisePK());
+
+    return createCaseTypeList(caseTypeDefaultList, caseTypeOverrideList);
+  }
+
+  /**
+   * Creates a Collection of CaseTypes
+   *
+   * @param caseTypeDefaultList List of caseTypeDefaults
+   * @param caseTypeOverrideList List of caseTypeOverrides
+   * @return Collection<CaseType> Collection of CaseTypes
+   */
+  public Collection<CaseType> createCaseTypeList(
+      List<? extends CaseType> caseTypeDefaultList, List<? extends CaseType> caseTypeOverrideList) {
+
+    Map<String, CaseType> defaultMap = new HashMap<>();
+
+    for (CaseType caseTypeDefault : caseTypeDefaultList) {
+      defaultMap.put(caseTypeDefault.getSampleUnitTypeFK(), caseTypeDefault);
     }
 
-    @Override
-    public List<CollectionExercise> findCollectionExercisesForParty(final UUID id) {
-        return this.collectRepo.findByPartyId(id);
+    for (CaseType caseTypeOverride : caseTypeOverrideList) {
+      defaultMap.put(caseTypeOverride.getSampleUnitTypeFK(), caseTypeOverride);
     }
 
-    @Override
-    public CollectionExercise findCollectionExercise(UUID id) {
+    return defaultMap.values();
+  }
 
-        return collectRepo.findOneById(id);
+  /**
+   * Delete existing SampleSummary links for input CollectionExercise then link all SampleSummaries
+   * in list to CollectionExercise
+   *
+   * @param collectionExerciseId the Id of the CollectionExercise to link to
+   * @param sampleSummaryIds the list of Ids of the SampleSummaries to be linked
+   * @return linkedSummaries the list of CollectionExercises and the linked SampleSummaries
+   */
+  @Transactional
+  @Override
+  public List<SampleLink> linkSampleSummaryToCollectionExercise(
+      UUID collectionExerciseId, List<UUID> sampleSummaryIds) {
+    sampleLinkRepository.deleteByCollectionExerciseId(collectionExerciseId);
+    List<SampleLink> linkedSummaries = new ArrayList<>();
+    for (UUID summaryId : sampleSummaryIds) {
+      linkedSummaries.add(createLink(summaryId, collectionExerciseId));
     }
 
-    @Override
-    public List<SampleLink> findLinkedSampleSummaries(UUID id) {
-        return sampleLinkRepository.findByCollectionExerciseId(id);
+    // This used to transition the collection exercise to ready for review, but now that only
+    // happens if
+    // the sample link is ACTIVE
+
+    return linkedSummaries;
+  }
+
+  /**
+   * Delete SampleSummary link
+   *
+   * @param sampleSummaryId a sample summary uuid
+   * @param collectionExerciseId a collection exercise uuid
+   * @throws CTPException thrown if transition fails
+   */
+  @Override
+  @Transactional
+  public void removeSampleSummaryLink(final UUID sampleSummaryId, final UUID collectionExerciseId)
+      throws CTPException {
+    sampleLinkRepository.deleteBySampleSummaryIdAndCollectionExerciseId(
+        sampleSummaryId, collectionExerciseId);
+
+    List<SampleLink> sampleLinks =
+        this.sampleLinkRepository.findByCollectionExerciseId(collectionExerciseId);
+
+    if (sampleLinks.size() == 0) {
+      transitionCollectionExercise(
+          collectionExerciseId, CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_DELETED);
+    }
+  }
+
+  /**
+   * Sets the values in a supplied collection exercise from a supplied DTO. WARNING: Mutates
+   * collection exercise
+   *
+   * @param collex the dto containing the data
+   * @param collectionExercise the collection exercise to apply the value from the dto to
+   */
+  private void setCollectionExerciseFromDto(
+      CollectionExerciseDTO collex, CollectionExercise collectionExercise) {
+    collectionExercise.setName(collex.getName());
+    collectionExercise.setUserDescription(collex.getUserDescription());
+    collectionExercise.setExerciseRef(collex.getExerciseRef());
+    collectionExercise.setSurveyId(UUID.fromString(collex.getSurveyId()));
+
+    // In the strictest sense, some of these dates are mandatory fields for collection exercises.
+    // However as they
+    // are not supplied at creation time, but later as "events" we will allow them to be null
+    if (collex.getScheduledStartDateTime() != null) {
+      collectionExercise.setScheduledStartDateTime(
+          new Timestamp(collex.getScheduledStartDateTime().getTime()));
+    }
+    if (collex.getScheduledEndDateTime() != null) {
+      collectionExercise.setScheduledEndDateTime(
+          new Timestamp(collex.getScheduledEndDateTime().getTime()));
+    }
+    if (collex.getScheduledExecutionDateTime() != null) {
+      collectionExercise.setScheduledExecutionDateTime(
+          new Timestamp(collex.getScheduledExecutionDateTime().getTime()));
+    }
+    if (collex.getActualExecutionDateTime() != null) {
+      collectionExercise.setActualExecutionDateTime(
+          new Timestamp(collex.getActualExecutionDateTime().getTime()));
+    }
+    if (collex.getActualPublishDateTime() != null) {
+      collectionExercise.setActualPublishDateTime(
+          new Timestamp(collex.getActualPublishDateTime().getTime()));
+    }
+  }
+
+  /**
+   * Create collection exercise This will also create the required action plans and casetypeoverride
+   *
+   * @param collex the data to create the collection exercise from
+   * @param survey representation of the survey for the given collection exercise
+   * @return created collection exercise
+   */
+  @Transactional
+  @Override
+  public CollectionExercise createCollectionExercise(
+      CollectionExerciseDTO collex, SurveyDTO survey) {
+    log.debug(
+        "Creating collection exercise, ExerciseRef: {}, SurveyRef: {}",
+        collex.getExerciseRef(),
+        survey.getSurveyRef());
+    CollectionExercise collectionExercise = newCollectionExerciseFromDTO(collex);
+    // Save collection exercise before creating action plans because we need the exercisepk
+    collectionExercise = this.collectRepo.saveAndFlush(collectionExercise);
+    createActionPlans(collectionExercise, survey);
+    log.debug(
+        "Successfully created collection exercise, CollectionExerciseId: {}",
+        collectionExercise.getId());
+    return collectionExercise;
+  }
+
+  /**
+   * Create and populate details of collection exercise.
+   *
+   * @param collex collection exercise
+   * @return collection exercise with details
+   */
+  private CollectionExercise newCollectionExerciseFromDTO(CollectionExerciseDTO collex) {
+    log.debug("Create new collection exercise from DTO");
+    CollectionExercise collectionExercise = new CollectionExercise();
+    setCollectionExerciseFromDto(collex, collectionExercise);
+    collectionExercise.setState(CollectionExerciseDTO.CollectionExerciseState.CREATED);
+    collectionExercise.setCreated(new Timestamp(new Date().getTime()));
+    collectionExercise.setId(UUID.randomUUID());
+    log.debug(
+        "Successfully created collection exercise from DTO, CollectionExerciseId: {}",
+        collectionExercise.getId());
+    return collectionExercise;
+  }
+
+  /**
+   * Create required action plans
+   *
+   * @param collectionExercise Collection Exercise
+   * @param survey SurveyDTO representing survey of collection exercise
+   */
+  private void createActionPlans(CollectionExercise collectionExercise, SurveyDTO survey) {
+    log.debug(
+        "Creating action plans for exercise, CollectionExerciseId: {}, SurveyId: {}",
+        collectionExercise.getId(),
+        survey.getId());
+    createDefaultActionPlan(survey, "B");
+    createDefaultActionPlan(survey, "BI");
+    createOverrideActionPlan(collectionExercise, survey, "B");
+    createOverrideActionPlan(collectionExercise, survey, "BI");
+    log.debug(
+        "Successfully created action plans for exercise, CollectionExerciseId: {}, SurveyID: {}",
+        collectionExercise.getId(),
+        survey.getId());
+  }
+
+  /**
+   * Create default action plan for collection exercise and case type if not already exists
+   *
+   * @param survey DTO Representation of survey
+   * @param sampleUnitType Sample Unit Type i.e. (B, H, HI)
+   */
+  private void createDefaultActionPlan(SurveyDTO survey, String sampleUnitType) {
+    log.debug(
+        "Creating default action plan, SurveyId: {} , SampleUnitType: {}",
+        survey.getId(),
+        sampleUnitType);
+
+    // If a casetypedefault already exists for this survey/sampleUnitType do nothing
+    CaseTypeDefault existingCaseTypeDefault =
+        caseTypeDefaultRepo.findTopBySurveyIdAndSampleUnitTypeFK(
+            UUID.fromString(survey.getId()), sampleUnitType);
+    if (existingCaseTypeDefault != null) {
+      log.debug(
+          "Default action plan already exists, SurveyId: {} SampleUnitType: {}",
+          survey.getId(),
+          sampleUnitType);
+      return;
     }
 
-    @Override
-    public List<CollectionExercise> findAllCollectionExercise() {
-        return collectRepo.findAll();
+    // Create new action plan and associated casetypedefault
+    String shortName = survey.getShortName();
+    String name = String.format("%s %s", shortName, sampleUnitType);
+    String description = String.format("%s %s Case", shortName, sampleUnitType);
+    ActionPlanDTO actionPlan = actionSvcClient.createActionPlan(name, description);
+    createCaseTypeDefault(survey, sampleUnitType, actionPlan);
+    log.debug(
+        "Successfully created default action plan, ActionPlanId: {}, SurveyId: {},"
+            + " SampleUnitType: {}",
+        actionPlan.getId(),
+        survey.getId(),
+        sampleUnitType);
+  }
+
+  /**
+   * Create case type default for action plan, survey and sample unit type if not already exists
+   *
+   * @param survey DTO Representation of survey
+   * @param sampleUnitType Sample Unit Type
+   * @param actionPlan DTO Representation of action plan
+   */
+  private void createCaseTypeDefault(
+      SurveyDTO survey, String sampleUnitType, ActionPlanDTO actionPlan) {
+    log.debug(
+        "Creating case type default, ActionPlanId: {}, SurveyId: {}, SampleUnitType: {}",
+        actionPlan.getId(),
+        survey.getId(),
+        sampleUnitType);
+    CaseTypeDefault caseTypeDefault = new CaseTypeDefault();
+    caseTypeDefault.setSurveyId(UUID.fromString(survey.getId()));
+    caseTypeDefault.setSampleUnitTypeFK(sampleUnitType);
+    caseTypeDefault.setActionPlanId(actionPlan.getId());
+
+    this.caseTypeDefaultRepo.saveAndFlush(caseTypeDefault);
+    log.debug(
+        "Successfully created case type default, ActionPlanId: {}, SurveyId: {},"
+            + " SampleUnitType: {}",
+        actionPlan.getId(),
+        survey.getId(),
+        sampleUnitType);
+  }
+
+  /**
+   * Create action plan for given collection exercise and case type if not already exists
+   *
+   * @param survey DTO Representation of survey for collection exercise
+   * @param collectionExercise Collection Exercise
+   * @param sampleUnitType Sample Unit Type i.e. (B, H, HI)
+   */
+  private void createOverrideActionPlan(
+      CollectionExercise collectionExercise, SurveyDTO survey, String sampleUnitType) {
+    log.debug(
+        "Creating override action plan, CollectionExerciseId: {}, SampleUnitType: {}",
+        collectionExercise.getId(),
+        sampleUnitType);
+
+    // If a casetypeoverride already exists for this exercise/sampleUnitType do nothing
+    CaseTypeOverride existingCaseTypeOverride =
+        caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(
+            collectionExercise.getExercisePK(), sampleUnitType);
+    if (existingCaseTypeOverride != null) {
+      log.debug(
+          "Override action plan already exists, CollectionExerciseId: {}, SampleUnitType: {}",
+          collectionExercise.getId(),
+          sampleUnitType);
+      return;
     }
 
-    @Override
-    public CollectionExercise findCollectionExercise(String surveyRef, String exerciseRef) {
-        CollectionExercise collex = null;
-        SurveyDTO survey = this.surveyService.findSurveyByRef(surveyRef);
+    // Create action plan with appropriate name and description
+    String exerciseRef = collectionExercise.getExerciseRef();
+    String shortName = survey.getShortName();
+    String name = String.format("%s %s %s", shortName, sampleUnitType, exerciseRef);
+    String description = String.format("%s %s Case %s", shortName, sampleUnitType, exerciseRef);
+    ActionPlanDTO actionPlan = actionSvcClient.createActionPlan(name, description);
 
-        if (survey != null) {
-            collex = findCollectionExercise(exerciseRef, survey);
-        }
+    // Create casetypeoverride linking collection exercise and sample unit type to the action plan
+    createCaseTypeOverride(collectionExercise, sampleUnitType, actionPlan);
+    log.debug(
+        "Successfully created override action plan, "
+            + "ActionPlanId: {}, CollectionExerciseId: {}, SampleUnitType: {}",
+        actionPlan.getId(),
+        collectionExercise.getId(),
+        sampleUnitType);
+  }
 
-        return collex;
-    }
+  /**
+   * Create case type override for given action plan and collection exercise
+   *
+   * @param collectionExercise representation of collection exercise
+   * @param sampleUnitType Sample unit type i.e. (B, H, HI)
+   * @param actionPlan the newly created action plan
+   * @throws DataAccessException if caseTypeOverride fails to save to database
+   */
+  private void createCaseTypeOverride(
+      CollectionExercise collectionExercise, String sampleUnitType, ActionPlanDTO actionPlan)
+      throws DataAccessException {
+    log.debug(
+        "Creating case type override, ActionPlanId: {}, CollectionExerciseId: {},"
+            + " SampleUnitType: {}",
+        actionPlan.getId(),
+        collectionExercise.getId(),
+        sampleUnitType);
+    CaseTypeOverride caseTypeOverride = new CaseTypeOverride();
+    caseTypeOverride.setExerciseFK(collectionExercise.getExercisePK());
+    caseTypeOverride.setSampleUnitTypeFK(sampleUnitType);
+    caseTypeOverride.setActionPlanId(actionPlan.getId());
+    this.caseTypeOverrideRepo.saveAndFlush(caseTypeOverride);
+    log.debug(
+        "Successfully created case type override, "
+            + "CollectionExerciseId: {}, SampleUnitType: {}, ActionPlanId: {}",
+        collectionExercise.getId(),
+        sampleUnitType,
+        actionPlan.getId());
+  }
 
-    @Override
-    public Collection<CaseType> getCaseTypesList(CollectionExercise collectionExercise) {
+  @Override
+  public CollectionExercise patchCollectionExercise(UUID id, CollectionExerciseDTO patchData)
+      throws CTPException {
+    CollectionExercise collex = findCollectionExercise(id);
 
-        List<CaseTypeDefault> caseTypeDefaultList =
-                caseTypeDefaultRepo.findBySurveyId(collectionExercise.getSurveyId());
+    if (collex == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format("Collection exercise %s not found", id));
+    } else {
+      String proposedPeriod =
+          patchData.getExerciseRef() == null ? collex.getExerciseRef() : patchData.getExerciseRef();
+      UUID proposedSurvey =
+          patchData.getSurveyId() == null
+              ? collex.getSurveyId()
+              : UUID.fromString(patchData.getSurveyId());
 
-        List<CaseTypeOverride> caseTypeOverrideList = caseTypeOverrideRepo
-                .findByExerciseFK(collectionExercise.getExercisePK());
+      // If period/survey not supplied in patchData then this call will trivially return
+      validateUniqueness(collex, proposedPeriod, proposedSurvey);
 
-        return createCaseTypeList(caseTypeDefaultList, caseTypeOverrideList);
-    }
+      if (!StringUtils.isBlank(patchData.getSurveyId())) {
+        UUID surveyId = UUID.fromString(patchData.getSurveyId());
 
-    /**
-     * Creates a Collection of CaseTypes
-     *
-     * @param caseTypeDefaultList  List of caseTypeDefaults
-     * @param caseTypeOverrideList List of caseTypeOverrides
-     * @return Collection<CaseType> Collection of CaseTypes
-     */
-    public Collection<CaseType> createCaseTypeList(List<? extends CaseType> caseTypeDefaultList,
-                                                   List<? extends CaseType> caseTypeOverrideList) {
+        SurveyDTO survey = this.surveyService.findSurvey(surveyId);
 
-        Map<String, CaseType> defaultMap = new HashMap<>();
-
-        for (CaseType caseTypeDefault : caseTypeDefaultList) {
-            defaultMap.put(caseTypeDefault.getSampleUnitTypeFK(), caseTypeDefault);
-        }
-
-        for (CaseType caseTypeOverride : caseTypeOverrideList) {
-            defaultMap.put(caseTypeOverride.getSampleUnitTypeFK(), caseTypeOverride);
-        }
-
-        return defaultMap.values();
-    }
-
-    /**
-     * Delete existing SampleSummary links for input CollectionExercise then link
-     * all SampleSummaries in list to CollectionExercise
-     *
-     * @param collectionExerciseId the Id of the CollectionExercise to link to
-     * @param sampleSummaryIds     the list of Ids of the SampleSummaries to be linked
-     * @return linkedSummaries the list of CollectionExercises and the linked
-     * SampleSummaries
-     */
-    @Transactional
-    @Override
-    public List<SampleLink> linkSampleSummaryToCollectionExercise(UUID collectionExerciseId,
-                                                                  List<UUID> sampleSummaryIds) {
-        sampleLinkRepository.deleteByCollectionExerciseId(collectionExerciseId);
-        List<SampleLink> linkedSummaries = new ArrayList<>();
-        for (UUID summaryId : sampleSummaryIds) {
-            linkedSummaries.add(createLink(summaryId, collectionExerciseId));
-        }
-
-        // This used to transition the collection exercise to ready for review, but now that only happens if
-        // the sample link is ACTIVE
-
-        return linkedSummaries;
-    }
-
-    /**
-     * Delete SampleSummary link
-     * @param sampleSummaryId a sample summary uuid
-     * @param collectionExerciseId a collection exercise uuid
-     * @throws CTPException thrown if transition fails
-     */
-    @Override
-    @Transactional
-    public void removeSampleSummaryLink(final UUID sampleSummaryId, final UUID collectionExerciseId)
-            throws CTPException {
-        sampleLinkRepository.deleteBySampleSummaryIdAndCollectionExerciseId(sampleSummaryId, collectionExerciseId);
-
-        List<SampleLink> sampleLinks = this.sampleLinkRepository.findByCollectionExerciseId(collectionExerciseId);
-
-        if (sampleLinks.size() == 0) {
-            transitionCollectionExercise(collectionExerciseId,
-                    CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_DELETED);
-        }
-    }
-
-    /**
-     * Sets the values in a supplied collection exercise from a supplied DTO.
-     * WARNING: Mutates collection exercise
-     *
-     * @param collex             the dto containing the data
-     * @param collectionExercise the collection exercise to apply the value from the dto to
-     */
-    private void setCollectionExerciseFromDto(CollectionExerciseDTO collex, CollectionExercise collectionExercise) {
-        collectionExercise.setName(collex.getName());
-        collectionExercise.setUserDescription(collex.getUserDescription());
-        collectionExercise.setExerciseRef(collex.getExerciseRef());
-        collectionExercise.setSurveyId(UUID.fromString(collex.getSurveyId()));
-
-        // In the strictest sense, some of these dates are mandatory fields for collection exercises.  However as they
-        // are not supplied at creation time, but later as "events" we will allow them to be null
-        if (collex.getScheduledStartDateTime() != null) {
-            collectionExercise.setScheduledStartDateTime(new Timestamp(collex.getScheduledStartDateTime().getTime()));
-        }
-        if (collex.getScheduledEndDateTime() != null) {
-            collectionExercise.setScheduledEndDateTime(new Timestamp(collex.getScheduledEndDateTime().getTime()));
-        }
-        if (collex.getScheduledExecutionDateTime() != null) {
-            collectionExercise.setScheduledExecutionDateTime(
-                    new Timestamp(collex.getScheduledExecutionDateTime().getTime()));
-        }
-        if (collex.getActualExecutionDateTime() != null) {
-            collectionExercise.setActualExecutionDateTime(new Timestamp(collex.getActualExecutionDateTime().getTime()));
-        }
-        if (collex.getActualPublishDateTime() != null) {
-            collectionExercise.setActualPublishDateTime(new Timestamp(collex.getActualPublishDateTime().getTime()));
-        }
-    }
-
-    /**
-     * Create collection exercise
-     * This will also create the required action plans and casetypeoverride
-     * @param collex the data to create the collection exercise from
-     * @param survey representation of the survey for the given collection exercise
-     * @return created collection exercise
-     */
-    @Transactional
-    @Override
-    public CollectionExercise createCollectionExercise(CollectionExerciseDTO collex, SurveyDTO survey) {
-        log.debug("Creating collection exercise, ExerciseRef: {}, SurveyRef: {}",
-                collex.getExerciseRef(), survey.getSurveyRef());
-        CollectionExercise collectionExercise = newCollectionExerciseFromDTO(collex);
-        // Save collection exercise before creating action plans because we need the exercisepk
-        collectionExercise = this.collectRepo.saveAndFlush(collectionExercise);
-        createActionPlans(collectionExercise, survey);
-        log.debug("Successfully created collection exercise, CollectionExerciseId: {}", collectionExercise.getId());
-        return collectionExercise;
-    }
-
-    /**
-     * Create and populate details of collection exercise.
-     * @param collex collection exercise
-     * @return collection exercise with details
-     */
-    private CollectionExercise newCollectionExerciseFromDTO(CollectionExerciseDTO collex) {
-        log.debug("Create new collection exercise from DTO");
-        CollectionExercise collectionExercise = new CollectionExercise();
-        setCollectionExerciseFromDto(collex, collectionExercise);
-        collectionExercise.setState(CollectionExerciseDTO.CollectionExerciseState.CREATED);
-        collectionExercise.setCreated(new Timestamp(new Date().getTime()));
-        collectionExercise.setId(UUID.randomUUID());
-        log.debug("Successfully created collection exercise from DTO, CollectionExerciseId: {}",
-                collectionExercise.getId());
-        return collectionExercise;
-    }
-
-    /**
-     * Create required action plans
-     * @param collectionExercise Collection Exercise
-     * @param survey SurveyDTO representing survey of collection exercise
-     */
-    private void createActionPlans(CollectionExercise collectionExercise, SurveyDTO survey) {
-        log.debug("Creating action plans for exercise, CollectionExerciseId: {}, SurveyId: {}",
-                collectionExercise.getId(), survey.getId());
-        createDefaultActionPlan(survey, "B");
-        createDefaultActionPlan(survey, "BI");
-        createOverrideActionPlan(collectionExercise, survey, "B");
-        createOverrideActionPlan(collectionExercise, survey, "BI");
-        log.debug("Successfully created action plans for exercise, CollectionExerciseId: {}, SurveyID: {}",
-                collectionExercise.getId(), survey.getId());
-    }
-
-    /**
-     * Create default action plan for collection exercise and case type if not already exists
-     * @param survey DTO Representation of survey
-     * @param sampleUnitType Sample Unit Type i.e. (B, H, HI)
-     */
-    private void createDefaultActionPlan(SurveyDTO survey, String sampleUnitType) {
-        log.debug("Creating default action plan, SurveyId: {} , SampleUnitType: {}",
-                survey.getId(), sampleUnitType);
-
-        // If a casetypedefault already exists for this survey/sampleUnitType do nothing
-        CaseTypeDefault existingCaseTypeDefault = caseTypeDefaultRepo.findTopBySurveyIdAndSampleUnitTypeFK(
-                UUID.fromString(survey.getId()), sampleUnitType);
-        if (existingCaseTypeDefault != null) {
-            log.debug("Default action plan already exists, SurveyId: {} SampleUnitType: {}",
-                    survey.getId(), sampleUnitType);
-            return;
-        }
-
-        // Create new action plan and associated casetypedefault
-        String shortName = survey.getShortName();
-        String name = String.format("%s %s", shortName, sampleUnitType);
-        String description = String.format("%s %s Case", shortName, sampleUnitType);
-        ActionPlanDTO actionPlan = actionSvcClient.createActionPlan(name, description);
-        createCaseTypeDefault(survey, sampleUnitType, actionPlan);
-        log.debug("Successfully created default action plan, ActionPlanId: {}, SurveyId: {}, SampleUnitType: {}",
-                actionPlan.getId(), survey.getId(), sampleUnitType);
-    }
-
-    /**
-     * Create case type default for action plan, survey and sample unit type if not already exists
-     * @param survey DTO Representation of survey
-     * @param sampleUnitType Sample Unit Type
-     * @param actionPlan DTO Representation of action plan
-     */
-    private void createCaseTypeDefault(SurveyDTO survey, String sampleUnitType, ActionPlanDTO actionPlan) {
-        log.debug("Creating case type default, ActionPlanId: {}, SurveyId: {}, SampleUnitType: {}",
-                actionPlan.getId(), survey.getId(), sampleUnitType);
-        CaseTypeDefault caseTypeDefault = new CaseTypeDefault();
-        caseTypeDefault.setSurveyId(UUID.fromString(survey.getId()));
-        caseTypeDefault.setSampleUnitTypeFK(sampleUnitType);
-        caseTypeDefault.setActionPlanId(actionPlan.getId());
-
-        this.caseTypeDefaultRepo.saveAndFlush(caseTypeDefault);
-        log.debug("Successfully created case type default, ActionPlanId: {}, SurveyId: {}, SampleUnitType: {}",
-                actionPlan.getId(), survey.getId(), sampleUnitType);
-    }
-
-    /**
-     * Create action plan for given collection exercise and case type if not already exists
-     * @param survey DTO Representation of survey for collection exercise
-     * @param collectionExercise Collection Exercise
-     * @param sampleUnitType Sample Unit Type i.e. (B, H, HI)
-     */
-    private void createOverrideActionPlan(CollectionExercise collectionExercise, SurveyDTO survey,
-                                          String sampleUnitType) {
-        log.debug("Creating override action plan, CollectionExerciseId: {}, SampleUnitType: {}",
-                   collectionExercise.getId(), sampleUnitType);
-
-        // If a casetypeoverride already exists for this exercise/sampleUnitType do nothing
-        CaseTypeOverride existingCaseTypeOverride = caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(
-                collectionExercise.getExercisePK(), sampleUnitType);
-        if (existingCaseTypeOverride != null) {
-            log.debug("Override action plan already exists, CollectionExerciseId: {}, SampleUnitType: {}",
-                    collectionExercise.getId(), sampleUnitType);
-            return;
-        }
-
-        // Create action plan with appropriate name and description
-        String exerciseRef = collectionExercise.getExerciseRef();
-        String shortName = survey.getShortName();
-        String name = String.format("%s %s %s", shortName, sampleUnitType, exerciseRef);
-        String description = String.format("%s %s Case %s", shortName, sampleUnitType, exerciseRef);
-        ActionPlanDTO actionPlan = actionSvcClient.createActionPlan(name, description);
-
-        // Create casetypeoverride linking collection exercise and sample unit type to the action plan
-        createCaseTypeOverride(collectionExercise, sampleUnitType, actionPlan);
-        log.debug("Successfully created override action plan, " +
-                  "ActionPlanId: {}, CollectionExerciseId: {}, SampleUnitType: {}",
-                   actionPlan.getId(), collectionExercise.getId(), sampleUnitType);
-    }
-
-    /**
-     * Create case type override for given action plan and collection exercise
-     * @param collectionExercise representation of collection exercise
-     * @param sampleUnitType Sample unit type i.e. (B, H, HI)
-     * @param actionPlan the newly created action plan
-     * @throws DataAccessException if caseTypeOverride fails to save to database
-     */
-    private void createCaseTypeOverride(CollectionExercise collectionExercise, String sampleUnitType,
-                                        ActionPlanDTO actionPlan) throws DataAccessException {
-        log.debug("Creating case type override, ActionPlanId: {}, CollectionExerciseId: {}, SampleUnitType: {}",
-                   actionPlan.getId(), collectionExercise.getId(), sampleUnitType);
-        CaseTypeOverride caseTypeOverride = new CaseTypeOverride();
-        caseTypeOverride.setExerciseFK(collectionExercise.getExercisePK());
-        caseTypeOverride.setSampleUnitTypeFK(sampleUnitType);
-        caseTypeOverride.setActionPlanId(actionPlan.getId());
-        this.caseTypeOverrideRepo.saveAndFlush(caseTypeOverride);
-        log.debug("Successfully created case type override, " +
-                  "CollectionExerciseId: {}, SampleUnitType: {}, ActionPlanId: {}",
-                collectionExercise.getId(), sampleUnitType, actionPlan.getId());
-    }
-
-    @Override
-    public CollectionExercise findCollectionExercise(String exerciseRef, SurveyDTO survey) {
-        List<CollectionExercise> existing = this.collectRepo.findByExerciseRefAndSurveyId(
-                exerciseRef,
-                UUID.fromString(survey.getId()));
-
-        switch (existing.size()) {
-            case 0:
-                return null;
-            default:
-                return existing.get(0);
-        }
-    }
-
-    @Override
-    public CollectionExercise findCollectionExercise(String exerciseRef, UUID surveyId) {
-        List<CollectionExercise> existing = this.collectRepo.findByExerciseRefAndSurveyId(exerciseRef, surveyId);
-
-        switch (existing.size()) {
-            case 0:
-                return null;
-            default:
-                return existing.get(0);
-        }
-    }
-
-    @Override
-    public CollectionExercise patchCollectionExercise(UUID id, CollectionExerciseDTO patchData) throws CTPException {
-        CollectionExercise collex = findCollectionExercise(id);
-
-        if (collex == null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("Collection exercise %s not found", id));
+        if (survey == null) {
+          throw new CTPException(
+              CTPException.Fault.BAD_REQUEST, String.format("Survey %s does not exist", surveyId));
         } else {
-            String proposedPeriod = patchData.getExerciseRef() == null
-                    ? collex.getExerciseRef()
-                    : patchData.getExerciseRef();
-            UUID proposedSurvey = patchData.getSurveyId() == null
-                    ? collex.getSurveyId()
-                    : UUID.fromString(patchData.getSurveyId());
-
-            // If period/survey not supplied in patchData then this call will trivially return
-            validateUniqueness(collex, proposedPeriod, proposedSurvey);
-
-            if (!StringUtils.isBlank(patchData.getSurveyId())) {
-                UUID surveyId = UUID.fromString(patchData.getSurveyId());
-
-                SurveyDTO survey = this.surveyService.findSurvey(surveyId);
-
-                if (survey == null) {
-                    throw new CTPException(CTPException.Fault.BAD_REQUEST,
-                            String.format("Survey %s does not exist", surveyId));
-                } else {
-                    collex.setSurveyId(surveyId);
-                }
-            }
-
-            if (!StringUtils.isBlank(patchData.getExerciseRef())) {
-                collex.setExerciseRef(patchData.getExerciseRef());
-            }
-            if (!StringUtils.isBlank(patchData.getName())) {
-                collex.setName(patchData.getName());
-            }
-            if (!StringUtils.isBlank(patchData.getUserDescription())) {
-                collex.setUserDescription(patchData.getUserDescription());
-            }
-            if (patchData.getScheduledStartDateTime() != null) {
-                collex.setScheduledStartDateTime(new Timestamp(patchData.getScheduledStartDateTime().getTime()));
-            }
-
-            collex.setUpdated(new Timestamp(new Date().getTime()));
-
-            return updateCollectionExercise(collex);
+          collex.setSurveyId(surveyId);
         }
+      }
+
+      if (!StringUtils.isBlank(patchData.getExerciseRef())) {
+        collex.setExerciseRef(patchData.getExerciseRef());
+      }
+      if (!StringUtils.isBlank(patchData.getName())) {
+        collex.setName(patchData.getName());
+      }
+      if (!StringUtils.isBlank(patchData.getUserDescription())) {
+        collex.setUserDescription(patchData.getUserDescription());
+      }
+      if (patchData.getScheduledStartDateTime() != null) {
+        collex.setScheduledStartDateTime(
+            new Timestamp(patchData.getScheduledStartDateTime().getTime()));
+      }
+
+      collex.setUpdated(new Timestamp(new Date().getTime()));
+
+      return updateCollectionExercise(collex);
+    }
+  }
+
+  /**
+   * This method checks whether the supplied CollectionExercise (existing) can change it's period to
+   * candidatePeriod and it's survey to candidateSurvey without breaching the uniqueness constraint
+   * on those fields
+   *
+   * @param existing the collection exercise that is to be updated
+   * @param candidatePeriod the proposed new value for the period (exerciseRef)
+   * @param candidateSurvey the proposed new value for the survey
+   * @throws CTPException thrown if there is an existing different collection exercise that already
+   *     uses the proposed combination of period and survey
+   */
+  private void validateUniqueness(
+      CollectionExercise existing, String candidatePeriod, UUID candidateSurvey)
+      throws CTPException {
+    if (!existing.getSurveyId().equals(candidateSurvey)
+        || !existing.getExerciseRef().equals(candidatePeriod)) {
+      CollectionExercise otherExisting = findCollectionExercise(candidatePeriod, candidateSurvey);
+
+      if (otherExisting != null && !otherExisting.getId().equals(existing.getId())) {
+        throw new CTPException(
+            CTPException.Fault.RESOURCE_VERSION_CONFLICT,
+            String.format(
+                "A collection exercise with period %s and id %s already exists.",
+                candidatePeriod, candidateSurvey));
+      }
+    }
+  }
+
+  @Override
+  public CollectionExercise updateCollectionExercise(UUID id, CollectionExerciseDTO collexDto)
+      throws CTPException {
+    CollectionExercise existing = findCollectionExercise(id);
+
+    if (existing == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format("Collection exercise with id %s does not exist", id));
+    } else {
+      UUID surveyUuid = UUID.fromString(collexDto.getSurveyId());
+      String period = collexDto.getExerciseRef();
+
+      // This will throw exception if period & surveyId are not unique
+      validateUniqueness(existing, period, surveyUuid);
+
+      SurveyDTO survey = this.surveyService.findSurvey(surveyUuid);
+
+      if (survey == null) {
+        throw new CTPException(
+            CTPException.Fault.BAD_REQUEST, String.format("Survey %s does not exist", surveyUuid));
+      } else {
+        setCollectionExerciseFromDto(collexDto, existing);
+        existing.setUpdated(new Timestamp(new Date().getTime()));
+
+        return updateCollectionExercise(existing);
+      }
+    }
+  }
+
+  @Override
+  public CollectionExercise updateCollectionExercise(final CollectionExercise collex) {
+    collex.setUpdated(new Timestamp(new Date().getTime()));
+    return this.collectRepo.saveAndFlush(collex);
+  }
+
+  /**
+   * Utility method to set the deleted flag for a collection exercise
+   *
+   * @param id the uuid of the collection exercise to update
+   * @param deleted true if the collection exercise is to be marked as deleted, false otherwise
+   * @return 200 if success, 404 if not found
+   * @throws CTPException thrown if specified collection exercise does not exist
+   */
+  private CollectionExercise updateCollectionExerciseDeleted(UUID id, boolean deleted)
+      throws CTPException {
+    CollectionExercise collex = findCollectionExercise(id);
+
+    if (collex == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format("Collection exercise %s does not exists", id));
+    } else {
+      collex.setDeleted(deleted);
+
+      return updateCollectionExercise(collex);
+    }
+  }
+
+  @Override
+  public CollectionExercise deleteCollectionExercise(UUID id) throws CTPException {
+    return updateCollectionExerciseDeleted(id, true);
+  }
+
+  @Override
+  public CollectionExercise undeleteCollectionExercise(UUID id) throws CTPException {
+    return updateCollectionExerciseDeleted(id, false);
+  }
+
+  @Override
+  public List<CollectionExercise> findByState(CollectionExerciseDTO.CollectionExerciseState state) {
+    return collectRepo.findByState(state);
+  }
+
+  @Override
+  public void transitionCollectionExercise(
+      CollectionExercise collex, CollectionExerciseDTO.CollectionExerciseEvent event)
+      throws CTPException {
+    CollectionExerciseDTO.CollectionExerciseState oldState = collex.getState();
+    CollectionExerciseDTO.CollectionExerciseState newState =
+        collectionExerciseTransitionState.transition(collex.getState(), event);
+    if (oldState != newState) {
+      collex.setState(newState);
+      updateCollectionExercise(collex);
+    }
+  }
+
+  @Override
+  public void transitionCollectionExercise(
+      final UUID collectionExerciseId, final CollectionExerciseDTO.CollectionExerciseEvent event)
+      throws CTPException {
+    CollectionExercise collex = findCollectionExercise(collectionExerciseId);
+
+    if (collex == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format("Cannot find collection exercise %s", collectionExerciseId));
     }
 
-    /**
-     * This method checks whether the supplied CollectionExercise (existing) can change it's period to candidatePeriod
-     * and it's survey to candidateSurvey without breaching the uniqueness constraint on those fields
-     *
-     * @param existing        the collection exercise that is to be updated
-     * @param candidatePeriod the proposed new value for the period (exerciseRef)
-     * @param candidateSurvey the proposed new value for the survey
-     * @throws CTPException thrown if there is an existing different collection exercise that already uses the proposed
-     *                      combination of period and survey
-     */
-    private void validateUniqueness(CollectionExercise existing, String candidatePeriod, UUID candidateSurvey)
-            throws CTPException {
-        if (!existing.getSurveyId().equals(candidateSurvey)
-                || !existing.getExerciseRef().equals(candidatePeriod)) {
-            CollectionExercise otherExisting = findCollectionExercise(candidatePeriod, candidateSurvey);
+    transitionCollectionExercise(collex, event);
+  }
 
-            if (otherExisting != null && !otherExisting.getId().equals(existing.getId())) {
-                throw new CTPException(
-                        CTPException.Fault.RESOURCE_VERSION_CONFLICT,
-                        String.format("A collection exercise with period %s and id %s already exists.",
-                                candidatePeriod,
-                                candidateSurvey));
-            }
-        }
+  @Override
+  public void transitionScheduleCollectionExerciseToReadyToReview(final UUID collectionExerciseId)
+      throws CTPException {
+    CollectionExercise collex = findCollectionExercise(collectionExerciseId);
+
+    if (collex != null) {
+      transitionScheduleCollectionExerciseToReadyToReview(collex);
     }
+  }
 
-    @Override
-    public CollectionExercise updateCollectionExercise(UUID id, CollectionExerciseDTO collexDto) throws CTPException {
-        CollectionExercise existing = findCollectionExercise(id);
+  @Override
+  public void transitionScheduleCollectionExerciseToReadyToReview(
+      final CollectionExercise collectionExercise) throws CTPException {
+    UUID collexId = collectionExercise.getId();
 
-        if (existing == null) {
-            throw new CTPException(
-                    CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("Collection exercise with id %s does not exist", id));
-        } else {
-            UUID surveyUuid = UUID.fromString(collexDto.getSurveyId());
-            String period = collexDto.getExerciseRef();
-
-            // This will throw exception if period & surveyId are not unique
-            validateUniqueness(existing, period, surveyUuid);
-
-            SurveyDTO survey = this.surveyService.findSurvey(surveyUuid);
-
-            if (survey == null) {
-                throw new CTPException(
-                        CTPException.Fault.BAD_REQUEST,
-                        String.format("Survey %s does not exist", surveyUuid));
-            } else {
-                setCollectionExerciseFromDto(collexDto, existing);
-                existing.setUpdated(new Timestamp(new Date().getTime()));
-
-                return updateCollectionExercise(existing);
-            }
-        }
+    Map<String, String> searchStringMap =
+        Collections.singletonMap("COLLECTION_EXERCISE", collectionExercise.getId().toString());
+    String searchStringJson = new JSONObject(searchStringMap).toString();
+    Integer numberOfCollectionInstruments =
+        collectionInstrumentSvcClient.countCollectionInstruments(searchStringJson);
+    boolean sampleLinksValid = validateSampleLinks(collexId);
+    boolean shouldTransition =
+        sampleLinksValid
+            && numberOfCollectionInstruments != null
+            && numberOfCollectionInstruments > 0;
+    log.info(
+        "ready_for_review transition check: sampleLinksValid: {},"
+            + " numberOfCollectionInstruments: {},"
+            + " shouldTransition: {}",
+        sampleLinksValid,
+        numberOfCollectionInstruments,
+        shouldTransition);
+    if (shouldTransition) {
+      transitionCollectionExercise(
+          collectionExercise, CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_ADDED);
+    } else {
+      transitionCollectionExercise(
+          collectionExercise, CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_DELETED);
     }
+  }
 
-    @Override
-    public CollectionExercise updateCollectionExercise(final CollectionExercise collex) {
-        collex.setUpdated(new Timestamp(new Date().getTime()));
-        return this.collectRepo.saveAndFlush(collex);
-    }
+  /**
+   * Method to validate the sample links for a collection exercise by ensuring that all associated
+   * SampleLinks are in the ACTIVE state
+   *
+   * @param collexId the collection exercise to validate
+   * @return true if the associated sample links are valid, false otherwise
+   */
+  private boolean validateSampleLinks(final UUID collexId) {
+    List<SampleLink> sampleLinks = this.sampleLinkRepository.findByCollectionExerciseId(collexId);
+    List<SampleLink> nonActiveSampleLinks =
+        sampleLinks
+            .stream()
+            .filter(sl -> SampleLinkState.ACTIVE != sl.getState())
+            .collect(Collectors.toList());
 
+    return sampleLinks.size() > 0 && nonActiveSampleLinks.size() == 0;
+  }
 
-    /**
-     * Utility method to set the deleted flag for a collection exercise
-     *
-     * @param id      the uuid of the collection exercise to update
-     * @param deleted true if the collection exercise is to be marked as deleted, false otherwise
-     * @return 200 if success, 404 if not found
-     * @throws CTPException thrown if specified collection exercise does not exist
-     */
-    private CollectionExercise updateCollectionExerciseDeleted(UUID id, boolean deleted) throws CTPException {
-        CollectionExercise collex = findCollectionExercise(id);
-
-        if (collex == null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("Collection exercise %s does not exists", id));
-        } else {
-            collex.setDeleted(deleted);
-
-            return updateCollectionExercise(collex);
-        }
-    }
-
-    @Override
-    public CollectionExercise deleteCollectionExercise(UUID id) throws CTPException {
-        return updateCollectionExerciseDeleted(id, true);
-    }
-
-    @Override
-    public CollectionExercise undeleteCollectionExercise(UUID id) throws CTPException {
-        return updateCollectionExerciseDeleted(id, false);
-    }
-
-    @Override
-    public List<CollectionExercise> findByState(CollectionExerciseDTO.CollectionExerciseState state) {
-        return collectRepo.findByState(state);
-    }
-
-    @Override
-    public void transitionCollectionExercise(CollectionExercise collex,
-                                             CollectionExerciseDTO.CollectionExerciseEvent event) throws CTPException {
-        CollectionExerciseDTO.CollectionExerciseState oldState = collex.getState();
-        CollectionExerciseDTO.CollectionExerciseState newState =
-                collectionExerciseTransitionState.transition(collex.getState(), event);
-        if (oldState != newState) {
-            collex.setState(newState);
-            updateCollectionExercise(collex);
-        }
-    }
-
-    @Override
-    public void transitionCollectionExercise(final UUID collectionExerciseId,
-                                             final CollectionExerciseDTO.CollectionExerciseEvent event)
-            throws CTPException {
-        CollectionExercise collex = findCollectionExercise(collectionExerciseId);
-
-        if (collex == null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("Cannot find collection exercise %s", collectionExerciseId));
-        }
-
-        transitionCollectionExercise(collex, event);
-    }
-
-    @Override
-    public void transitionScheduleCollectionExerciseToReadyToReview(final UUID collectionExerciseId)
-            throws CTPException {
-        CollectionExercise collex = findCollectionExercise(collectionExerciseId);
-
-        if (collex != null) {
-            transitionScheduleCollectionExerciseToReadyToReview(collex);
-        }
-    }
-
-    /**
-     * Method to validate the sample links for a collection exercise by ensuring that all associated SampleLinks are
-     * in the ACTIVE state
-     * @param collexId the collection exercise to validate
-     * @return true if the associated sample links are valid, false otherwise
-     */
-    private boolean validateSampleLinks(final UUID collexId) {
-        List<SampleLink> sampleLinks = this.sampleLinkRepository.findByCollectionExerciseId(collexId);
-        List<SampleLink> nonActiveSampleLinks = sampleLinks
-                .stream()
-                .filter(sl -> SampleLinkState.ACTIVE != sl.getState())
-                .collect(Collectors.toList());
-
-        return sampleLinks.size() > 0 && nonActiveSampleLinks.size() == 0;
-    }
-
-    @Override
-    public void transitionScheduleCollectionExerciseToReadyToReview(final CollectionExercise collectionExercise)
-            throws CTPException {
-        UUID collexId = collectionExercise.getId();
-
-        Map<String, String> searchStringMap = Collections.singletonMap("COLLECTION_EXERCISE",
-                collectionExercise.getId().toString());
-        String searchStringJson = new JSONObject(searchStringMap).toString();
-        Integer numberOfCollectionInstruments = collectionInstrumentSvcClient.countCollectionInstruments(
-                searchStringJson);
-        boolean sampleLinksValid = validateSampleLinks(collexId);
-        boolean shouldTransition = sampleLinksValid
-                && numberOfCollectionInstruments != null
-                && numberOfCollectionInstruments > 0;
-        log.info("ready_for_review transition check: sampleLinksValid: {}, numberOfCollectionInstruments: {},"
-                + " shouldTransition: {}", sampleLinksValid, numberOfCollectionInstruments, shouldTransition);
-        if (shouldTransition) {
-            transitionCollectionExercise(collectionExercise,
-                    CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_ADDED);
-        } else {
-            transitionCollectionExercise(collectionExercise,
-                    CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_DELETED);
-        }
-    }
-
-    /**
-     * Links a sample summary to a collection exercise and stores in db
-     *
-     * @param sampleSummaryId      the Id of the Sample summary to be linked
-     * @param collectionExerciseId the Id of the Sample summary to be linked
-     * @return sampleLink stored in database
-     */
-    SampleLink createLink(final UUID sampleSummaryId, final UUID collectionExerciseId) {
-        SampleLink sampleLink = new SampleLink();
-        sampleLink.setSampleSummaryId(sampleSummaryId);
-        sampleLink.setCollectionExerciseId(collectionExerciseId);
-        sampleLink.setState(SampleLinkState.INIT);
-        return sampleLinkRepository.saveAndFlush(sampleLink);
-    }
-
+  /**
+   * Links a sample summary to a collection exercise and stores in db
+   *
+   * @param sampleSummaryId the Id of the Sample summary to be linked
+   * @param collectionExerciseId the Id of the Sample summary to be linked
+   * @return sampleLink stored in database
+   */
+  SampleLink createLink(final UUID sampleSummaryId, final UUID collectionExerciseId) {
+    SampleLink sampleLink = new SampleLink();
+    sampleLink.setSampleSummaryId(sampleSummaryId);
+    sampleLink.setCollectionExerciseId(collectionExerciseId);
+    sampleLink.setState(SampleLinkState.INIT);
+    return sampleLinkRepository.saveAndFlush(sampleLink);
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImpl.java
@@ -1,25 +1,5 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
-import ma.glasnost.orika.MapperFacade;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.stereotype.Service;
-import uk.gov.ons.ctp.common.error.CTPException;
-import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
-import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
-import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEventPublisher;
-import uk.gov.ons.ctp.response.collection.exercise.repository.EventRepository;
-import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
-import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
-import uk.gov.ons.ctp.response.collection.exercise.schedule.SchedulerConfiguration;
-import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
-import uk.gov.ons.ctp.response.collection.exercise.service.EventChangeHandler;
-import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
-
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Date;
@@ -29,266 +9,274 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEventPublisher;
+import uk.gov.ons.ctp.response.collection.exercise.repository.EventRepository;
+import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
+import uk.gov.ons.ctp.response.collection.exercise.schedule.SchedulerConfiguration;
+import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventChangeHandler;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
 @Service
 @Slf4j
 public class EventServiceImpl implements EventService {
 
-    @Autowired
-    private CollectionExerciseService collectionExerciseService;
+  @Autowired private CollectionExerciseService collectionExerciseService;
 
-    @Autowired
-    private EventRepository eventRepository;
+  @Autowired private EventRepository eventRepository;
 
-    @Autowired
-    private EventChangeHandler[] changeHandlers;
+  @Autowired private EventChangeHandler[] changeHandlers;
 
-    @Autowired
-    private EventValidator eventValidator;
+  @Autowired private EventValidator eventValidator;
 
-    @Autowired
-    private Scheduler scheduler;
+  @Autowired private Scheduler scheduler;
 
-    @Override
-    public Event createEvent(EventDTO eventDto) throws CTPException {
-        UUID collexId = eventDto.getCollectionExerciseId();
-        CollectionExercise collex =
-                this.collectionExerciseService.findCollectionExercise(collexId);
+  @Override
+  public Event createEvent(EventDTO eventDto) throws CTPException {
+    UUID collexId = eventDto.getCollectionExerciseId();
+    CollectionExercise collex = this.collectionExerciseService.findCollectionExercise(collexId);
 
-        if (collex == null) {
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                    String.format("Collection exercise %s does not exist", eventDto.getCollectionExerciseId()));
+    if (collex == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format(
+              "Collection exercise %s does not exist", eventDto.getCollectionExerciseId()));
+    } else {
+      Event existing =
+          this.eventRepository.findOneByCollectionExerciseAndTag(collex, eventDto.getTag());
+
+      if (existing != null) {
+        throw new CTPException(
+            CTPException.Fault.RESOURCE_VERSION_CONFLICT,
+            String.format(
+                "Event %s already exists for collection exercise %s",
+                eventDto.getTag(), collex.getId()));
+      } else {
+        Event event = new Event();
+
+        event.setCollectionExercise(collex);
+        event.setTag(eventDto.getTag());
+        event.setId(UUID.randomUUID());
+        event.setTimestamp(new Timestamp(eventDto.getTimestamp().getTime()));
+        event.setCreated(new Timestamp(new Date().getTime()));
+
+        event = eventRepository.save(event);
+
+        fireEventChangeHandlers(CollectionExerciseEventPublisher.MessageType.EventCreated, event);
+
+        return event;
+      }
+    }
+  }
+
+  @Override
+  public List<Event> getEvents(UUID collexId) throws CTPException {
+    return this.eventRepository.findByCollectionExerciseId(collexId);
+  }
+
+  @Override
+  public Event updateEvent(UUID collexUuid, String tag, Date date) throws CTPException {
+    CollectionExercise collex = this.collectionExerciseService.findCollectionExercise(collexUuid);
+    if (collex != null) {
+      Event event = this.eventRepository.findOneByCollectionExerciseAndTag(collex, tag);
+      if (event != null) {
+        event.setTimestamp(new Timestamp(date.getTime()));
+
+        List<Event> existingEvents = this.eventRepository.findByCollectionExercise(collex);
+
+        if (this.eventValidator.validate(existingEvents, event, collex.getState())) {
+
+          this.eventRepository.save(event);
+
+          fireEventChangeHandlers(CollectionExerciseEventPublisher.MessageType.EventUpdated, event);
         } else {
-            Event existing = this.eventRepository.findOneByCollectionExerciseAndTag(collex, eventDto.getTag());
-
-            if (existing != null) {
-                throw new CTPException(CTPException.Fault.RESOURCE_VERSION_CONFLICT,
-                        String.format("Event %s already exists for collection exercise %s",
-                                eventDto.getTag(), collex.getId()));
-            } else {
-                Event event = new Event();
-
-                event.setCollectionExercise(collex);
-                event.setTag(eventDto.getTag());
-                event.setId(UUID.randomUUID());
-                event.setTimestamp(new Timestamp(eventDto.getTimestamp().getTime()));
-                event.setCreated(new Timestamp(new Date().getTime()));
-
-                event = eventRepository.save(event);
-
-                fireEventChangeHandlers(CollectionExerciseEventPublisher.MessageType.EventCreated, event);
-
-                return event;
-            }
+          throw new CTPException(
+              CTPException.Fault.BAD_REQUEST, String.format("Invalid event update"));
         }
+
+      } else {
+        throw new CTPException(
+            CTPException.Fault.RESOURCE_NOT_FOUND,
+            String.format("Event %s does not exist", event.getId()));
+      }
+
+      return event;
+    } else {
+      throw new CTPException(
+          CTPException.Fault.BAD_REQUEST,
+          String.format("Collection exercise %s does not exist", collexUuid));
     }
+  }
 
-    @Override
-    public List<Event> getEvents(UUID collexId) throws CTPException {
-        return this.eventRepository.findByCollectionExerciseId(collexId);
+  @Override
+  public Event getEvent(UUID collexUuid, String tag) throws CTPException {
+    CollectionExercise collex = this.collectionExerciseService.findCollectionExercise(collexUuid);
+    if (collex != null) {
+      Event event = this.eventRepository.findOneByCollectionExerciseAndTag(collex, tag);
+      if (event != null) {
+        return event;
+      } else {
+        throw new CTPException(
+            CTPException.Fault.RESOURCE_NOT_FOUND,
+            String.format("Event %s does not exist", event.getId()));
+      }
+
+    } else {
+      throw new CTPException(
+          CTPException.Fault.BAD_REQUEST,
+          String.format("Collection exercise %s does not exist", collex.getId()));
     }
+  }
 
-    @Override
-    public Event updateEvent(UUID collexUuid, String tag, Date date) throws CTPException
-    {
-        CollectionExercise collex = this.collectionExerciseService.findCollectionExercise(collexUuid);
-        if (collex != null)
-        {
-            Event event = this.eventRepository.findOneByCollectionExerciseAndTag(collex, tag);
-            if (event != null)
-            {
-                event.setTimestamp(new Timestamp(date.getTime()));
+  @Override
+  public Event getEvent(UUID eventId) throws CTPException {
+    Event event = this.eventRepository.findOneById(eventId);
 
-                List<Event> existingEvents = this.eventRepository.findByCollectionExercise(collex);
-
-                if (this.eventValidator.validate(existingEvents, event, collex.getState())) {
-
-                    this.eventRepository.save(event);
-
-                    fireEventChangeHandlers(CollectionExerciseEventPublisher.MessageType.EventUpdated, event);
-                } else {
-                    throw new CTPException(CTPException.Fault.BAD_REQUEST,
-                            String.format("Invalid event update"));
-                }
-
-            }
-            else
-                {
-                    throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                            String.format("Event %s does not exist", event.getId()));
-                }
-
-                return event;
-        }
-        else
-            {
-                throw new CTPException(CTPException.Fault.BAD_REQUEST,
-                        String.format("Collection exercise %s does not exist", collexUuid));
-            }
-
-
+    if (event == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND, String.format("Event %s does not exist", event));
+    } else {
+      return event;
     }
+  }
 
-    @Override
-    public Event getEvent(UUID collexUuid, String tag) throws CTPException
-    {
-        CollectionExercise collex = this.collectionExerciseService.findCollectionExercise(collexUuid);
-        if (collex != null)
-        {
-            Event event = this.eventRepository.findOneByCollectionExerciseAndTag(collex, tag);
-            if (event != null)
-            {
-                return event;
-            }
-            else
-            {
-                throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                        String.format("Event %s does not exist", event.getId()));
-            }
+  public Event deleteEvent(UUID collexUuid, String tag) throws CTPException {
 
-        }
-        else
-        {
-            throw new CTPException(CTPException.Fault.BAD_REQUEST,
-                    String.format("Collection exercise %s does not exist", collex.getId()));
-        }
+    CollectionExercise collex = this.collectionExerciseService.findCollectionExercise(collexUuid);
+    if (collex != null) {
+      Event event = this.eventRepository.findOneByCollectionExerciseAndTag(collex, tag);
+      if (event != null) {
+        event.setDeleted(true);
+        this.eventRepository.delete(event);
 
+        fireEventChangeHandlers(CollectionExerciseEventPublisher.MessageType.EventDeleted, event);
+        return event;
+      } else {
+        throw new CTPException(
+            CTPException.Fault.RESOURCE_NOT_FOUND, String.format("Event %s does not exist", tag));
+      }
+
+    } else {
+      throw new CTPException(
+          CTPException.Fault.BAD_REQUEST,
+          String.format("Collection exercise %s does not exist", collex.getId()));
     }
+  }
 
-    @Override
-    public Event getEvent(UUID eventId) throws CTPException {
-        Event event = this.eventRepository.findOneById(eventId);
-
-        if (event == null){
-            throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, String.format("Event %s does not exist",
-                    event));
-        } else {
-            return event;
-        }
-    }
-
-    public Event deleteEvent(UUID collexUuid, String tag) throws CTPException
-    {
-
-        CollectionExercise collex = this.collectionExerciseService.findCollectionExercise(collexUuid);
-        if (collex != null)
-        {
-            Event event = this.eventRepository.findOneByCollectionExerciseAndTag(collex, tag);
-            if (event != null)
-            {
-                event.setDeleted(true);
-                this.eventRepository.delete(event);
-
-                fireEventChangeHandlers(CollectionExerciseEventPublisher.MessageType.EventDeleted, event);
-                return event;
-            }
-            else
-            {
-                throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND,
-                        String.format("Event %s does not exist", tag));
-            }
-
-        }
-        else
-        {
-            throw new CTPException(CTPException.Fault.BAD_REQUEST,
-                    String.format("Collection exercise %s does not exist", collex.getId()));
-
-        }
-
-    }
-
-    /**
-     * Method that is called whenever a change occurs to a collection exercise event
-     * @param messageType the type of change
-     * @param event the event to which the change occurred
-     */
-    private void fireEventChangeHandlers(final CollectionExerciseEventPublisher.MessageType messageType,
-                                         final Event event) {
-        Arrays.stream(this.changeHandlers).forEach(handler -> {
-            try {
+  /**
+   * Method that is called whenever a change occurs to a collection exercise event
+   *
+   * @param messageType the type of change
+   * @param event the event to which the change occurred
+   */
+  private void fireEventChangeHandlers(
+      final CollectionExerciseEventPublisher.MessageType messageType, final Event event) {
+    Arrays.stream(this.changeHandlers)
+        .forEach(
+            handler -> {
+              try {
                 handler.handleEventLifecycle(messageType, event);
-            } catch (CTPException e) {
-                log.error("Failed to handle event change for {} of {} - {} ({})",
-                        messageType, event.getId(), e.getMessage(), e.getFault());
-            }
-        });
+              } catch (CTPException e) {
+                log.error(
+                    "Failed to handle event change for {} of {} - {} ({})",
+                    messageType,
+                    event.getId(),
+                    e.getMessage(),
+                    e.getFault());
+              }
+            });
+  }
+
+  @Override
+  public List<Event> getOutstandingEvents() {
+    return this.eventRepository.findByMessageSentNull();
+  }
+
+  @Override
+  public void setEventMessageSent(UUID eventId) throws CTPException {
+    Event event = getEvent(eventId);
+
+    event.setMessageSent(new Timestamp(new Date().getTime()));
+
+    this.eventRepository.save(event);
+  }
+
+  @Override
+  public void clearEventMessageSent(UUID eventId) throws CTPException {
+    Event event = getEvent(eventId);
+
+    event.setMessageSent(null);
+
+    this.eventRepository.save(event);
+  }
+
+  /**
+   * 'scheduled' is defined as having events for mps, go_live, return_by and exercise_end
+   *
+   * @param collexUuid the collection exercise to check for scheduled
+   * @return true if the mandatory events are all present, false otherwise
+   * @throws CTPException if collection exercise not found etc
+   */
+  @Override
+  public boolean isScheduled(UUID collexUuid) throws CTPException {
+    Map<String, Event> events =
+        getEvents(collexUuid)
+            .stream()
+            .collect(Collectors.toMap(Event::getTag, Function.identity()));
+
+    int numberOfMandatoryEvents =
+        Arrays.stream(Tag.values()).filter(Tag::isMandatory).collect(Collectors.toList()).size();
+
+    return Arrays.stream(Tag.values())
+            .filter(Tag::isMandatory)
+            .map(t -> events.get(t.name()))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList())
+            .size()
+        >= numberOfMandatoryEvents;
+  }
+
+  /**
+   * Unschedule a collection exercise event
+   *
+   * @param event the event to unschedule
+   * @throws CTPException thrown if error occurred scheduling event
+   */
+  @Override
+  public void unscheduleEvent(final Event event) throws CTPException {
+    try {
+      SchedulerConfiguration.unscheduleEvent(this.scheduler, event);
+    } catch (SchedulerException e) {
+      throw new CTPException(
+          CTPException.Fault.SYSTEM_ERROR,
+          String.format("Error unscheduling event %s", event.getId()),
+          e);
     }
+  }
 
-    @Override
-    public List<Event> getOutstandingEvents() {
-        return this.eventRepository.findByMessageSentNull();
+  /**
+   * Schedule a collection exercise event
+   *
+   * @param event the event to shchedule
+   * @throws CTPException thrown if error occurred scheduling event
+   */
+  @Override
+  public void scheduleEvent(final Event event) throws CTPException {
+    try {
+      SchedulerConfiguration.scheduleEvent(this.scheduler, event);
+    } catch (SchedulerException e) {
+      throw new CTPException(
+          CTPException.Fault.SYSTEM_ERROR,
+          String.format("Error scheduling event %s", event.getId()),
+          e);
     }
-
-    @Override
-    public void setEventMessageSent(UUID eventId) throws CTPException {
-        Event event = getEvent(eventId);
-
-        event.setMessageSent(new Timestamp(new Date().getTime()));
-
-        this.eventRepository.save(event);
-    }
-
-    @Override
-    public void clearEventMessageSent(UUID eventId) throws CTPException {
-        Event event = getEvent(eventId);
-
-        event.setMessageSent(null);
-
-        this.eventRepository.save(event);
-    }
-
-    /**
-     * 'scheduled' is defined as having events for mps, go_live, return_by and exercise_end
-     * @param collexUuid  the collection exercise to check for scheduled
-     * @return true if the mandatory events are all present, false otherwise
-     * @throws CTPException if collection exercise not found etc
-     */
-    @Override
-    public boolean isScheduled(UUID collexUuid) throws CTPException {
-        Map<String, Event> events = getEvents(collexUuid).stream().collect(
-                Collectors.toMap(Event::getTag, Function.identity())
-        );
-
-        int numberOfMandatoryEvents = Arrays.stream(Tag.values())
-                .filter(Tag::isMandatory).collect(Collectors.toList()).size();
-
-        return Arrays.stream(Tag.values())
-                .filter(Tag::isMandatory)
-                .map(t -> events.get(t.name()))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList())
-                .size() >= numberOfMandatoryEvents;
-
-    }
-
-    /**
-     * Unschedule a collection exercise event
-     * @param event the event to unschedule
-     * @throws CTPException thrown if error occurred scheduling event
-     */
-    @Override
-    public void unscheduleEvent(final Event event) throws CTPException {
-        try {
-            SchedulerConfiguration.unscheduleEvent(this.scheduler, event);
-        } catch (SchedulerException e) {
-            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, String.format("Error unscheduling event %s",
-                    event.getId()), e);
-        }
-    }
-
-    /**
-     * Schedule a collection exercise event
-     * @param event the event to shchedule
-     * @throws CTPException thrown if error occurred scheduling event
-     */
-    @Override
-    public void scheduleEvent(final Event event) throws CTPException {
-        try {
-            SchedulerConfiguration.scheduleEvent(this.scheduler, event);
-        } catch (SchedulerException e) {
-            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, String.format("Error scheduling event %s",
-                    event.getId()), e);
-        }
-    }
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventValidator.java
@@ -1,135 +1,139 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
-import java.sql.Timestamp;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.List;
-
 public class EventValidator {
 
-    /**q
-     * Validates the events timestamps are in the correct order and the updated event can be updated,
-     * i.e is not a mandatory or reminder event.
-     * @param existingEvents
-     * @param updatedEvent
-     * @return
-     */
-    public boolean validate(final List<Event> existingEvents, final Event updatedEvent,
-                            final CollectionExerciseDTO.CollectionExerciseState collectionExerciseState) {
+  /**
+   * q Validates the events timestamps are in the correct order and the updated event can be
+   * updated, i.e is not a mandatory or reminder event.
+   *
+   * @param existingEvents
+   * @param updatedEvent
+   * @return
+   */
+  public boolean validate(
+      final List<Event> existingEvents,
+      final Event updatedEvent,
+      final CollectionExerciseDTO.CollectionExerciseState collectionExerciseState) {
 
-        // Can only update reminders of the non mandatory events when READY_FOR_LIVE
-        if ((collectionExerciseState.equals(CollectionExerciseDTO.CollectionExerciseState.READY_FOR_LIVE)
-                || collectionExerciseState.equals(CollectionExerciseDTO.CollectionExerciseState.LIVE))
-                && (isMandatory(updatedEvent) || !isReminder(updatedEvent))) {
-            return false;
-        }
-
-        Optional<Event> existingEvent = existingEvents.stream().findFirst().filter(
-                event -> event.getTag().equals(updatedEvent.getTag()));
-
-        // Events can't be updated if already past or updated date is in the past
-        if ((existingEvent.isPresent() && isEventInPast(existingEvent.get()))
-                || isEventInPast(updatedEvent)) {
-            return false;
-        }
-
-        Map<String, Event> eventMap = generateEventsMap(existingEvents, updatedEvent);
-
-        return validateMandatoryEvents(eventMap) && validateNonMandatoryEvents(eventMap);
+    // Can only update reminders of the non mandatory events when READY_FOR_LIVE
+    if ((collectionExerciseState.equals(
+                CollectionExerciseDTO.CollectionExerciseState.READY_FOR_LIVE)
+            || collectionExerciseState.equals(CollectionExerciseDTO.CollectionExerciseState.LIVE))
+        && (isMandatory(updatedEvent) || !isReminder(updatedEvent))) {
+      return false;
     }
 
-    /**
-     * Validates the dates which aren't mandatory for a collection exercise to be executed.
-     *  If the events exist it checks that reference period start before referencePeriodEnd and
-     *  all reminders are during the collection exercise.
-     * @param eventMap
-     * @return
-     */
-    private boolean validateNonMandatoryEvents(final Map<String, Event>eventMap) {
-        Event referencePeriodStart = eventMap.get(EventService.Tag.ref_period_start.toString());
-        Event referencePeriodEnd = eventMap.get(EventService.Tag.ref_period_end.toString());
+    Optional<Event> existingEvent =
+        existingEvents
+            .stream()
+            .findFirst()
+            .filter(event -> event.getTag().equals(updatedEvent.getTag()));
 
-        return referencePeriodInCorrectOrder(referencePeriodStart, referencePeriodEnd)
-                && remindersDuringExercise(eventMap);
+    // Events can't be updated if already past or updated date is in the past
+    if ((existingEvent.isPresent() && isEventInPast(existingEvent.get()))
+        || isEventInPast(updatedEvent)) {
+      return false;
     }
 
-    private boolean referencePeriodInCorrectOrder(final Event referencePeriodStart, final Event referencePeriodEnd) {
-        boolean isValid = true;
-        if (referencePeriodStart != null && referencePeriodEnd != null) {
-            isValid = referencePeriodStart.getTimestamp().before(referencePeriodEnd.getTimestamp());
-        }
-        return isValid;
+    Map<String, Event> eventMap = generateEventsMap(existingEvents, updatedEvent);
+
+    return validateMandatoryEvents(eventMap) && validateNonMandatoryEvents(eventMap);
+  }
+
+  /**
+   * Validates the dates which aren't mandatory for a collection exercise to be executed. If the
+   * events exist it checks that reference period start before referencePeriodEnd and all reminders
+   * are during the collection exercise.
+   *
+   * @param eventMap
+   * @return
+   */
+  private boolean validateNonMandatoryEvents(final Map<String, Event> eventMap) {
+    Event referencePeriodStart = eventMap.get(EventService.Tag.ref_period_start.toString());
+    Event referencePeriodEnd = eventMap.get(EventService.Tag.ref_period_end.toString());
+
+    return referencePeriodInCorrectOrder(referencePeriodStart, referencePeriodEnd)
+        && remindersDuringExercise(eventMap);
+  }
+
+  private boolean referencePeriodInCorrectOrder(
+      final Event referencePeriodStart, final Event referencePeriodEnd) {
+    boolean isValid = true;
+    if (referencePeriodStart != null && referencePeriodEnd != null) {
+      isValid = referencePeriodStart.getTimestamp().before(referencePeriodEnd.getTimestamp());
     }
+    return isValid;
+  }
 
+  private boolean remindersDuringExercise(final Map<String, Event> eventMap) {
+    Event goLive = eventMap.get(EventService.Tag.go_live.toString());
+    Event exerciseEnd = eventMap.get(EventService.Tag.exercise_end.toString());
 
-    private boolean remindersDuringExercise(final Map<String, Event>eventMap) {
-        Event goLive = eventMap.get(EventService.Tag.go_live.toString());
-        Event exerciseEnd = eventMap.get(EventService.Tag.exercise_end.toString());
+    Event reminder = eventMap.get(EventService.Tag.reminder.toString());
+    Event reminder2 = eventMap.get(EventService.Tag.reminder2.toString());
+    Event reminder3 = eventMap.get(EventService.Tag.reminder3.toString());
+    return eventDuringExercise(goLive, reminder, exerciseEnd)
+        && eventDuringExercise(goLive, reminder2, exerciseEnd)
+        && eventDuringExercise(goLive, reminder3, exerciseEnd);
+  }
 
-        Event reminder = eventMap.get(EventService.Tag.reminder.toString());
-        Event reminder2 = eventMap.get(EventService.Tag.reminder2.toString());
-        Event reminder3 = eventMap.get(EventService.Tag.reminder3.toString());
-        return eventDuringExercise(goLive, reminder, exerciseEnd)
-                && eventDuringExercise(goLive, reminder2, exerciseEnd)
-                && eventDuringExercise(goLive, reminder3, exerciseEnd);
-
+  private boolean eventDuringExercise(Event goLive, Event event, Event exerciseEnd) {
+    boolean isValid = true;
+    if (event != null) {
+      isValid =
+          goLive.getTimestamp().before(event.getTimestamp())
+              && event.getTimestamp().before(exerciseEnd.getTimestamp());
     }
+    return isValid;
+  }
 
-    private boolean eventDuringExercise(Event goLive, Event event, Event exerciseEnd) {
-        boolean isValid = true;
-        if(event != null) {
-            isValid = goLive.getTimestamp().before(event.getTimestamp())
-                    && event.getTimestamp().before(exerciseEnd.getTimestamp());
-        }
-        return isValid;
+  /**
+   * Validates the mandatory events are in the following order: MPS Go Live Return By Exercise End
+   */
+  private boolean validateMandatoryEvents(final Map<String, Event> eventMap) {
+    Event mpsEvent = eventMap.get(EventService.Tag.mps.toString());
+    Event goLiveEvent = eventMap.get(EventService.Tag.go_live.toString());
+    Event returnByEvent = eventMap.get(EventService.Tag.return_by.toString());
+    Event exerciseEndEvent = eventMap.get(EventService.Tag.exercise_end.toString());
+
+    return mpsEvent.getTimestamp().before(goLiveEvent.getTimestamp())
+        && goLiveEvent.getTimestamp().before(returnByEvent.getTimestamp())
+        && returnByEvent.getTimestamp().before(exerciseEndEvent.getTimestamp());
+  }
+
+  private Map<String, Event> generateEventsMap(
+      final List<Event> existingEvents, final Event updatedEvent) {
+    Map<String, Event> eventMap = new HashMap<>();
+    for (Event event : existingEvents) {
+      eventMap.put(event.getTag(), event);
     }
+    eventMap.put(updatedEvent.getTag(), updatedEvent);
 
-    /**
-     * Validates the mandatory events are in the following order:
-     * MPS
-     * Go Live
-     * Return By
-     * Exercise End
-     */
-    private boolean validateMandatoryEvents(final Map<String, Event> eventMap) {
-        Event mpsEvent = eventMap.get(EventService.Tag.mps.toString());
-        Event goLiveEvent = eventMap.get(EventService.Tag.go_live.toString());
-        Event returnByEvent = eventMap.get(EventService.Tag.return_by.toString());
-        Event exerciseEndEvent = eventMap.get(EventService.Tag.exercise_end.toString());
+    return eventMap;
+  }
 
-        return mpsEvent.getTimestamp().before(goLiveEvent.getTimestamp())
-                && goLiveEvent.getTimestamp().before(returnByEvent.getTimestamp())
-                && returnByEvent.getTimestamp().before(exerciseEndEvent.getTimestamp());
-    }
+  private boolean isEventInPast(final Event existingEvent) {
+    Timestamp currentTimestamp = new Timestamp(Calendar.getInstance().getTime().getTime());
+    return existingEvent.getTimestamp().before(currentTimestamp);
+  }
 
-    private Map<String, Event> generateEventsMap(final List<Event> existingEvents, final Event updatedEvent) {
-        Map<String, Event> eventMap = new HashMap<>();
-        for (Event event : existingEvents) {
-            eventMap.put(event.getTag(), event);
-        }
-        eventMap.put(updatedEvent.getTag(), updatedEvent);
+  private boolean isMandatory(final Event updatedEvent) {
+    return EventService.Tag.valueOf(updatedEvent.getTag()).isMandatory();
+  }
 
-        return eventMap;
-    }
-
-    private boolean isEventInPast(final Event existingEvent) {
-        Timestamp currentTimestamp = new Timestamp(Calendar.getInstance().getTime().getTime());
-        return existingEvent.getTimestamp().before(currentTimestamp);
-    }
-
-    private boolean isMandatory(final Event updatedEvent) {
-        return EventService.Tag.valueOf(updatedEvent.getTag()).isMandatory();
-    }
-
-    private boolean isReminder(final Event updatedEvent) {
-        return EventService.Tag.valueOf(updatedEvent.getTag()).equals(EventService.Tag.reminder)
-                || EventService.Tag.valueOf(updatedEvent.getTag()).equals(EventService.Tag.reminder2)
-                || EventService.Tag.valueOf(updatedEvent.getTag()).equals(EventService.Tag.reminder3);
-    }
+  private boolean isReminder(final Event updatedEvent) {
+    return EventService.Tag.valueOf(updatedEvent.getTag()).equals(EventService.Tag.reminder)
+        || EventService.Tag.valueOf(updatedEvent.getTag()).equals(EventService.Tag.reminder2)
+        || EventService.Tag.valueOf(updatedEvent.getTag()).equals(EventService.Tag.reminder3);
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ExerciseSampleUnitGroupServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ExerciseSampleUnitGroupServiceImpl.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -14,50 +15,47 @@ import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitReposito
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.ExerciseSampleUnitGroupService;
 
-import java.util.List;
-
-/**
- * Implementation to deal with sampleUnitGroups.
- */
+/** Implementation to deal with sampleUnitGroups. */
 @Service
 @Slf4j
 public class ExerciseSampleUnitGroupServiceImpl implements ExerciseSampleUnitGroupService {
 
   private static final int TRANSACTION_TIMEOUT = 60;
 
-  @Autowired
-  private SampleUnitRepository sampleUnitRepo;
+  @Autowired private SampleUnitRepository sampleUnitRepo;
 
-  @Autowired
-  private SampleUnitGroupRepository sampleUnitGroupRepo;
+  @Autowired private SampleUnitGroupRepository sampleUnitGroupRepo;
 
   @Override
-  public Long countByStateFKAndCollectionExercise(SampleUnitGroupDTO.SampleUnitGroupState state,
-      CollectionExercise exercise) {
+  public Long countByStateFKAndCollectionExercise(
+      SampleUnitGroupDTO.SampleUnitGroupState state, CollectionExercise exercise) {
     return sampleUnitGroupRepo.countByStateFKAndCollectionExercise(state, exercise);
   }
 
   @Override
   public List<ExerciseSampleUnitGroup>
-    findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
-      SampleUnitGroupDTO.SampleUnitGroupState state,
-      List<CollectionExercise> exercises,
-      List<Integer> excludedGroups,
-      Pageable pageable) {
-    return sampleUnitGroupRepo.findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
-        state,
-        exercises,
-        excludedGroups,
-        pageable);
+      findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
+          SampleUnitGroupDTO.SampleUnitGroupState state,
+          List<CollectionExercise> exercises,
+          List<Integer> excludedGroups,
+          Pageable pageable) {
+    return sampleUnitGroupRepo
+        .findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
+            state, exercises, excludedGroups, pageable);
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED, readOnly = false, timeout = TRANSACTION_TIMEOUT)
-  public ExerciseSampleUnitGroup storeExerciseSampleUnitGroup(ExerciseSampleUnitGroup sampleUnitGroup,
-      List<ExerciseSampleUnit> sampleUnits) {
-    ExerciseSampleUnitGroup savedExerciseSampleUnitGroup = sampleUnitGroupRepo.save(sampleUnitGroup);
+  @Transactional(
+      propagation = Propagation.REQUIRED,
+      readOnly = false,
+      timeout = TRANSACTION_TIMEOUT)
+  public ExerciseSampleUnitGroup storeExerciseSampleUnitGroup(
+      ExerciseSampleUnitGroup sampleUnitGroup, List<ExerciseSampleUnit> sampleUnits) {
+    ExerciseSampleUnitGroup savedExerciseSampleUnitGroup =
+        sampleUnitGroupRepo.save(sampleUnitGroup);
     if (sampleUnits.isEmpty()) {
-      log.warn("No sampleUnits updated for SampleUnitGroup {}", sampleUnitGroup.getSampleUnitGroupPK());
+      log.warn(
+          "No sampleUnits updated for SampleUnitGroup {}", sampleUnitGroup.getSampleUnitGroupPK());
     } else {
       sampleUnitRepo.save(sampleUnits);
     }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ExerciseSampleUnitServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ExerciseSampleUnitServiceImpl.java
@@ -1,23 +1,18 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
 import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.collection.exercise.service.ExerciseSampleUnitService;
 
-/**
- * Implementation to deal with sampleUnits.
- */
+/** Implementation to deal with sampleUnits. */
 @Service
 public class ExerciseSampleUnitServiceImpl implements ExerciseSampleUnitService {
 
-  @Autowired
-  private SampleUnitRepository sampleUnitRepo;
+  @Autowired private SampleUnitRepository sampleUnitRepo;
 
   @Override
   public List<ExerciseSampleUnit> findBySampleUnitGroup(ExerciseSampleUnitGroup sampleUnitGroup) {

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -1,5 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -29,191 +35,193 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
-import java.util.function.Predicate;
-
-/**
- * The implementation of the SampleService
- */
+/** The implementation of the SampleService */
 @Service
 @Slf4j
 public class SampleServiceImpl implements SampleService {
 
-    private static final int TRANSACTION_TIMEOUT = 60;
+  private static final int TRANSACTION_TIMEOUT = 60;
 
-    @Autowired
-    private PartySvcClient partySvcClient;
+  @Autowired private PartySvcClient partySvcClient;
 
-    @Autowired
-    private SampleLinkRepository sampleLinkRepository;
+  @Autowired private SampleLinkRepository sampleLinkRepository;
 
-    @Autowired
-    private SampleUnitRepository sampleUnitRepo;
+  @Autowired private SampleUnitRepository sampleUnitRepo;
 
-    @Autowired
-    private SampleUnitGroupRepository sampleUnitGroupRepo;
+  @Autowired private SampleUnitGroupRepository sampleUnitGroupRepo;
 
-    @Autowired
-    private CollectionExerciseRepository collectRepo;
+  @Autowired private CollectionExerciseRepository collectRepo;
 
-    @Autowired
-    private SampleSvcClient sampleSvcClient;
+  @Autowired private SampleSvcClient sampleSvcClient;
 
-    @Autowired
-    @Qualifier("collectionExercise")
-    private StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent> collectionExerciseTransitionState;
+  @Autowired
+  @Qualifier("collectionExercise")
+  private StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent>
+      collectionExerciseTransitionState;
 
-    @Autowired
-    private ValidateSampleUnits validate;
+  @Autowired private ValidateSampleUnits validate;
 
-    @Autowired
-    private SampleUnitDistributor distributor;
+  @Autowired private SampleUnitDistributor distributor;
 
-    /**
-     * Method to get all the validation errors for a sample unit
-     * @param su a sample unit
-     * @return a dto containing all the validation errors
-     */
-    private static SampleUnitValidationErrorDTO validateSampleUnit(final ExerciseSampleUnit su) {
-        SampleUnitValidationErrorDTO dto = new SampleUnitValidationErrorDTO();
+  /**
+   * Method to get all the validation errors for a sample unit
+   *
+   * @param su a sample unit
+   * @return a dto containing all the validation errors
+   */
+  private static SampleUnitValidationErrorDTO validateSampleUnit(final ExerciseSampleUnit su) {
+    SampleUnitValidationErrorDTO dto = new SampleUnitValidationErrorDTO();
 
-        dto.setSampleUnitRef(su.getSampleUnitRef());
-        List<SampleUnitValidationErrorDTO.ValidationError> errors = new ArrayList<>();
+    dto.setSampleUnitRef(su.getSampleUnitRef());
+    List<SampleUnitValidationErrorDTO.ValidationError> errors = new ArrayList<>();
 
-        if (su.getCollectionInstrumentId() == null || !(su.getCollectionInstrumentId() instanceof UUID)) {
-            errors.add(SampleUnitValidationErrorDTO.ValidationError.MISSING_COLLECTION_INSTRUMENT);
-        }
-        if (su.getPartyId() == null || !(su.getPartyId() instanceof UUID)) {
-            errors.add(SampleUnitValidationErrorDTO.ValidationError.MISSING_PARTY);
-        }
-
-        SampleUnitValidationErrorDTO.ValidationError[] errorArray =
-                errors.toArray(new SampleUnitValidationErrorDTO.ValidationError[errors.size()]);
-        dto.setErrors(errorArray);
-
-        return dto;
+    if (su.getCollectionInstrumentId() == null
+        || !(su.getCollectionInstrumentId() instanceof UUID)) {
+      errors.add(SampleUnitValidationErrorDTO.ValidationError.MISSING_COLLECTION_INSTRUMENT);
+    }
+    if (su.getPartyId() == null || !(su.getPartyId() instanceof UUID)) {
+      errors.add(SampleUnitValidationErrorDTO.ValidationError.MISSING_PARTY);
     }
 
-    @Override
-    public SampleUnitsRequestDTO requestSampleUnits(final UUID id) throws CTPException {
+    SampleUnitValidationErrorDTO.ValidationError[] errorArray =
+        errors.toArray(new SampleUnitValidationErrorDTO.ValidationError[errors.size()]);
+    dto.setErrors(errorArray);
 
-        SampleUnitsRequestDTO replyDTO = null;
+    return dto;
+  }
 
-        CollectionExercise collectionExercise = collectRepo.findOneById(id);
+  @Override
+  public SampleUnitsRequestDTO requestSampleUnits(final UUID id) throws CTPException {
 
-        // Check collection exercise exists
-        if (collectionExercise != null) {
-            replyDTO = sampleSvcClient.requestSampleUnits(collectionExercise);
+    SampleUnitsRequestDTO replyDTO = null;
 
-            if (replyDTO != null && replyDTO.getSampleUnitsTotal() > 0) {
+    CollectionExercise collectionExercise = collectRepo.findOneById(id);
 
-                List<SampleLink> sampleLinks = sampleLinkRepository.findByCollectionExerciseId(
-                        collectionExercise.getId());
-                for (SampleLink samplelink : sampleLinks) {
-                    partySvcClient.linkSampleSummaryId(samplelink.getSampleSummaryId().toString(),
-                            collectionExercise.getId().toString());
-                }
+    // Check collection exercise exists
+    if (collectionExercise != null) {
+      replyDTO = sampleSvcClient.requestSampleUnits(collectionExercise);
 
-                collectionExercise.setSampleSize(replyDTO.getSampleUnitsTotal());
-                collectionExercise.setState(collectionExerciseTransitionState.transition(collectionExercise.getState(),
-                        CollectionExerciseEvent.EXECUTE));
-                collectRepo.saveAndFlush(collectionExercise);
-            }
-        }
-        return replyDTO;
-    }
+      if (replyDTO != null && replyDTO.getSampleUnitsTotal() > 0) {
 
-    /**
-     * Accepts the sample unit from the sample service. This checks that this is
-     * dealing with the initial creation of the sample, no additions of sample
-     * units to a sample unit group, no updates to a sample unit.
-     *
-     * @param sampleUnit the sample unit from the message.
-     * @return the saved sample unit.
-     */
-    @Transactional(propagation = Propagation.REQUIRED, readOnly = false, timeout = TRANSACTION_TIMEOUT)
-    @Override
-    public ExerciseSampleUnit acceptSampleUnit(SampleUnit sampleUnit) throws CTPException {
-        ExerciseSampleUnit exerciseSampleUnit = null;
-
-        CollectionExercise collectionExercise = collectRepo.findOneById(
-                UUID.fromString(sampleUnit.getCollectionExerciseId()));
-
-        // Check collection exercise exists
-        if (collectionExercise != null) {
-            // Check Sample Unit doesn't already exist for collection exercise
-            if (!sampleUnitRepo.tupleExists(collectionExercise.getExercisePK(), sampleUnit.getSampleUnitRef(),
-                    sampleUnit.getSampleUnitType())) {
-
-                ExerciseSampleUnitGroup sampleUnitGroup = new ExerciseSampleUnitGroup();
-                sampleUnitGroup.setCollectionExercise(collectionExercise);
-                sampleUnitGroup.setFormType(sampleUnit.getFormType());
-                sampleUnitGroup.setStateFK(SampleUnitGroupState.INIT);
-                sampleUnitGroup.setCreatedDateTime(new Timestamp(new Date().getTime()));
-                sampleUnitGroup = sampleUnitGroupRepo.saveAndFlush(sampleUnitGroup);
-
-                exerciseSampleUnit = new ExerciseSampleUnit();
-                exerciseSampleUnit.setSampleUnitGroup(sampleUnitGroup);
-                exerciseSampleUnit.setSampleUnitRef(sampleUnit.getSampleUnitRef());
-                exerciseSampleUnit.setSampleUnitType(SampleUnitDTO.SampleUnitType.valueOf(sampleUnit.getSampleUnitType()));
-
-                sampleUnitRepo.saveAndFlush(exerciseSampleUnit);
-
-                if (sampleUnitRepo.totalByExercisePK(collectionExercise.getExercisePK()) == collectionExercise
-                        .getSampleSize()) {
-                    collectionExercise.setState(collectionExerciseTransitionState.transition(collectionExercise.getState(),
-                            CollectionExerciseEvent.EXECUTION_COMPLETE));
-                    collectionExercise.setActualExecutionDateTime(new Timestamp(new Date().getTime()));
-                    collectRepo.saveAndFlush(collectionExercise);
-                }
-
-            } else {
-                log.warn("SampleUnitRef {} with  setSampleUnitTypeFK {} already exists for CollectionExercise {}",
-                        sampleUnit.getSampleUnitRef(),
-                        sampleUnit.getSampleUnitType(), sampleUnit.getCollectionExerciseId());
-            }
-        } else {
-            log.error("No CollectionExercise {} for SampleUnit Ref: {} Type: {}, FormType: {}",
-                    sampleUnit.getCollectionExerciseId(),
-                    sampleUnit.getSampleUnitRef(), sampleUnit.getSampleUnitType(), sampleUnit.getFormType());
+        List<SampleLink> sampleLinks =
+            sampleLinkRepository.findByCollectionExerciseId(collectionExercise.getId());
+        for (SampleLink samplelink : sampleLinks) {
+          partySvcClient.linkSampleSummaryId(
+              samplelink.getSampleSummaryId().toString(), collectionExercise.getId().toString());
         }
 
-        return exerciseSampleUnit;
+        collectionExercise.setSampleSize(replyDTO.getSampleUnitsTotal());
+        collectionExercise.setState(
+            collectionExerciseTransitionState.transition(
+                collectionExercise.getState(), CollectionExerciseEvent.EXECUTE));
+        collectRepo.saveAndFlush(collectionExercise);
+      }
+    }
+    return replyDTO;
+  }
+
+  /**
+   * Accepts the sample unit from the sample service. This checks that this is dealing with the
+   * initial creation of the sample, no additions of sample units to a sample unit group, no updates
+   * to a sample unit.
+   *
+   * @param sampleUnit the sample unit from the message.
+   * @return the saved sample unit.
+   */
+  @Transactional(
+      propagation = Propagation.REQUIRED,
+      readOnly = false,
+      timeout = TRANSACTION_TIMEOUT)
+  @Override
+  public ExerciseSampleUnit acceptSampleUnit(SampleUnit sampleUnit) throws CTPException {
+    ExerciseSampleUnit exerciseSampleUnit = null;
+
+    CollectionExercise collectionExercise =
+        collectRepo.findOneById(UUID.fromString(sampleUnit.getCollectionExerciseId()));
+
+    // Check collection exercise exists
+    if (collectionExercise != null) {
+      // Check Sample Unit doesn't already exist for collection exercise
+      if (!sampleUnitRepo.tupleExists(
+          collectionExercise.getExercisePK(),
+          sampleUnit.getSampleUnitRef(),
+          sampleUnit.getSampleUnitType())) {
+
+        ExerciseSampleUnitGroup sampleUnitGroup = new ExerciseSampleUnitGroup();
+        sampleUnitGroup.setCollectionExercise(collectionExercise);
+        sampleUnitGroup.setFormType(sampleUnit.getFormType());
+        sampleUnitGroup.setStateFK(SampleUnitGroupState.INIT);
+        sampleUnitGroup.setCreatedDateTime(new Timestamp(new Date().getTime()));
+        sampleUnitGroup = sampleUnitGroupRepo.saveAndFlush(sampleUnitGroup);
+
+        exerciseSampleUnit = new ExerciseSampleUnit();
+        exerciseSampleUnit.setSampleUnitGroup(sampleUnitGroup);
+        exerciseSampleUnit.setSampleUnitRef(sampleUnit.getSampleUnitRef());
+        exerciseSampleUnit.setSampleUnitType(
+            SampleUnitDTO.SampleUnitType.valueOf(sampleUnit.getSampleUnitType()));
+
+        sampleUnitRepo.saveAndFlush(exerciseSampleUnit);
+
+        if (sampleUnitRepo.totalByExercisePK(collectionExercise.getExercisePK())
+            == collectionExercise.getSampleSize()) {
+          collectionExercise.setState(
+              collectionExerciseTransitionState.transition(
+                  collectionExercise.getState(), CollectionExerciseEvent.EXECUTION_COMPLETE));
+          collectionExercise.setActualExecutionDateTime(new Timestamp(new Date().getTime()));
+          collectRepo.saveAndFlush(collectionExercise);
+        }
+
+      } else {
+        log.warn(
+            "SampleUnitRef {} with  setSampleUnitTypeFK {}"
+                + " already exists for CollectionExercise {}",
+            sampleUnit.getSampleUnitRef(),
+            sampleUnit.getSampleUnitType(),
+            sampleUnit.getCollectionExerciseId());
+      }
+    } else {
+      log.error(
+          "No CollectionExercise {} for SampleUnit Ref: {} Type: {}, FormType: {}",
+          sampleUnit.getCollectionExerciseId(),
+          sampleUnit.getSampleUnitRef(),
+          sampleUnit.getSampleUnitType(),
+          sampleUnit.getFormType());
     }
 
-    @Override
-    public void validateSampleUnits() {
-        validate.validateSampleUnits();
-    }
+    return exerciseSampleUnit;
+  }
 
-    @Override
-    public void distributeSampleUnits(CollectionExercise exercise) {
-        distributor.distributeSampleUnits(exercise);
-    }
+  @Override
+  public void validateSampleUnits() {
+    validate.validateSampleUnits();
+  }
 
-    @Override
-    public SampleUnitValidationErrorDTO[] getValidationErrors(final UUID collectionExerciseId) {
-        List<ExerciseSampleUnit> sampleUnits = this.sampleUnitRepo.findInvalidByCollectionExercise(collectionExerciseId);
-        Predicate<ExerciseSampleUnit> validTest = su -> !(su.getPartyId() instanceof UUID)
-                || !(su.getCollectionInstrumentId() instanceof UUID);
-        return sampleUnits
-                .stream()
-                .filter(validTest)
-                .map(SampleServiceImpl::validateSampleUnit)
-                .toArray(SampleUnitValidationErrorDTO[]::new);
-    }
+  @Override
+  public void distributeSampleUnits(CollectionExercise exercise) {
+    distributor.distributeSampleUnits(exercise);
+  }
 
-    @Override
-    public List<SampleLink> getSampleLinksForSummary(final UUID sampleSummaryId) {
-        return this.sampleLinkRepository.findBySampleSummaryId(sampleSummaryId);
-    }
+  @Override
+  public SampleUnitValidationErrorDTO[] getValidationErrors(final UUID collectionExerciseId) {
+    List<ExerciseSampleUnit> sampleUnits =
+        this.sampleUnitRepo.findInvalidByCollectionExercise(collectionExerciseId);
+    Predicate<ExerciseSampleUnit> validTest =
+        su ->
+            !(su.getPartyId() instanceof UUID) || !(su.getCollectionInstrumentId() instanceof UUID);
+    return sampleUnits
+        .stream()
+        .filter(validTest)
+        .map(SampleServiceImpl::validateSampleUnit)
+        .toArray(SampleUnitValidationErrorDTO[]::new);
+  }
 
-    @Override
-    public SampleLink saveSampleLink(final SampleLink sampleLink) {
-        return this.sampleLinkRepository.saveAndFlush(sampleLink);
-    }
+  @Override
+  public List<SampleLink> getSampleLinksForSummary(final UUID sampleSummaryId) {
+    return this.sampleLinkRepository.findBySampleSummaryId(sampleSummaryId);
+  }
+
+  @Override
+  public SampleLink saveSampleLink(final SampleLink sampleLink) {
+    return this.sampleLinkRepository.saveAndFlush(sampleLink);
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/PublishEventToQueueHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/PublishEventToQueueHandler.java
@@ -9,19 +9,18 @@ import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEve
 import uk.gov.ons.ctp.response.collection.exercise.service.EventChangeHandler;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
-/**
- * EventChangeHandler to publish a message to a rabbit queue when the event changes
- */
+/** EventChangeHandler to publish a message to a rabbit queue when the event changes */
 @Component
 @Slf4j
 public final class PublishEventToQueueHandler implements EventChangeHandler {
-    @Autowired
-    private CollectionExerciseEventPublisher eventPublisher;
+  @Autowired private CollectionExerciseEventPublisher eventPublisher;
 
-    @Override
-    public void handleEventLifecycle(final CollectionExerciseEventPublisher.MessageType change, final Event event)
-            throws CTPException {
-        log.debug("Publishing {} message for {}", change, event);
-        eventPublisher.publishCollectionExerciseEvent(change, EventService.createEventDTOFromEvent(event));
-    }
+  @Override
+  public void handleEventLifecycle(
+      final CollectionExerciseEventPublisher.MessageType change, final Event event)
+      throws CTPException {
+    log.debug("Publishing {} message for {}", change, event);
+    eventPublisher.publishCollectionExerciseEvent(
+        change, EventService.createEventDTOFromEvent(event));
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduleEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduleEvent.java
@@ -9,32 +9,34 @@ import uk.gov.ons.ctp.response.collection.exercise.service.EventChangeHandler;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
 /**
- * EventChangeHandler to schedule and unschedule collection exercise events when CRUD operations occur
+ * EventChangeHandler to schedule and unschedule collection exercise events when CRUD operations
+ * occur
  */
 @Component
 public class ScheduleEvent implements EventChangeHandler {
-    @Autowired
-    private EventService eventService;
+  @Autowired private EventService eventService;
 
-    /**
-     * Schedules and unschedules events based on collection exericse event CRUD events
-     * @param change the type of change that occurred
-     * @param event the event to which the change occurred
-     * @throws CTPException
-     */
-    @Override
-    public void handleEventLifecycle(final CollectionExerciseEventPublisher.MessageType change, final Event event)
-            throws CTPException {
-        switch (change) {
-            case EventCreated:
-            case EventUpdated:
-                this.eventService.scheduleEvent(event);
-                break;
-            case EventDeleted:
-                this.eventService.unscheduleEvent(event);
-                break;
-            default:
-                // We don't care about Elapsed
-        }
+  /**
+   * Schedules and unschedules events based on collection exericse event CRUD events
+   *
+   * @param change the type of change that occurred
+   * @param event the event to which the change occurred
+   * @throws CTPException
+   */
+  @Override
+  public void handleEventLifecycle(
+      final CollectionExerciseEventPublisher.MessageType change, final Event event)
+      throws CTPException {
+    switch (change) {
+      case EventCreated:
+      case EventUpdated:
+        this.eventService.scheduleEvent(event);
+        break;
+      case EventDeleted:
+        this.eventService.unscheduleEvent(event);
+        break;
+      default:
+        // We don't care about Elapsed
     }
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStartDateHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStartDateHandler.java
@@ -11,60 +11,66 @@ import uk.gov.ons.ctp.response.collection.exercise.service.EventChangeHandler;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
 /**
- * EventChangeHandler to set the scheduledStartDate for a collection exercise when an mps event is created or updated
+ * EventChangeHandler to set the scheduledStartDate for a collection exercise when an mps event is
+ * created or updated
  */
 @Component
 @Slf4j
 public final class ScheduledStartDateHandler implements EventChangeHandler {
 
-    @Autowired
-    private CollectionExerciseService collectionExerciseService;
+  @Autowired private CollectionExerciseService collectionExerciseService;
 
-    @Override
-    public void handleEventLifecycle(CollectionExerciseEventPublisher.MessageType change, Event event) {
-        switch(change) {
-            case EventCreated:
-            case EventUpdated:
-                updateCollectionExerciseFromEvent(event);
-                break;
-            default:
-                break;
-        }
+  @Override
+  public void handleEventLifecycle(
+      CollectionExerciseEventPublisher.MessageType change, Event event) {
+    switch (change) {
+      case EventCreated:
+      case EventUpdated:
+        updateCollectionExerciseFromEvent(event);
+        break;
+      default:
+        break;
     }
+  }
 
-    /**
-     * Updates the scheduledStartDate for the collection exercise from the event timestamp if the event is an mps event
-     * @param event the incoming event
-     */
-    private void updateCollectionExerciseFromEvent(final Event event) {
-        try {
-            EventService.Tag tag = EventService.Tag.valueOf(event.getTag());
-            CollectionExercise collex = event.getCollectionExercise();
+  /**
+   * Updates the scheduledStartDate for the collection exercise from the event timestamp if the
+   * event is an mps event
+   *
+   * @param event the incoming event
+   */
+  private void updateCollectionExerciseFromEvent(final Event event) {
+    try {
+      EventService.Tag tag = EventService.Tag.valueOf(event.getTag());
+      CollectionExercise collex = event.getCollectionExercise();
 
-            if (collex != null) {
-                switch (tag) {
-                    case mps:
-                        log.info("Setting scheduledStartDate for {} to {}", collex.getId(), event.getTimestamp());
-                        collex.setScheduledStartDateTime(event.getTimestamp());
-                        collex.setScheduledExecutionDateTime(event.getTimestamp());
-                        collex.setPeriodStartDateTime(event.getTimestamp());
-                        break;
-                    case exercise_end:
-                        log.info("Setting scheduledEndDate for {} to {}", collex.getId(), event.getTimestamp());
-                        collex.setScheduledEndDateTime(event.getTimestamp());
-                        collex.setPeriodEndDateTime(event.getTimestamp());
-                        break;
-                    case return_by:
-                        log.info("Setting scheduledReturnDate for {} to {}", collex.getId(), event.getTimestamp());
-                        collex.setScheduledReturnDateTime(event.getTimestamp());
-                        break;
-                    default:
-                        break;
-                }
-                this.collectionExerciseService.updateCollectionExercise(collex);
-            }
-        } catch(IllegalArgumentException e) {
-            // Thrown if tag isn't one of the mandatory types - if it happens we don't care about the event
+      if (collex != null) {
+        switch (tag) {
+          case mps:
+            log.info(
+                "Setting scheduledStartDate for {} to {}", collex.getId(), event.getTimestamp());
+            collex.setScheduledStartDateTime(event.getTimestamp());
+            collex.setScheduledExecutionDateTime(event.getTimestamp());
+            collex.setPeriodStartDateTime(event.getTimestamp());
+            break;
+          case exercise_end:
+            log.info("Setting scheduledEndDate for {} to {}", collex.getId(), event.getTimestamp());
+            collex.setScheduledEndDateTime(event.getTimestamp());
+            collex.setPeriodEndDateTime(event.getTimestamp());
+            break;
+          case return_by:
+            log.info(
+                "Setting scheduledReturnDate for {} to {}", collex.getId(), event.getTimestamp());
+            collex.setScheduledReturnDateTime(event.getTimestamp());
+            break;
+          default:
+            break;
         }
+        this.collectionExerciseService.updateCollectionExercise(collex);
+      }
+    } catch (IllegalArgumentException e) {
+      // Thrown if tag isn't one of the mandatory types - if it happens we don't care about the
+      // event
     }
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStateTransitionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStateTransitionHandler.java
@@ -2,10 +2,8 @@ package uk.gov.ons.ctp.response.collection.exercise.service.impl.change;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.error.CTPException;
-import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEventPublisher;
@@ -15,43 +13,52 @@ import uk.gov.ons.ctp.response.collection.exercise.service.EventChangeHandler;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
 /**
- * This is an EventChangeHandler that will fire the relevant EVENTS_ADDED/EVENTS_DELETED event at the corresponding
- * collection exercise when an event is updated.  In the event it's EVENTS_ADDED this will also give the collection
- * exercise a kick to check whether it should transition to READY_FOR_LIVE
+ * This is an EventChangeHandler that will fire the relevant EVENTS_ADDED/EVENTS_DELETED event at
+ * the corresponding collection exercise when an event is updated. In the event it's EVENTS_ADDED
+ * this will also give the collection exercise a kick to check whether it should transition to
+ * READY_FOR_LIVE
  */
 @Component
 @Slf4j
 public class ScheduledStateTransitionHandler implements EventChangeHandler {
 
-    @Autowired
-    private EventService eventService;
+  @Autowired private EventService eventService;
 
-    @Autowired
-    private CollectionExerciseService collectionExerciseService;
+  @Autowired private CollectionExerciseService collectionExerciseService;
 
-    @Override
-    public void handleEventLifecycle(CollectionExerciseEventPublisher.MessageType change, Event event) throws CTPException {
-        CollectionExercise collectionExercise = event.getCollectionExercise();
-        CollectionExerciseDTO.CollectionExerciseEvent ceEvent = null;
+  @Override
+  public void handleEventLifecycle(CollectionExerciseEventPublisher.MessageType change, Event event)
+      throws CTPException {
+    CollectionExercise collectionExercise = event.getCollectionExercise();
+    CollectionExerciseDTO.CollectionExerciseEvent ceEvent = null;
 
-        try {
-            if (this.eventService.isScheduled(collectionExercise.getId())) {
-                ceEvent = CollectionExerciseDTO.CollectionExerciseEvent.EVENTS_ADDED;
-                this.collectionExerciseService.transitionCollectionExercise(collectionExercise, ceEvent);
-                // This is a bit of a kludge on account of SCHEDULED not being a proper state.  If the CI & sample are
-                // already loaded, loading the events may trigger a transition straight through to READY_FOR_REVIEW
-                // Performing this call here will force that
-                this.collectionExerciseService.transitionScheduleCollectionExerciseToReadyToReview(collectionExercise);
-            } else {
-                ceEvent = CollectionExerciseDTO.CollectionExerciseEvent.EVENTS_DELETED;
-                this.collectionExerciseService.transitionCollectionExercise(collectionExercise, ceEvent);
-            }
-        } catch(CTPException e) {
-            // As the events are deliberately fired indiscriminately (i.e. the collection exercise state is not
-            // checked first) there is a reasonable likelihood that the transition will fail harmlessly. Hence this
-            // exception is being logged as a warning minus the stack trace
-            log.warn("Collection exercise {} failed to handle state transition {} - {} ({})",
-                    collectionExercise.getId(), ceEvent, e.getMessage(), e.getFault());
-        }
+    try {
+      if (this.eventService.isScheduled(collectionExercise.getId())) {
+        ceEvent = CollectionExerciseDTO.CollectionExerciseEvent.EVENTS_ADDED;
+        this.collectionExerciseService.transitionCollectionExercise(collectionExercise, ceEvent);
+        // This is a bit of a kludge on account of SCHEDULED not being a proper state.  If the CI &
+        // sample are
+        // already loaded, loading the events may trigger a transition straight through to
+        // READY_FOR_REVIEW
+        // Performing this call here will force that
+        this.collectionExerciseService.transitionScheduleCollectionExerciseToReadyToReview(
+            collectionExercise);
+      } else {
+        ceEvent = CollectionExerciseDTO.CollectionExerciseEvent.EVENTS_DELETED;
+        this.collectionExerciseService.transitionCollectionExercise(collectionExercise, ceEvent);
+      }
+    } catch (CTPException e) {
+      // As the events are deliberately fired indiscriminately (i.e. the collection exercise state
+      // is not
+      // checked first) there is a reasonable likelihood that the transition will fail harmlessly.
+      // Hence this
+      // exception is being logged as a warning minus the stack trace
+      log.warn(
+          "Collection exercise {} failed to handle state transition {} - {} ({})",
+          collectionExercise.getId(),
+          ceEvent,
+          e.getMessage(),
+          e.getFault());
     }
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
@@ -2,24 +2,21 @@ package uk.gov.ons.ctp.response.collection.exercise.state;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.springframework.stereotype.Component;
-
 import uk.gov.ons.ctp.common.state.BasicStateTransitionManager;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.common.state.StateTransitionManagerFactory;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
-import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO.SampleLinkState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO.SampleLinkEvent;
+import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO.SampleLinkState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
 
-/**
- * State transition manager factory for the collection exercise service.
- */
+/** State transition manager factory for the collection exercise service. */
 @Component
-public class CollectionExerciseStateTransitionManagerFactory implements StateTransitionManagerFactory {
+public class CollectionExerciseStateTransitionManagerFactory
+    implements StateTransitionManagerFactory {
 
   public static final String COLLLECTIONEXERCISE_ENTITY = "CollectionExercise";
 
@@ -30,104 +27,120 @@ public class CollectionExerciseStateTransitionManagerFactory implements StateTra
   private Map<String, StateTransitionManager<?, ?>> managers;
 
   /**
-   * Create and initialise the factory with concrete StateTransitionManagers for
-   * each required entity
+   * Create and initialise the factory with concrete StateTransitionManagers for each required
+   * entity
    */
   public CollectionExerciseStateTransitionManagerFactory() {
     managers = new HashMap<>();
 
-    StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent> collectionExerciseStateTransitionManager =
-        createCollectionExerciseStateTransitionManager();
+    StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent>
+        collectionExerciseStateTransitionManager = createCollectionExerciseStateTransitionManager();
     managers.put(COLLLECTIONEXERCISE_ENTITY, collectionExerciseStateTransitionManager);
 
-    StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent> sampleUnitGroupStateTransitionManager =
-        createSampleUnitGroupStateTransitionManager();
+    StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent>
+        sampleUnitGroupStateTransitionManager = createSampleUnitGroupStateTransitionManager();
     managers.put(SAMPLEUNITGROUP_ENTITY, sampleUnitGroupStateTransitionManager);
 
-    StateTransitionManager<SampleLinkState, SampleLinkEvent>
-            sampleLinkStateTransitionManager = createSampleLinkStateTransitionManager();
+    StateTransitionManager<SampleLinkState, SampleLinkEvent> sampleLinkStateTransitionManager =
+        createSampleLinkStateTransitionManager();
     managers.put(SAMPLELINK_ENTITY, sampleLinkStateTransitionManager);
   }
 
   /**
-   * Create and initialise the factory with the concrete StateTransitionManager
-   * for the CollectionExercise entity
+   * Create and initialise the factory with the concrete StateTransitionManager for the
+   * CollectionExercise entity
    *
    * @return StateTransitionManager
    */
   private StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent>
       createCollectionExerciseStateTransitionManager() {
 
-    Map<CollectionExerciseState, Map<CollectionExerciseEvent, CollectionExerciseState>> transitions = new HashMap<>();
-
     // INIT/CREATED
     Map<CollectionExerciseEvent, CollectionExerciseState> transitionForInit = new HashMap<>();
     transitionForInit.put(CollectionExerciseEvent.CI_SAMPLE_ADDED, CollectionExerciseState.CREATED);
-    transitionForInit.put(CollectionExerciseEvent.CI_SAMPLE_DELETED, CollectionExerciseState.CREATED);
-    transitionForInit.put(CollectionExerciseEvent.EXECUTE, CollectionExerciseState.EXECUTION_STARTED);
+    transitionForInit.put(
+        CollectionExerciseEvent.CI_SAMPLE_DELETED, CollectionExerciseState.CREATED);
+    transitionForInit.put(
+        CollectionExerciseEvent.EXECUTE, CollectionExerciseState.EXECUTION_STARTED);
     transitionForInit.put(CollectionExerciseEvent.EVENTS_ADDED, CollectionExerciseState.SCHEDULED);
     transitionForInit.put(CollectionExerciseEvent.EVENTS_DELETED, CollectionExerciseState.CREATED);
+    Map<CollectionExerciseState, Map<CollectionExerciseEvent, CollectionExerciseState>>
+        transitions = new HashMap<>();
     transitions.put(CollectionExerciseState.CREATED, transitionForInit);
 
     // SCHEDULED
     Map<CollectionExerciseEvent, CollectionExerciseState> transitionForScheduled = new HashMap<>();
-    transitionForScheduled.put(CollectionExerciseEvent.EVENTS_ADDED, CollectionExerciseState.SCHEDULED);
-    transitionForScheduled.put(CollectionExerciseEvent.EVENTS_DELETED, CollectionExerciseState.CREATED);
-    transitionForScheduled.put(CollectionExerciseEvent.CI_SAMPLE_DELETED, CollectionExerciseState.SCHEDULED);
-    transitionForScheduled.put(CollectionExerciseEvent.CI_SAMPLE_ADDED, CollectionExerciseState.READY_FOR_REVIEW);
+    transitionForScheduled.put(
+        CollectionExerciseEvent.EVENTS_ADDED, CollectionExerciseState.SCHEDULED);
+    transitionForScheduled.put(
+        CollectionExerciseEvent.EVENTS_DELETED, CollectionExerciseState.CREATED);
+    transitionForScheduled.put(
+        CollectionExerciseEvent.CI_SAMPLE_DELETED, CollectionExerciseState.SCHEDULED);
+    transitionForScheduled.put(
+        CollectionExerciseEvent.CI_SAMPLE_ADDED, CollectionExerciseState.READY_FOR_REVIEW);
     transitions.put(CollectionExerciseState.SCHEDULED, transitionForScheduled);
 
     // READY_FOR_REVIEW
     Map<CollectionExerciseEvent, CollectionExerciseState> transitionForReview = new HashMap<>();
-    transitionForReview.put(CollectionExerciseEvent.CI_SAMPLE_DELETED, CollectionExerciseState.SCHEDULED);
-    transitionForReview.put(CollectionExerciseEvent.EVENTS_DELETED, CollectionExerciseState.CREATED);
-    transitionForReview.put(CollectionExerciseEvent.EXECUTE, CollectionExerciseState.EXECUTION_STARTED);
+    transitionForReview.put(
+        CollectionExerciseEvent.CI_SAMPLE_DELETED, CollectionExerciseState.SCHEDULED);
+    transitionForReview.put(
+        CollectionExerciseEvent.EVENTS_DELETED, CollectionExerciseState.CREATED);
+    transitionForReview.put(
+        CollectionExerciseEvent.EXECUTE, CollectionExerciseState.EXECUTION_STARTED);
     transitions.put(CollectionExerciseState.READY_FOR_REVIEW, transitionForReview);
 
     // PENDING/EXECUTION_STARTED
     Map<CollectionExerciseEvent, CollectionExerciseState> transitionForPending = new HashMap<>();
-    transitionForPending.put(CollectionExerciseEvent.EXECUTION_COMPLETE, CollectionExerciseState.EXECUTED);
-    transitionForPending.put(CollectionExerciseEvent.EXECUTE, CollectionExerciseState.EXECUTION_STARTED);
+    transitionForPending.put(
+        CollectionExerciseEvent.EXECUTION_COMPLETE, CollectionExerciseState.EXECUTED);
+    transitionForPending.put(
+        CollectionExerciseEvent.EXECUTE, CollectionExerciseState.EXECUTION_STARTED);
     transitions.put(CollectionExerciseState.EXECUTION_STARTED, transitionForPending);
 
     // EXECUTED
     Map<CollectionExerciseEvent, CollectionExerciseState> transitionForExecuted = new HashMap<>();
     transitionForExecuted.put(CollectionExerciseEvent.VALIDATE, CollectionExerciseState.VALIDATED);
-    transitionForExecuted.put(CollectionExerciseEvent.INVALIDATE, CollectionExerciseState.FAILEDVALIDATION);
+    transitionForExecuted.put(
+        CollectionExerciseEvent.INVALIDATE, CollectionExerciseState.FAILEDVALIDATION);
     transitions.put(CollectionExerciseState.EXECUTED, transitionForExecuted);
 
     // VALIDATED
     Map<CollectionExerciseEvent, CollectionExerciseState> transitionForValidated = new HashMap<>();
-    transitionForValidated.put(CollectionExerciseEvent.PUBLISH, CollectionExerciseState.READY_FOR_LIVE);
+    transitionForValidated.put(
+        CollectionExerciseEvent.PUBLISH, CollectionExerciseState.READY_FOR_LIVE);
     transitions.put(CollectionExerciseState.VALIDATED, transitionForValidated);
 
     // FAILEDVALIDATION
-    Map<CollectionExerciseEvent, CollectionExerciseState> transitionForFailedvalidation = new HashMap<>();
-    transitionForFailedvalidation.put(CollectionExerciseEvent.EXECUTE, CollectionExerciseState.EXECUTION_STARTED);
+    Map<CollectionExerciseEvent, CollectionExerciseState> transitionForFailedvalidation =
+        new HashMap<>();
+    transitionForFailedvalidation.put(
+        CollectionExerciseEvent.EXECUTE, CollectionExerciseState.EXECUTION_STARTED);
     transitions.put(CollectionExerciseState.FAILEDVALIDATION, transitionForFailedvalidation);
 
     // READY_FOR_LIVE
-    Map<CollectionExerciseEvent, CollectionExerciseState> transitionForReadyForLive = new HashMap<>();
+    Map<CollectionExerciseEvent, CollectionExerciseState> transitionForReadyForLive =
+        new HashMap<>();
     transitionForReadyForLive.put(CollectionExerciseEvent.GO_LIVE, CollectionExerciseState.LIVE);
     transitions.put(CollectionExerciseState.READY_FOR_LIVE, transitionForReadyForLive);
 
-    StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent> collectionExerciseTransitionManager =
-        new BasicStateTransitionManager<>(transitions);
+    StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent>
+        collectionExerciseTransitionManager = new BasicStateTransitionManager<>(transitions);
 
     return collectionExerciseTransitionManager;
-
   }
 
   /**
-   * Create and initialise the factory with the concrete StateTransitionManager
-   * for the SampleUnitGroup entity
+   * Create and initialise the factory with the concrete StateTransitionManager for the
+   * SampleUnitGroup entity
    *
    * @return StateTransitionManager
    */
   private StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent>
-  createSampleUnitGroupStateTransitionManager() {
+      createSampleUnitGroupStateTransitionManager() {
 
-    Map<SampleUnitGroupState, Map<SampleUnitGroupEvent, SampleUnitGroupState>> transitions = new HashMap<>();
+    Map<SampleUnitGroupState, Map<SampleUnitGroupEvent, SampleUnitGroupState>> transitions =
+        new HashMap<>();
 
     // INIT
     Map<SampleUnitGroupEvent, SampleUnitGroupState> transitionForInit = new HashMap<>();
@@ -141,22 +154,21 @@ public class CollectionExerciseStateTransitionManagerFactory implements StateTra
     transitions.put(SampleUnitGroupState.VALIDATED, transitionForValidated);
 
     StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent> sampleUnitTransitionManager =
-            new BasicStateTransitionManager<>(transitions);
+        new BasicStateTransitionManager<>(transitions);
 
     return sampleUnitTransitionManager;
   }
 
   /**
-   * Create and initialise the factory with the concrete StateTransitionManager
-   * for the SampleLink entity
+   * Create and initialise the factory with the concrete StateTransitionManager for the SampleLink
+   * entity
    *
    * @return StateTransitionManager
    */
   private StateTransitionManager<SampleLinkState, SampleLinkEvent>
       createSampleLinkStateTransitionManager() {
 
-    Map<SampleLinkState,
-        Map<SampleLinkEvent, SampleLinkState>> transitions = new HashMap<>();
+    Map<SampleLinkState, Map<SampleLinkEvent, SampleLinkState>> transitions = new HashMap<>();
 
     // INIT
     Map<SampleLinkEvent, SampleLinkState> transitionForInit = new HashMap<>();
@@ -164,8 +176,7 @@ public class CollectionExerciseStateTransitionManagerFactory implements StateTra
 
     transitions.put(SampleLinkState.INIT, transitionForInit);
 
-    StateTransitionManager<SampleLinkState,
-            SampleLinkEvent> sampleUnitTransitionManager =
+    StateTransitionManager<SampleLinkState, SampleLinkEvent> sampleUnitTransitionManager =
         new BasicStateTransitionManager<>(transitions);
 
     return sampleUnitTransitionManager;
@@ -176,5 +187,4 @@ public class CollectionExerciseStateTransitionManagerFactory implements StateTra
   public StateTransitionManager<?, ?> getStateTransitionManager(String entity) {
     return managers.get(entity);
   }
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/CollectionInstrumentClassifierTypes.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/CollectionInstrumentClassifierTypes.java
@@ -1,17 +1,16 @@
 package uk.gov.ons.ctp.response.collection.exercise.validation;
 
 import java.util.function.Function;
-
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 
 /**
- * Classifier Types used to search the Collection Instrument Service to return
- * the appropriate collection instrument for a sample unit. The classifiers used
- * in the Collection Instrument Service Search.
+ * Classifier Types used to search the Collection Instrument Service to return the appropriate
+ * collection instrument for a sample unit. The classifiers used in the Collection Instrument
+ * Service Search.
  *
- * Note. These classifier types need to match the classifier types returned from
- * the Survey service for the Collection Instrument Selector Type, with an
- * appropriate lambda expression to obtain the value.
+ * <p>Note. These classifier types need to match the classifier types returned from the Survey
+ * service for the Collection Instrument Selector Type, with an appropriate lambda expression to
+ * obtain the value.
  */
 public enum CollectionInstrumentClassifierTypes implements Function<ExerciseSampleUnit, String> {
   COLLECTION_EXERCISE(unit -> unit.getSampleUnitGroup().getCollectionExercise().getId().toString()),
@@ -22,6 +21,7 @@ public enum CollectionInstrumentClassifierTypes implements Function<ExerciseSamp
 
   /**
    * Create an instance of the enum.
+   *
    * @param lambda expression to be applied to obtain value for classifier.
    */
   CollectionInstrumentClassifierTypes(Function<ExerciseSampleUnit, String> lambda) {
@@ -32,5 +32,4 @@ public enum CollectionInstrumentClassifierTypes implements Function<ExerciseSamp
   public String apply(ExerciseSampleUnit unit) {
     return func.apply(unit);
   }
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidationScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidationScheduler.java
@@ -3,23 +3,18 @@ package uk.gov.ons.ctp.response.collection.exercise.validation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
 
 /**
- * Schedule Validation of sample units in INIT state checking Collection Instruments exist for
- * each sample unit.
- *
+ * Schedule Validation of sample units in INIT state checking Collection Instruments exist for each
+ * sample unit.
  */
 @Component
 public class ValidationScheduler {
 
-  @Autowired
-  private SampleService sampleService;
+  @Autowired private SampleService sampleService;
 
-  /**
-   * Carry out scheduled validation according to configured fixed delay.
-   */
+  /** Carry out scheduled validation according to configured fixed delay. */
   @Scheduled(fixedDelayString = "#{appConfig.schedules.validationScheduleDelayMilliSeconds}")
   public void scheduleValidation() {
     sampleService.validateSampleUnits();

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
@@ -6,6 +6,10 @@ import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.json.JSONArray;
@@ -15,194 +19,203 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleLinkDTO;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-
-/**
- * A class to wrap the collection exercise REST API in Java using Unirest
- */
+/** A class to wrap the collection exercise REST API in Java using Unirest */
 public class CollectionExerciseClient {
 
-    private ObjectMapper jacksonMapper;
-    private int port;
-    private String username;
-    private String password;
+  private ObjectMapper jacksonMapper;
+  private int port;
+  private String username;
+  private String password;
 
-    /**
-     * Constructor for client - accepts API connection information
-     * @param aPort collection exercise API port
-     * @param aUsername  collection exercise API username
-     * @param aPassword collection exercise API password
-     * @param aMapper an object mapper
-     */
-    public CollectionExerciseClient(final int aPort, final String aUsername, final String aPassword,
-                                    final ObjectMapper aMapper) {
-        this.port = aPort;
-        this.jacksonMapper = aMapper;
-        this.username = aUsername;
-        this.password = aPassword;
+  /**
+   * Constructor for client - accepts API connection information
+   *
+   * @param aPort collection exercise API port
+   * @param aUsername collection exercise API username
+   * @param aPassword collection exercise API password
+   * @param aMapper an object mapper
+   */
+  public CollectionExerciseClient(
+      final int aPort, final String aUsername, final String aPassword, final ObjectMapper aMapper) {
+    this.port = aPort;
+    this.jacksonMapper = aMapper;
+    this.username = aUsername;
+    this.password = aPassword;
 
-        initialiseUnirestObjectMapper();
-    }
+    initialiseUnirestObjectMapper();
+  }
 
-    /**
-     * Initialises object mapper as used by unirest (needs a Jackson ObjectMapper to construct)
-     */
-    private void initialiseUnirestObjectMapper() {
-        Unirest.setObjectMapper(new com.mashape.unirest.http.ObjectMapper() {
-            public <T> T readValue(final String value, final Class<T> valueType) {
-                try {
-                    return jacksonMapper.readValue(value, valueType);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
+  /** Initialises object mapper as used by unirest (needs a Jackson ObjectMapper to construct) */
+  private void initialiseUnirestObjectMapper() {
+    Unirest.setObjectMapper(
+        new com.mashape.unirest.http.ObjectMapper() {
+          public <T> T readValue(final String value, final Class<T> valueType) {
+            try {
+              return jacksonMapper.readValue(value, valueType);
+            } catch (IOException e) {
+              throw new RuntimeException(e);
             }
+          }
 
-            public String writeValue(final Object value) {
-                try {
-                    return jacksonMapper.writeValueAsString(value);
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
+          public String writeValue(final Object value) {
+            try {
+              return jacksonMapper.writeValueAsString(value);
+            } catch (JsonProcessingException e) {
+              throw new RuntimeException(e);
             }
+          }
         });
+  }
+
+  /**
+   * Calls the API to create a collection exercise
+   *
+   * @param surveyId survey to create collection exercise for
+   * @param exerciseRef the period of the collection exercise
+   * @param userDescription the description of the collection exercise
+   * @return a Pair of the status code of the operation and the location at which the new resource
+   *     has been created
+   * @throws CTPException thrown if an error occurred creating the collection exercise
+   */
+  public Pair<Integer, String> createCollectionExercise(
+      final UUID surveyId, final String exerciseRef, final String userDescription)
+      throws CTPException {
+    CollectionExerciseDTO inputDto = new CollectionExerciseDTO();
+
+    inputDto.setSurveyId(surveyId.toString());
+    inputDto.setExerciseRef(exerciseRef);
+    inputDto.setUserDescription(userDescription);
+
+    try {
+      HttpResponse<String> createCollexResponse =
+          Unirest.post("http://localhost:" + this.port + "/collectionexercises")
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/json")
+              .header("Content-Type", "application/json")
+              .body(inputDto)
+              .asString();
+      int statusCode = createCollexResponse.getStatus();
+      List<String> locations = createCollexResponse.getHeaders().get("Location");
+      String location = locations != null && locations.size() > 0 ? locations.get(0) : null;
+
+      return new ImmutablePair<>(statusCode, location);
+    } catch (UnirestException e) {
+      throw new CTPException(
+          CTPException.Fault.SYSTEM_ERROR, "Failed to create collection exercise", e);
     }
+  }
 
-    /**
-     * Calls the API to create a collection exercise
-     * @param surveyId survey to create collection exercise for
-     * @param exerciseRef the period of the collection exercise
-     * @param userDescription the description of the collection exercise
-     * @return a Pair of the status code of the operation and the location at which the new resource has been created
-     * @throws CTPException thrown if an error occurred creating the collection exercise
-     */
-    public Pair<Integer, String> createCollectionExercise(final UUID surveyId, final String exerciseRef,
-                                                          final String userDescription)
-            throws CTPException {
-        CollectionExerciseDTO inputDto = new CollectionExerciseDTO();
-
-        inputDto.setSurveyId(surveyId.toString());
-        inputDto.setExerciseRef(exerciseRef);
-        inputDto.setUserDescription(userDescription);
-
-        try {
-            HttpResponse<String> createCollexResponse =
-                    Unirest.post("http://localhost:" + this.port + "/collectionexercises")
-                            .basicAuth(this.username, this.password)
-                            .header("accept", "application/json")
-                            .header("Content-Type", "application/json")
-                            .body(inputDto)
-                            .asString();
-            int statusCode = createCollexResponse.getStatus();
-            List<String> locations = createCollexResponse.getHeaders().get("Location");
-            String location = locations != null && locations.size() > 0 ? locations.get(0) : null;
-
-            return new ImmutablePair<>(statusCode, location);
-        } catch (UnirestException e) {
-            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to create collection exercise", e);
-        }
+  /**
+   * Calls the API to get a collection exercise from a UUID
+   *
+   * @param collexId the uuid of the collection exercise
+   * @return the full details of the collection exercise
+   * @throws CTPException thrown if an error occurred retrieving the collection exercise details
+   */
+  public CollectionExerciseDTO getCollectionExercise(final UUID collexId) throws CTPException {
+    try {
+      return Unirest.get("http://localhost:" + this.port + "/collectionexercises/{id}")
+          .routeParam("id", collexId.toString())
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/json")
+          .asObject(CollectionExerciseDTO.class)
+          .getBody();
+    } catch (UnirestException e) {
+      throw new CTPException(
+          CTPException.Fault.SYSTEM_ERROR, "Failed to get collection exercise", e);
     }
+  }
 
-    /**
-     * Calls the API to get a collection exercise from a UUID
-     * @param collexId the uuid of the collection exercise
-     * @return the full details of the collection exercise
-     * @throws CTPException thrown if an error occurred retrieving the collection exercise details
-     */
-    public CollectionExerciseDTO getCollectionExercise(final UUID collexId) throws CTPException {
-        try {
-            return Unirest.get("http://localhost:" + this.port + "/collectionexercises/{id}")
-                    .routeParam("id", collexId.toString())
-                    .basicAuth(this.username, this.password)
-                    .header("accept", "application/json")
-                    .asObject(CollectionExerciseDTO.class)
-                    .getBody();
-        } catch (UnirestException e) {
-            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to get collection exercise", e);
-        }
+  /**
+   * Gets a collection exercise given the whole URI (e.g. as returned in a Location header)
+   *
+   * @param uriStr the full URI of the collection exercise resource
+   * @return a representation of the collection exercise
+   * @throws CTPException thrown if there was an error retrieving the collection exercise
+   */
+  public CollectionExerciseDTO getCollectionExercise(final String uriStr) throws CTPException {
+    try {
+      return Unirest.get(uriStr)
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/json")
+          .asObject(CollectionExerciseDTO.class)
+          .getBody();
+    } catch (UnirestException e) {
+      throw new CTPException(
+          CTPException.Fault.SYSTEM_ERROR, "Failed to get collection exercise", e);
     }
+  }
 
-    /**
-     * Gets a collection exercise given the whole URI (e.g. as returned in a Location header)
-     * @param uriStr the full URI of the collection exercise resource
-     * @return a representation of the collection exercise
-     * @throws CTPException thrown if there was an error retrieving the collection exercise
-     */
-    public CollectionExerciseDTO getCollectionExercise(final String uriStr) throws CTPException {
-        try {
-            return Unirest.get(uriStr)
-                    .basicAuth(this.username, this.password)
-                    .header("accept", "application/json")
-                    .asObject(CollectionExerciseDTO.class)
-                    .getBody();
-        } catch (UnirestException e) {
-            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to get collection exercise", e);
-        }
+  /**
+   * Calls the API to link a list of sample summaries to a collection exercise
+   *
+   * @param collexId the uuid of the collection exercise to link
+   * @param sampleSummaryIds a list of the uuids of the sample summaries to link
+   * @return the http status code of the operation
+   * @throws CTPException thrown if there was an error linking the sample summaries to the
+   *     collection exercise
+   */
+  public int linkSampleSummaries(final UUID collexId, final List<UUID> sampleSummaryIds)
+      throws CTPException {
+    try {
+      JSONObject jsonPayload = new JSONObject();
+      JSONArray jsonSampleSummaryIds = new JSONArray();
+      sampleSummaryIds.stream().forEach(ssi -> jsonSampleSummaryIds.put(ssi.toString()));
+      jsonPayload.put("sampleSummaryIds", jsonSampleSummaryIds);
+
+      HttpResponse<JsonNode> linkResponse =
+          Unirest.put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+              .routeParam("id", collexId.toString())
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/json")
+              .header("Content-Type", "application/json")
+              .body(jsonPayload)
+              .asJson();
+
+      return linkResponse.getStatus();
+    } catch (JSONException e) {
+      throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to create payload", e);
+    } catch (UnirestException e) {
+      throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to serialize payload", e);
     }
+  }
 
-    /**
-     * Calls the API to link a list of sample summaries to a collection exercise
-     * @param collexId the uuid of the collection exercise to link
-     * @param sampleSummaryIds a list of the uuids of the sample summaries to link
-     * @return the http status code of the operation
-     * @throws CTPException thrown if there was an error linking the sample summaries to the collection exercise
-     */
-    public int linkSampleSummaries(final UUID collexId, final List<UUID> sampleSummaryIds) throws CTPException {
-        try {
-            JSONObject jsonPayload = new JSONObject();
-            JSONArray jsonSampleSummaryIds = new JSONArray();
-            sampleSummaryIds.stream().forEach(ssi -> jsonSampleSummaryIds.put(ssi.toString()));
-            jsonPayload.put("sampleSummaryIds", jsonSampleSummaryIds);
+  /**
+   * Links a sample summary to a collection exercise
+   *
+   * @param collexId the uuid of the collection exercise to link
+   * @param sampleSummaryId the uuid of the sample summary to link
+   * @return the http status code of the operation
+   * @throws CTPException thrown if there was an error linking the sample summary to the collection
+   *     exercise
+   * @see CollectionExerciseClient#linkSampleSummaries
+   */
+  public int linkSampleSummary(final UUID collexId, final UUID sampleSummaryId)
+      throws CTPException {
+    return linkSampleSummaries(collexId, Arrays.asList(sampleSummaryId));
+  }
 
-            HttpResponse<JsonNode> linkResponse =
-                    Unirest.put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
-                            .routeParam("id", collexId.toString())
-                            .basicAuth(this.username, this.password)
-                            .header("accept", "application/json")
-                            .header("Content-Type", "application/json")
-                            .body(jsonPayload)
-                            .asJson();
+  /**
+   * Get the samples linked to a collection exercise
+   *
+   * @param collexId the uuid of the collection exercise
+   * @return a list of samole links
+   * @throws CTPException thrown if an error occurs retrieving the sample links
+   */
+  public List<SampleLinkDTO> getSampleLinks(final UUID collexId) throws CTPException {
+    try {
+      SampleLinkDTO[] linkArray =
+          Unirest.get("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+              .routeParam("id", collexId.toString())
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/vnd.ons.sdc.samplelink.v1+json")
+              .asObject(SampleLinkDTO[].class)
+              .getBody();
 
-            return linkResponse.getStatus();
-        } catch (JSONException e) {
-            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to create payload", e);
-        } catch (UnirestException e) {
-            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to serialize payload", e);
-        }
+      return Arrays.asList(linkArray);
+    } catch (UnirestException e) {
+      throw new CTPException(
+          CTPException.Fault.SYSTEM_ERROR, "Failed to get collection exercise", e);
     }
-
-    /**
-     * Links a sample summary to a collection exercise
-     * @param collexId the uuid of the collection exercise to link
-     * @param sampleSummaryId the uuid of the sample summary to link
-     * @return the http status code of the operation
-     * @throws CTPException thrown if there was an error linking the sample summary to the collection exercise
-     * @see CollectionExerciseClient#linkSampleSummaries
-     */
-    public int linkSampleSummary(final UUID collexId, final UUID sampleSummaryId) throws CTPException {
-        return linkSampleSummaries(collexId, Arrays.asList(sampleSummaryId));
-    }
-
-    /**
-     * Get the samples linked to a collection exercise
-     * @param collexId the uuid of the collection exercise
-     * @return a list of samole links
-     * @throws CTPException thrown if an error occurs retrieving the sample links
-     */
-    public List<SampleLinkDTO> getSampleLinks(final UUID collexId) throws CTPException {
-        try {
-            SampleLinkDTO[] linkArray = Unirest.get("http://localhost:" + this.port + "/collectionexercises/link/{id}")
-                    .routeParam("id", collexId.toString())
-                    .basicAuth(this.username, this.password)
-                    .header("accept", "application/vnd.ons.sdc.samplelink.v1+json")
-                    .asObject(SampleLinkDTO[].class)
-                    .getBody();
-
-            return Arrays.asList(linkArray);
-        } catch (UnirestException e) {
-            throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to get collection exercise", e);
-        }
-    }
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
@@ -1,6 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.endpoint;
 
+import static org.junit.Assert.assertEquals;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
@@ -22,15 +27,7 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExer
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleLinkDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
 
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
-
-import static org.junit.Assert.assertEquals;
-
-/**
- * A class to contain integration tests for the collection exercise service
- */
+/** A class to contain integration tests for the collection exercise service */
 @Slf4j
 @RunWith(SpringRunner.class)
 @ContextConfiguration
@@ -38,125 +35,128 @@ import static org.junit.Assert.assertEquals;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class CollectionExerciseEndpointIT {
 
-    // TODO pull these from config
-    private static final UUID TEST_SURVEY_ID = UUID.fromString("c23bb1c1-5202-43bb-8357-7a07c844308f");
-    private static final String TEST_USERNAME = "admin";
-    private static final String TEST_PASSWORD = "secret";
+  // TODO pull these from config
+  private static final UUID TEST_SURVEY_ID =
+      UUID.fromString("c23bb1c1-5202-43bb-8357-7a07c844308f");
+  private static final String TEST_USERNAME = "admin";
+  private static final String TEST_PASSWORD = "secret";
 
-    @LocalServerPort
-    private int port;
+  @LocalServerPort private int port;
 
-    @Autowired
-    private ObjectMapper mapper;
+  @Autowired private ObjectMapper mapper;
 
-    @Autowired
-    private AppConfig appConfig;
+  @Autowired private AppConfig appConfig;
 
-    private CollectionExerciseClient client;
+  private CollectionExerciseClient client;
 
-    /**
-     * Method to set up integration test
-     */
-    @Before
-    public void setUp() {
-        client = new CollectionExerciseClient(this.port, TEST_USERNAME, TEST_PASSWORD, this.mapper);
-    }
+  /** Method to set up integration test */
+  @Before
+  public void setUp() {
+    client = new CollectionExerciseClient(this.port, TEST_USERNAME, TEST_PASSWORD, this.mapper);
+  }
 
-    /**
-     * Method to test construction of a collection exercise via the API
-     * - Create a collection exercise
-     * - Get the collection exercise from the returned Location header
-     * - Assert the collection exercise fields match those expected
-     *
-     * @throws CTPException thrown by error creating collection exercise
-     */
-    @Test
-    public void shouldCreateCollectionExercise() throws CTPException {
-        String exerciseRef = "899990";
-        String userDescription = "Test Description";
-        Pair<Integer, String> result = this.client.createCollectionExercise(TEST_SURVEY_ID, exerciseRef,
-                userDescription);
+  /**
+   * Method to test construction of a collection exercise via the API - Create a collection exercise
+   * - Get the collection exercise from the returned Location header - Assert the collection
+   * exercise fields match those expected
+   *
+   * @throws CTPException thrown by error creating collection exercise
+   */
+  @Test
+  public void shouldCreateCollectionExercise() throws CTPException {
+    String exerciseRef = "899990";
+    String userDescription = "Test Description";
+    Pair<Integer, String> result =
+        this.client.createCollectionExercise(TEST_SURVEY_ID, exerciseRef, userDescription);
 
-        assertEquals(201, (int) result.getLeft());
+    assertEquals(201, (int) result.getLeft());
 
-        CollectionExerciseDTO newCollex = this.client.getCollectionExercise(result.getRight());
+    CollectionExerciseDTO newCollex = this.client.getCollectionExercise(result.getRight());
 
-        assertEquals(TEST_SURVEY_ID, UUID.fromString(newCollex.getSurveyId()));
-        assertEquals(exerciseRef, newCollex.getExerciseRef());
-        assertEquals(userDescription, newCollex.getUserDescription());
-    }
+    assertEquals(TEST_SURVEY_ID, UUID.fromString(newCollex.getSurveyId()));
+    assertEquals(exerciseRef, newCollex.getExerciseRef());
+    assertEquals(userDescription, newCollex.getUserDescription());
+  }
 
-    /**
-     * Creates a new SimpleMessageSender based on the config in AppConfig
-     * @return a new SimpleMessageSender
-     */
-    private SimpleMessageSender getMessageSender() {
-        Rabbitmq config = this.appConfig.getRabbitmq();
+  /**
+   * Creates a new SimpleMessageSender based on the config in AppConfig
+   *
+   * @return a new SimpleMessageSender
+   */
+  private SimpleMessageSender getMessageSender() {
+    Rabbitmq config = this.appConfig.getRabbitmq();
 
-        return new SimpleMessageSender(config.getHost(), config.getPort(), config.getUsername(), config.getPassword());
-    }
+    return new SimpleMessageSender(
+        config.getHost(), config.getPort(), config.getUsername(), config.getPassword());
+  }
 
-    /**
-     * Creates a new SimpleMessageListener based on the config in AppConfig
-     * @return a new SimpleMessageListener
-     */
-    private SimpleMessageListener getMessageListener() {
-        Rabbitmq config = this.appConfig.getRabbitmq();
+  /**
+   * Creates a new SimpleMessageListener based on the config in AppConfig
+   *
+   * @return a new SimpleMessageListener
+   */
+  private SimpleMessageListener getMessageListener() {
+    Rabbitmq config = this.appConfig.getRabbitmq();
 
-        return new SimpleMessageListener(config.getHost(), config.getPort(), config.getUsername(), config.getPassword());
-    }
+    return new SimpleMessageListener(
+        config.getHost(), config.getPort(), config.getUsername(), config.getPassword());
+  }
 
-    /**
-     * Method to test the flow receving a message that a sample upload has finished.
-     * - Create a collection exercise
-     * - Get the collection exercise
-     * - Link the collection exercise to a sample summary with a random sample summary id
-     * - Send a message to Sample.SampleUploadFinished.binding key on sample-outbound-exchange
-     * - Get the sample links for the collection exercise
-     * - Assert the sample link is active (and the sample summary ids match)
-     *
-     * @throws CTPException throw if errors occur in any of the interactions
-     */
-    @Test
-    public void shouldActivateSampleLink() throws Exception {
-        String exerciseRef = "899991";
-        String userDescription = "Test Description";
-        Pair<Integer, String> result = this.client.createCollectionExercise(TEST_SURVEY_ID, exerciseRef, userDescription);
+  /**
+   * Method to test the flow receving a message that a sample upload has finished. - Create a
+   * collection exercise - Get the collection exercise - Link the collection exercise to a sample
+   * summary with a random sample summary id - Send a message to Sample.SampleUploadFinished.binding
+   * key on sample-outbound-exchange - Get the sample links for the collection exercise - Assert the
+   * sample link is active (and the sample summary ids match)
+   *
+   * @throws CTPException throw if errors occur in any of the interactions
+   */
+  @Test
+  public void shouldActivateSampleLink() throws Exception {
+    String exerciseRef = "899991";
+    String userDescription = "Test Description";
+    Pair<Integer, String> result =
+        this.client.createCollectionExercise(TEST_SURVEY_ID, exerciseRef, userDescription);
 
-        assertEquals(201, (int) result.getLeft());
-        CollectionExerciseDTO newCollex = this.client.getCollectionExercise(result.getRight());
+    assertEquals(201, (int) result.getLeft());
+    CollectionExerciseDTO newCollex = this.client.getCollectionExercise(result.getRight());
 
-        log.info("Collection exercise to link: {}", newCollex);
+    log.info("Collection exercise to link: {}", newCollex);
 
-        UUID sampleSummaryId = UUID.randomUUID();
+    UUID sampleSummaryId = UUID.randomUUID();
 
-        final int status = this.client.linkSampleSummary(newCollex.getId(), sampleSummaryId);
-        assertEquals(200, status);
+    final int status = this.client.linkSampleSummary(newCollex.getId(), sampleSummaryId);
+    assertEquals(200, status);
 
-        SimpleMessageSender sender = getMessageSender();
+    SimpleMessageSender sender = getMessageSender();
 
-        SampleSummaryDTO sampleSummary = new SampleSummaryDTO();
-        sampleSummary.setId(sampleSummaryId);
+    SampleSummaryDTO sampleSummary = new SampleSummaryDTO();
+    sampleSummary.setId(sampleSummaryId);
 
-        SimpleMessageListener listener = getMessageListener();
-        BlockingQueue<String> queue = listener.listen( SimpleMessageBase.ExchangeType.Direct,
-                "collection-outbound-exchange", "SampleLink.Activated.binding");
+    SimpleMessageListener listener = getMessageListener();
+    BlockingQueue<String> queue =
+        listener.listen(
+            SimpleMessageBase.ExchangeType.Direct,
+            "collection-outbound-exchange",
+            "SampleLink.Activated.binding");
 
-        // This will cause an exception to be thrown as there is no collection instrument service but this is
-        // harmless to our purpose
-        sender.sendMessage("sample-outbound-exchange", "Sample.SampleUploadFinished.binding",
-                this.mapper.writeValueAsString(sampleSummary));
+    // This will cause an exception to be thrown as there is no collection instrument service but
+    // this is
+    // harmless to our purpose
+    sender.sendMessage(
+        "sample-outbound-exchange",
+        "Sample.SampleUploadFinished.binding",
+        this.mapper.writeValueAsString(sampleSummary));
 
-        queue.take();
+    queue.take();
 
-        List<SampleLinkDTO> links = this.client.getSampleLinks(newCollex.getId());
+    List<SampleLinkDTO> links = this.client.getSampleLinks(newCollex.getId());
 
-        assertEquals(1, links.size());
+    assertEquals(1, links.size());
 
-        SampleLinkDTO link = links.get(0);
+    SampleLinkDTO link = links.get(0);
 
-        assertEquals(sampleSummaryId, UUID.fromString(link.getSampleSummaryId()));
-        assertEquals("ACTIVE", link.getState());
-    }
+    assertEquals(sampleSummaryId, UUID.fromString(link.getSampleSummaryId()));
+    assertEquals("ACTIVE", link.getState());
+  }
 }
-

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseExecutionEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseExecutionEndpointUnitTests.java
@@ -1,5 +1,14 @@
 package uk.gov.ons.ctp.response.collection.exercise.endpoint;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static uk.gov.ons.ctp.common.MvcHelper.*;
+import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
+
+import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,29 +25,16 @@ import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 
-import java.util.List;
-import java.util.UUID;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static uk.gov.ons.ctp.common.MvcHelper.*;
-import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
-
-/**
- * Collection Exercise Endpoint Unit tests
- */
+/** Collection Exercise Endpoint Unit tests */
 @Slf4j
 public class CollectionExerciseExecutionEndpointUnitTests {
-  private static final UUID COLLECTIONEXERCISE_ID1 = UUID.fromString("3ec82e0e-18ff-4886-8703-5b83442041ba");
+  private static final UUID COLLECTIONEXERCISE_ID1 =
+      UUID.fromString("3ec82e0e-18ff-4886-8703-5b83442041ba");
   private static final int SAMPLEUNITSTOTAL = 500;
 
-  @InjectMocks
-  private CollectionExerciseExecutionEndpoint collectionExerciseExecutionEndpoint;
+  @InjectMocks private CollectionExerciseExecutionEndpoint collectionExerciseExecutionEndpoint;
 
-  @Mock
-  private SampleService sampleService;
+  @Mock private SampleService sampleService;
 
   private MockMvc mockCollectionExerciseExecutionMvc;
   private List<SampleUnitsRequestDTO> sampleUnitsRequestDTOResults;
@@ -52,13 +48,14 @@ public class CollectionExerciseExecutionEndpointUnitTests {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
-    this.mockCollectionExerciseExecutionMvc = MockMvcBuilders
-        .standaloneSetup(collectionExerciseExecutionEndpoint)
-        .setHandlerExceptionResolvers(mockAdviceFor(RestExceptionHandler.class))
-        .setMessageConverters(new MappingJackson2HttpMessageConverter(new CustomObjectMapper()))
-        .build();
+    this.mockCollectionExerciseExecutionMvc =
+        MockMvcBuilders.standaloneSetup(collectionExerciseExecutionEndpoint)
+            .setHandlerExceptionResolvers(mockAdviceFor(RestExceptionHandler.class))
+            .setMessageConverters(new MappingJackson2HttpMessageConverter(new CustomObjectMapper()))
+            .build();
 
-    this.sampleUnitsRequestDTOResults = FixtureHelper.loadClassFixtures(SampleUnitsRequestDTO[].class);
+    this.sampleUnitsRequestDTOResults =
+        FixtureHelper.loadClassFixtures(SampleUnitsRequestDTO[].class);
   }
 
   /**
@@ -68,17 +65,19 @@ public class CollectionExerciseExecutionEndpointUnitTests {
    */
   @Test
   public void requestSampleUnits() throws Exception {
-    when(sampleService.requestSampleUnits(COLLECTIONEXERCISE_ID1)).thenReturn(sampleUnitsRequestDTOResults.get(0));
+    when(sampleService.requestSampleUnits(COLLECTIONEXERCISE_ID1))
+        .thenReturn(sampleUnitsRequestDTOResults.get(0));
 
-    ResultActions actions = mockCollectionExerciseExecutionMvc
-        .perform(postJson(String.format("/collectionexerciseexecution/%s", COLLECTIONEXERCISE_ID1), "{}"));
+    ResultActions actions =
+        mockCollectionExerciseExecutionMvc.perform(
+            postJson(
+                String.format("/collectionexerciseexecution/%s", COLLECTIONEXERCISE_ID1), "{}"));
 
-    actions.andExpect(status().isOk())
+    actions
+        .andExpect(status().isOk())
         .andExpect(handler().handlerType(CollectionExerciseExecutionEndpoint.class))
         .andExpect(handler().methodName("requestSampleUnits"))
         .andExpect(jsonPath("$.*", hasSize(1)))
         .andExpect(jsonPath("$.sampleUnitsTotal", is(SAMPLEUNITSTOTAL)));
-
   }
-
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandlerTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandlerTests.java
@@ -1,5 +1,10 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Map;
+import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.messaging.MessageHandlingException;
@@ -7,126 +12,119 @@ import org.springframework.messaging.support.GenericMessage;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.message.dto.CollectionInstrumentMessageDTO;
 
-import java.util.Map;
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-/**
- * Unit tests for ExceptionHandler class
- */
+/** Unit tests for ExceptionHandler class */
 public class ExceptionHandlerTests {
 
-    private static final UUID COLLECTION_INSTRUMENT_ID = UUID.fromString("699632ec-c75b-4454-a0ae-d15c592a6473");
-    private static final UUID COLLECTION_EXERCISE_ID = UUID.fromString("d42f358c-812c-45f7-a064-39739d0189a6");
+  private static final UUID COLLECTION_INSTRUMENT_ID =
+      UUID.fromString("699632ec-c75b-4454-a0ae-d15c592a6473");
+  private static final UUID COLLECTION_EXERCISE_ID =
+      UUID.fromString("d42f358c-812c-45f7-a064-39739d0189a6");
 
-    private static final CTPException.Fault EXCEPTION_FAULT = CTPException.Fault.RESOURCE_VERSION_CONFLICT;
-    private static final String EXCEPTION_MESSAGE = "Test exception message";
+  private static final CTPException.Fault EXCEPTION_FAULT =
+      CTPException.Fault.RESOURCE_VERSION_CONFLICT;
+  private static final String EXCEPTION_MESSAGE = "Test exception message";
 
-    private ExceptionHandler exceptionHandler;
+  private ExceptionHandler exceptionHandler;
 
-    private CollectionInstrumentMessageDTO messageDto;
+  private CollectionInstrumentMessageDTO messageDto;
 
-    private CTPException ctpException;
+  private CTPException ctpException;
 
-    /**
-     * Create objects common to many tests
-     */
-    @Before
-    public void setUp() {
-        this.exceptionHandler = new ExceptionHandler();
-        this.ctpException = new CTPException(EXCEPTION_FAULT, EXCEPTION_MESSAGE);
-        this.messageDto = new CollectionInstrumentMessageDTO(null, COLLECTION_EXERCISE_ID.toString(),
-                COLLECTION_INSTRUMENT_ID.toString());
-    }
+  /** Create objects common to many tests */
+  @Before
+  public void setUp() {
+    this.exceptionHandler = new ExceptionHandler();
+    this.ctpException = new CTPException(EXCEPTION_FAULT, EXCEPTION_MESSAGE);
+    this.messageDto =
+        new CollectionInstrumentMessageDTO(
+            null, COLLECTION_EXERCISE_ID.toString(), COLLECTION_INSTRUMENT_ID.toString());
+  }
 
-    /**
-     * Given null exception
-     * When handleException
-     * Then empty response
-     */
-    @Test
-    public void givenNullExceptionWhenHandleExceptionThenEmptyResponse() {
-        Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(null);
+  /** Given null exception When handleException Then empty response */
+  @Test
+  public void givenNullExceptionWhenHandleExceptionThenEmptyResponse() {
+    Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(null);
 
-        assertEquals(0, result.size());
-    }
+    assertEquals(0, result.size());
+  }
 
-    /**
-     * Given all fields
-     * When handleException
-     * Then all fields returned
-     */
-    @Test
-    public void givenAllFieldsWhenHandleExceptionThenAllFields() {
-        GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
-        MessageHandlingException exception = new MessageHandlingException(message, this.ctpException);
+  /** Given all fields When handleException Then all fields returned */
+  @Test
+  public void givenAllFieldsWhenHandleExceptionThenAllFields() {
+    GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
+    MessageHandlingException exception = new MessageHandlingException(message, this.ctpException);
 
-        Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(exception);
+    Map<ExceptionHandler.ResultKey, String> result =
+        this.exceptionHandler.handleException(exception);
 
-        assertEquals(COLLECTION_INSTRUMENT_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionInstrument));
-        assertEquals(COLLECTION_EXERCISE_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionExercise));
-        assertEquals(EXCEPTION_FAULT.name(), result.get(ExceptionHandler.ResultKey.errorType));
-        assertEquals(EXCEPTION_MESSAGE, result.get(ExceptionHandler.ResultKey.errorMessage));
-        assertEquals(this.ctpException.getTimestamp(),
-                Long.parseLong(result.get(ExceptionHandler.ResultKey.errorTimestamp)));
-    }
+    assertEquals(
+        COLLECTION_INSTRUMENT_ID.toString(),
+        result.get(ExceptionHandler.ResultKey.collectionInstrument));
+    assertEquals(
+        COLLECTION_EXERCISE_ID.toString(),
+        result.get(ExceptionHandler.ResultKey.collectionExercise));
+    assertEquals(EXCEPTION_FAULT.name(), result.get(ExceptionHandler.ResultKey.errorType));
+    assertEquals(EXCEPTION_MESSAGE, result.get(ExceptionHandler.ResultKey.errorMessage));
+    assertEquals(
+        this.ctpException.getTimestamp(),
+        Long.parseLong(result.get(ExceptionHandler.ResultKey.errorTimestamp)));
+  }
 
-    /**
-     * Given no failed message
-     * When handleException
-     * Then only exeception details returned
-     */
-    @Test
-    public void givenNoFailedMessageWhenHandleExceptionThenOnlyExeceptionDetails() {
-        MessageHandlingException exception = new MessageHandlingException(null, this.ctpException);
+  /** Given no failed message When handleException Then only exeception details returned */
+  @Test
+  public void givenNoFailedMessageWhenHandleExceptionThenOnlyExeceptionDetails() {
+    MessageHandlingException exception = new MessageHandlingException(null, this.ctpException);
 
-        Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(exception);
+    Map<ExceptionHandler.ResultKey, String> result =
+        this.exceptionHandler.handleException(exception);
 
-        assertNull(result.get(ExceptionHandler.ResultKey.collectionInstrument));
-        assertNull(result.get(ExceptionHandler.ResultKey.collectionExercise));
-        assertEquals(EXCEPTION_FAULT.name(), result.get(ExceptionHandler.ResultKey.errorType));
-        assertEquals(EXCEPTION_MESSAGE, result.get(ExceptionHandler.ResultKey.errorMessage));
-        assertEquals(this.ctpException.getTimestamp(),
-                Long.parseLong(result.get(ExceptionHandler.ResultKey.errorTimestamp)));
-    }
+    assertNull(result.get(ExceptionHandler.ResultKey.collectionInstrument));
+    assertNull(result.get(ExceptionHandler.ResultKey.collectionExercise));
+    assertEquals(EXCEPTION_FAULT.name(), result.get(ExceptionHandler.ResultKey.errorType));
+    assertEquals(EXCEPTION_MESSAGE, result.get(ExceptionHandler.ResultKey.errorMessage));
+    assertEquals(
+        this.ctpException.getTimestamp(),
+        Long.parseLong(result.get(ExceptionHandler.ResultKey.errorTimestamp)));
+  }
 
-    /**
-     * Given no exception
-     * When handleException
-     * Then only message details returned
-     */
-    @Test
-    public void givenNoExceptionWhenHandleExceptionThenOnlyMessageDetails() {
-        GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
-        MessageHandlingException exception = new MessageHandlingException(message, (Exception) null);
+  /** Given no exception When handleException Then only message details returned */
+  @Test
+  public void givenNoExceptionWhenHandleExceptionThenOnlyMessageDetails() {
+    GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
+    MessageHandlingException exception = new MessageHandlingException(message, (Exception) null);
 
-        Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(exception);
+    Map<ExceptionHandler.ResultKey, String> result =
+        this.exceptionHandler.handleException(exception);
 
-        assertEquals(COLLECTION_INSTRUMENT_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionInstrument));
-        assertEquals(COLLECTION_EXERCISE_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionExercise));
-        assertNull(result.get(ExceptionHandler.ResultKey.errorType));
-        assertNull(result.get(ExceptionHandler.ResultKey.errorMessage));
-        assertNull(result.get(ExceptionHandler.ResultKey.errorTimestamp));
-    }
+    assertEquals(
+        COLLECTION_INSTRUMENT_ID.toString(),
+        result.get(ExceptionHandler.ResultKey.collectionInstrument));
+    assertEquals(
+        COLLECTION_EXERCISE_ID.toString(),
+        result.get(ExceptionHandler.ResultKey.collectionExercise));
+    assertNull(result.get(ExceptionHandler.ResultKey.errorType));
+    assertNull(result.get(ExceptionHandler.ResultKey.errorMessage));
+    assertNull(result.get(ExceptionHandler.ResultKey.errorTimestamp));
+  }
 
-    /**
-     * Given non CTPException
-     * When handleException
-     * Then only exception message returned
-     */
-    @Test
-    public void givenNonCtpExceptionWhenHandleExceptionThenOnlyExceptionMessage() {
-        GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
-        MessageHandlingException exception = new MessageHandlingException(message, new Exception(EXCEPTION_MESSAGE));
+  /** Given non CTPException When handleException Then only exception message returned */
+  @Test
+  public void givenNonCtpExceptionWhenHandleExceptionThenOnlyExceptionMessage() {
+    GenericMessage<CollectionInstrumentMessageDTO> message = new GenericMessage<>(this.messageDto);
+    MessageHandlingException exception =
+        new MessageHandlingException(message, new Exception(EXCEPTION_MESSAGE));
 
-        Map<ExceptionHandler.ResultKey, String> result = this.exceptionHandler.handleException(exception);
+    Map<ExceptionHandler.ResultKey, String> result =
+        this.exceptionHandler.handleException(exception);
 
-        assertEquals(COLLECTION_INSTRUMENT_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionInstrument));
-        assertEquals(COLLECTION_EXERCISE_ID.toString(), result.get(ExceptionHandler.ResultKey.collectionExercise));
-        assertNull(result.get(ExceptionHandler.ResultKey.errorType));
-        assertNull(result.get(ExceptionHandler.ResultKey.errorTimestamp));
-        assertEquals(EXCEPTION_MESSAGE, result.get(ExceptionHandler.ResultKey.errorMessage));
-    }
+    assertEquals(
+        COLLECTION_INSTRUMENT_ID.toString(),
+        result.get(ExceptionHandler.ResultKey.collectionInstrument));
+    assertEquals(
+        COLLECTION_EXERCISE_ID.toString(),
+        result.get(ExceptionHandler.ResultKey.collectionExercise));
+    assertNull(result.get(ExceptionHandler.ResultKey.errorType));
+    assertNull(result.get(ExceptionHandler.ResultKey.errorTimestamp));
+    assertEquals(EXCEPTION_MESSAGE, result.get(ExceptionHandler.ResultKey.errorMessage));
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUploadedInboundReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUploadedInboundReceiverTest.java
@@ -1,30 +1,5 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.SerializationUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import uk.gov.ons.ctp.common.error.CTPException;
-import uk.gov.ons.ctp.common.message.rabbit.Rabbitmq;
-import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageSender;
-import uk.gov.ons.ctp.common.state.StateTransitionManager;
-import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
-import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
-import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO;
-import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
-import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
-import uk.gov.ons.ctp.response.party.representation.SampleLinkDTO;
-import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -33,67 +8,82 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageSender;
+import uk.gov.ons.ctp.common.state.StateTransitionManager;
+import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
+import uk.gov.ons.ctp.response.collection.exercise.representation.LinkSampleSummaryDTO;
+import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
+import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
+import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
+
 @RunWith(MockitoJUnitRunner.class)
 public class SampleUploadedInboundReceiverTest {
 
-    @InjectMocks
-    private SampleUploadedInboundReceiver receiver;
+  @InjectMocks private SampleUploadedInboundReceiver receiver;
 
-    @Mock
-    private SampleService sampleService;
+  @Mock private SampleService sampleService;
 
-    @Mock
-    private CollectionExerciseService collectionExerciseService;
+  @Mock private CollectionExerciseService collectionExerciseService;
 
-    @Mock
-    private SimpleMessageSender sender;
+  @Mock private SimpleMessageSender sender;
 
-    @Mock
-    private ObjectMapper mapper;
+  @Mock private ObjectMapper mapper;
 
-    @Mock
-    private RabbitTemplate rabbitTemplate;
+  @Mock private RabbitTemplate rabbitTemplate;
 
-    @Mock
-    private StateTransitionManager<LinkSampleSummaryDTO.SampleLinkState,
-            LinkSampleSummaryDTO.SampleLinkEvent> sampleLinkState;
+  @Mock
+  private StateTransitionManager<
+          LinkSampleSummaryDTO.SampleLinkState, LinkSampleSummaryDTO.SampleLinkEvent>
+      sampleLinkState;
 
-    private SampleLink generateSampleLink(){
-        UUID sampleLinkId1 = UUID.randomUUID(),
-                collexId1 = UUID.randomUUID();
+  private SampleLink generateSampleLink() {
+    UUID sampleLinkId1 = UUID.randomUUID(), collexId1 = UUID.randomUUID();
 
-        SampleLink sampleLink = new SampleLink();
-        sampleLink.setCollectionExerciseId(collexId1);
-        sampleLink.setSampleSummaryId(sampleLinkId1);
+    SampleLink sampleLink = new SampleLink();
+    sampleLink.setCollectionExerciseId(collexId1);
+    sampleLink.setSampleSummaryId(sampleLinkId1);
 
-        return sampleLink;
-    }
+    return sampleLink;
+  }
 
-    @Test
-    public void testActivateSampleLink() throws CTPException {
-        SampleLink sampleLink = generateSampleLink();
-        List<SampleLink> sampleLinkList = Arrays.asList(new SampleLink[]{ sampleLink });
+  @Test
+  public void testActivateSampleLink() throws CTPException {
+    SampleLink sampleLink = generateSampleLink();
+    List<SampleLink> sampleLinkList = Arrays.asList(new SampleLink[] {sampleLink});
 
-        when(this.sampleService.getSampleLinksForSummary(any())).thenReturn(sampleLinkList);
-        when(this.sampleLinkState.transition(any(),
-                any(LinkSampleSummaryDTO.SampleLinkEvent.class))).thenReturn(LinkSampleSummaryDTO.SampleLinkState.ACTIVE);
+    when(this.sampleService.getSampleLinksForSummary(any())).thenReturn(sampleLinkList);
+    when(this.sampleLinkState.transition(any(), any(LinkSampleSummaryDTO.SampleLinkEvent.class)))
+        .thenReturn(LinkSampleSummaryDTO.SampleLinkState.ACTIVE);
 
-        this.receiver.sampleUploaded(new SampleSummaryDTO());
+    this.receiver.sampleUploaded(new SampleSummaryDTO());
 
-        ArgumentCaptor<SampleLink> sampleLinkCaptor = ArgumentCaptor.forClass(SampleLink.class);
-        verify(this.sampleService, times(1)).saveSampleLink(sampleLinkCaptor.capture());
-        verify(this.rabbitTemplate, times(1))
-                .convertAndSend(
-                        eq(SampleUploadedInboundReceiver.OUTBOUND_EXCHANGE),
-                        eq(SampleUploadedInboundReceiver.OUTBOUND_ROUTING_KEY),
-                        anyString());
-        verify(this.collectionExerciseService, times(1))
-                .transitionScheduleCollectionExerciseToReadyToReview(eq(sampleLink.getCollectionExerciseId()));
+    ArgumentCaptor<SampleLink> sampleLinkCaptor = ArgumentCaptor.forClass(SampleLink.class);
+    verify(this.sampleService, times(1)).saveSampleLink(sampleLinkCaptor.capture());
+    verify(this.rabbitTemplate, times(1))
+        .convertAndSend(
+            eq(SampleUploadedInboundReceiver.OUTBOUND_EXCHANGE),
+            eq(SampleUploadedInboundReceiver.OUTBOUND_ROUTING_KEY),
+            anyString());
+    verify(this.collectionExerciseService, times(1))
+        .transitionScheduleCollectionExerciseToReadyToReview(
+            eq(sampleLink.getCollectionExerciseId()));
 
-        SampleLink capturedLink = sampleLinkCaptor.getValue();
+    SampleLink capturedLink = sampleLinkCaptor.getValue();
 
-        assertEquals(sampleLink.getSampleSummaryId(), capturedLink.getSampleSummaryId());
-        assertEquals(sampleLink.getCollectionExerciseId(), capturedLink.getCollectionExerciseId());
-        assertEquals(LinkSampleSummaryDTO.SampleLinkState.ACTIVE, capturedLink.getState());
-    }
+    assertEquals(sampleLink.getSampleSummaryId(), capturedLink.getSampleSummaryId());
+    assertEquals(sampleLink.getCollectionExerciseId(), capturedLink.getCollectionExerciseId());
+    assertEquals(LinkSampleSummaryDTO.SampleLinkState.ACTIVE, capturedLink.getState());
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/schedule/SchedulerConfigurationTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/schedule/SchedulerConfigurationTests.java
@@ -1,5 +1,16 @@
 package uk.gov.ons.ctp.response.collection.exercise.schedule;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,130 +26,119 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
-import java.sql.Timestamp;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-/**
- * Class containing tests for SchedulerConfiguration
- */
+/** Class containing tests for SchedulerConfiguration */
 @RunWith(MockitoJUnitRunner.class)
 public class SchedulerConfigurationTests {
-    private static final Timestamp EVENT_TIMESTAMP = new Timestamp(new Date().getTime());
-    private static final EventService.Tag EVENT_TAG = EventService.Tag.go_live;
-    @Mock
-    private Scheduler scheduler;
-    @Mock
-    private EventService eventService;
-    @InjectMocks
-    private SchedulerConfiguration schedulerConfiguration;
-    private Event event;
-    private JobKey jobKey;
+  private static final Timestamp EVENT_TIMESTAMP = new Timestamp(new Date().getTime());
+  private static final EventService.Tag EVENT_TAG = EventService.Tag.go_live;
+  @Mock private Scheduler scheduler;
+  @Mock private EventService eventService;
+  @InjectMocks private SchedulerConfiguration schedulerConfiguration;
+  private Event event;
+  private JobKey jobKey;
 
-    /**
-     * Generate a single test event with a random UUID (collection exercise also has random UUID)
-     * @return a test event
-     */
-    private static Event getTestEvent() {
-        CollectionExercise collex = new CollectionExercise();
-        collex.setId(UUID.randomUUID());
+  /**
+   * Generate a single test event with a random UUID (collection exercise also has random UUID)
+   *
+   * @return a test event
+   */
+  private static Event getTestEvent() {
+    CollectionExercise collex = new CollectionExercise();
+    collex.setId(UUID.randomUUID());
 
-        Event event = new Event();
+    Event event = new Event();
 
-        event.setId(UUID.randomUUID());
-        event.setCollectionExercise(collex);
-        event.setTimestamp(EVENT_TIMESTAMP);
-        event.setTag(EVENT_TAG.name());
+    event.setId(UUID.randomUUID());
+    event.setCollectionExercise(collex);
+    event.setTimestamp(EVENT_TIMESTAMP);
+    event.setTag(EVENT_TAG.name());
 
-        return event;
-    }
+    return event;
+  }
 
-    /**
-     * Setup method run before each test
-     */
-    @Before
-    public void setUp() {
-        this.event = getTestEvent();
-        this.jobKey = JobKey.jobKey(SchedulerConfiguration.getJobKey(this.event.getCollectionExercise().getId(),
-                this.event));
-    }
+  /** Setup method run before each test */
+  @Before
+  public void setUp() {
+    this.event = getTestEvent();
+    this.jobKey =
+        JobKey.jobKey(
+            SchedulerConfiguration.getJobKey(
+                this.event.getCollectionExercise().getId(), this.event));
+  }
 
-    /**
-     * Test of scheduling an event
-     * @throws SchedulerException thrown by quartz if there is a problem scheduling the event
-     */
-    @Test
-    public void testScheduleEvent() throws SchedulerException {
-        when(scheduler.checkExists(this.jobKey)).thenReturn(Boolean.FALSE);
+  /**
+   * Test of scheduling an event
+   *
+   * @throws SchedulerException thrown by quartz if there is a problem scheduling the event
+   */
+  @Test
+  public void testScheduleEvent() throws SchedulerException {
+    when(scheduler.checkExists(this.jobKey)).thenReturn(Boolean.FALSE);
 
-        SchedulerConfiguration.scheduleEvent(this.scheduler, this.event);
+    SchedulerConfiguration.scheduleEvent(this.scheduler, this.event);
 
-        verify(scheduler, times(1)).scheduleJob(any(JobDetail.class), any(Trigger.class));
-    }
+    verify(scheduler, times(1)).scheduleJob(any(JobDetail.class), any(Trigger.class));
+  }
 
-    /**
-     * Test of rescheduling an event
-     * @throws SchedulerException thrown by quartz if there is a problem rescheduling the event
-     */
-    @Test
-    public void testRescheduleEvent() throws SchedulerException {
-        when(scheduler.checkExists(this.jobKey)).thenReturn(Boolean.FALSE);
+  /**
+   * Test of rescheduling an event
+   *
+   * @throws SchedulerException thrown by quartz if there is a problem rescheduling the event
+   */
+  @Test
+  public void testRescheduleEvent() throws SchedulerException {
+    when(scheduler.checkExists(this.jobKey)).thenReturn(Boolean.FALSE);
 
-        SchedulerConfiguration.scheduleEvent(this.scheduler, this.event);
+    SchedulerConfiguration.scheduleEvent(this.scheduler, this.event);
 
-        when(scheduler.checkExists(this.jobKey)).thenReturn(Boolean.TRUE);
+    when(scheduler.checkExists(this.jobKey)).thenReturn(Boolean.TRUE);
 
-        SchedulerConfiguration.scheduleEvent(this.scheduler, event);
+    SchedulerConfiguration.scheduleEvent(this.scheduler, event);
 
-        verify(scheduler, times(2)).scheduleJob(any(JobDetail.class), any(Trigger.class));
-    }
+    verify(scheduler, times(2)).scheduleJob(any(JobDetail.class), any(Trigger.class));
+  }
 
-    /**
-     * Test of unscheduling an event
-     * @throws SchedulerException thrown by quartz if there is a problem unscheduling the event
-     */
-    @Test
-    public void testUnscheduleEvent() throws SchedulerException {
-        when(scheduler.checkExists(this.jobKey)).thenReturn(Boolean.FALSE);
+  /**
+   * Test of unscheduling an event
+   *
+   * @throws SchedulerException thrown by quartz if there is a problem unscheduling the event
+   */
+  @Test
+  public void testUnscheduleEvent() throws SchedulerException {
+    when(scheduler.checkExists(this.jobKey)).thenReturn(Boolean.FALSE);
 
-        SchedulerConfiguration.unscheduleEvent(this.scheduler, this.event);
+    SchedulerConfiguration.unscheduleEvent(this.scheduler, this.event);
 
-        verify(scheduler, times(1)).deleteJob(this.jobKey);
-    }
+    verify(scheduler, times(1)).deleteJob(this.jobKey);
+  }
 
-    /**
-     * Test of scheduling outstanding events (those for which messageSent is null)
-     * @throws SchedulerException throw by quartz if error scheduling outstanding events
-     */
-    @Test
-    public void testScheduleOutstandingEvents() throws SchedulerException {
-        int numTestEvents = 10;
-        List<Event> testEvents = getTestEventList(numTestEvents);
+  /**
+   * Test of scheduling outstanding events (those for which messageSent is null)
+   *
+   * @throws SchedulerException throw by quartz if error scheduling outstanding events
+   */
+  @Test
+  public void testScheduleOutstandingEvents() throws SchedulerException {
+    int numTestEvents = 10;
+    List<Event> testEvents = getTestEventList(numTestEvents);
 
-        when(this.eventService.getOutstandingEvents()).thenReturn(testEvents);
+    when(this.eventService.getOutstandingEvents()).thenReturn(testEvents);
 
-        this.schedulerConfiguration.scheduleOutstandingEvents(this.scheduler);
+    this.schedulerConfiguration.scheduleOutstandingEvents(this.scheduler);
 
-        verify(this.scheduler, times(numTestEvents)).scheduleJob(any(JobDetail.class), any(Trigger.class));
-    }
+    verify(this.scheduler, times(numTestEvents))
+        .scheduleJob(any(JobDetail.class), any(Trigger.class));
+  }
 
-    /**
-     * Generate a list of test events
-     * @param numEvents the number of events to create
-     * @return a list of events
-     */
-    private List<Event> getTestEventList(final Integer numEvents) {
-        return Stream
-                .generate(SchedulerConfigurationTests::getTestEvent)
-                .limit(numEvents)
-                .collect(Collectors.toList());
-    }
+  /**
+   * Generate a list of test events
+   *
+   * @param numEvents the number of events to create
+   * @return a list of events
+   */
+  private List<Event> getTestEventList(final Integer numEvents) {
+    return Stream.generate(SchedulerConfigurationTests::getTestEvent)
+        .limit(numEvents)
+        .collect(Collectors.toList());
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ActionSvcClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ActionSvcClientImplTest.java
@@ -1,5 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -17,105 +23,98 @@ import uk.gov.ons.ctp.response.collection.exercise.client.impl.ActionSvcRestClie
 import uk.gov.ons.ctp.response.collection.exercise.config.ActionSvc;
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 @RunWith(MockitoJUnitRunner.class)
 public class ActionSvcClientImplTest {
 
-    private static final String ACTION_PATH = "/actions";
-    private static final String HTTP = "http";
-    private static final String LOCALHOST = "localhost";
-    private static final String ACTION_PLAN_NAME = "example";
-    private static final String ACTION_PLAN_DESCRIPTION = "example description";
+  private static final String ACTION_PATH = "/actions";
+  private static final String HTTP = "http";
+  private static final String LOCALHOST = "localhost";
+  private static final String ACTION_PLAN_NAME = "example";
+  private static final String ACTION_PLAN_DESCRIPTION = "example description";
 
-    @Mock
-    private AppConfig appConfig;
+  @Mock private AppConfig appConfig;
 
-    @InjectMocks
-    private ActionSvcRestClientImpl actionSvcClient;
+  @InjectMocks private ActionSvcRestClientImpl actionSvcClient;
 
-    @Mock
-    private RestTemplate restTemplate;
+  @Mock private RestTemplate restTemplate;
 
-    @Mock
-    private RestUtility restUtility;
+  @Mock private RestUtility restUtility;
 
-    /**
-     * Test that the action service is called with the correct details when creating action plan.
-     */
-    @Test
-    public void testCreateActionPlan() {
-        // Given
-        ActionSvc actionSvcConfig = new ActionSvc();
-        actionSvcConfig.setActionPlansPath(ACTION_PATH);
-        when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
+  /** Test that the action service is called with the correct details when creating action plan. */
+  @Test
+  public void testCreateActionPlan() {
+    // Given
+    ActionSvc actionSvcConfig = new ActionSvc();
+    actionSvcConfig.setActionPlansPath(ACTION_PATH);
+    when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
 
-        UriComponents uriComponents = UriComponentsBuilder.newInstance()
-                .scheme(HTTP)
-                .host(LOCALHOST)
-                .port(80)
-                .path(ACTION_PATH)
-                .build();
-        when(restUtility.createUriComponents(any(String.class), any(MultiValueMap.class))).
-                thenReturn(uriComponents);
+    UriComponents uriComponents =
+        UriComponentsBuilder.newInstance()
+            .scheme(HTTP)
+            .host(LOCALHOST)
+            .port(80)
+            .path(ACTION_PATH)
+            .build();
+    when(restUtility.createUriComponents(any(String.class), any(MultiValueMap.class)))
+        .thenReturn(uriComponents);
 
-        ActionPlanDTO actionPlanDTO = new ActionPlanDTO();
-        actionPlanDTO.setName(ACTION_PLAN_NAME);
-        actionPlanDTO.setDescription(ACTION_PLAN_DESCRIPTION);
-        actionPlanDTO.setCreatedBy("SYSTEM");
+    ActionPlanDTO actionPlanDTO = new ActionPlanDTO();
+    actionPlanDTO.setName(ACTION_PLAN_NAME);
+    actionPlanDTO.setDescription(ACTION_PLAN_DESCRIPTION);
+    actionPlanDTO.setCreatedBy("SYSTEM");
 
-        HttpEntity httpEntity = new HttpEntity<>(actionPlanDTO, null);
-        when(restUtility.createHttpEntity(any(ActionPlanDTO.class))).thenReturn(httpEntity);
-        when(restTemplate.postForObject(eq(uriComponents.toUri()), eq(httpEntity), eq(ActionPlanDTO.class)))
-                .thenReturn(actionPlanDTO);
+    HttpEntity httpEntity = new HttpEntity<>(actionPlanDTO, null);
+    when(restUtility.createHttpEntity(any(ActionPlanDTO.class))).thenReturn(httpEntity);
+    when(restTemplate.postForObject(
+            eq(uriComponents.toUri()), eq(httpEntity), eq(ActionPlanDTO.class)))
+        .thenReturn(actionPlanDTO);
 
-        // When
-        ActionPlanDTO createdActionPlanDTO = actionSvcClient.createActionPlan(
-                ACTION_PLAN_NAME, ACTION_PLAN_DESCRIPTION);
-
-        // Then
-        verify(restTemplate).postForObject(eq(uriComponents.toUri()), eq(httpEntity), eq(ActionPlanDTO.class));
-        assertEquals(createdActionPlanDTO.getName(), ACTION_PLAN_NAME);
-        assertEquals(createdActionPlanDTO.getDescription(), ACTION_PLAN_DESCRIPTION);
-        assertEquals(createdActionPlanDTO.getCreatedBy(), "SYSTEM");
-    }
-
-    /**
-     * Test that a rest client exception is thrown when issues contacting the action service to create an action plan.
-     */
-    @Test(expected = RestClientException.class)
-    public void testCreateActionPlanRestClientException() {
-        // Given
-        ActionSvc actionSvcConfig = new ActionSvc();
-        actionSvcConfig.setActionPlansPath(ACTION_PATH);
-        when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
-
-        UriComponents uriComponents = UriComponentsBuilder.newInstance()
-                .scheme(HTTP)
-                .host(LOCALHOST)
-                .port(80)
-                .path(ACTION_PATH)
-                .build();
-        when(restUtility.createUriComponents(any(String.class), any(MultiValueMap.class))).
-                thenReturn(uriComponents);
-
-        ActionPlanDTO actionPlanDTO = new ActionPlanDTO();
-        actionPlanDTO.setName(ACTION_PLAN_NAME);
-        actionPlanDTO.setDescription(ACTION_PLAN_DESCRIPTION);
-        actionPlanDTO.setCreatedBy("SYSTEM");
-        HttpEntity httpEntity = new HttpEntity<>(actionPlanDTO, null);
-        when(restUtility.createHttpEntity(any(ActionPlanDTO.class))).thenReturn(httpEntity);
-        when(restTemplate.postForObject(eq(uriComponents.toUri()), eq(httpEntity), eq(ActionPlanDTO.class)))
-                .thenThrow(RestClientException.class);
-
-        // When
+    // When
+    ActionPlanDTO createdActionPlanDTO =
         actionSvcClient.createActionPlan(ACTION_PLAN_NAME, ACTION_PLAN_DESCRIPTION);
 
-        // Then RestClientException is thrown
-    }
+    // Then
+    verify(restTemplate)
+        .postForObject(eq(uriComponents.toUri()), eq(httpEntity), eq(ActionPlanDTO.class));
+    assertEquals(createdActionPlanDTO.getName(), ACTION_PLAN_NAME);
+    assertEquals(createdActionPlanDTO.getDescription(), ACTION_PLAN_DESCRIPTION);
+    assertEquals(createdActionPlanDTO.getCreatedBy(), "SYSTEM");
+  }
 
+  /**
+   * Test that a rest client exception is thrown when issues contacting the action service to create
+   * an action plan.
+   */
+  @Test(expected = RestClientException.class)
+  public void testCreateActionPlanRestClientException() {
+    // Given
+    ActionSvc actionSvcConfig = new ActionSvc();
+    actionSvcConfig.setActionPlansPath(ACTION_PATH);
+    when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
+
+    UriComponents uriComponents =
+        UriComponentsBuilder.newInstance()
+            .scheme(HTTP)
+            .host(LOCALHOST)
+            .port(80)
+            .path(ACTION_PATH)
+            .build();
+    when(restUtility.createUriComponents(any(String.class), any(MultiValueMap.class)))
+        .thenReturn(uriComponents);
+
+    ActionPlanDTO actionPlanDTO = new ActionPlanDTO();
+    actionPlanDTO.setName(ACTION_PLAN_NAME);
+    actionPlanDTO.setDescription(ACTION_PLAN_DESCRIPTION);
+    actionPlanDTO.setCreatedBy("SYSTEM");
+    HttpEntity httpEntity = new HttpEntity<>(actionPlanDTO, null);
+    when(restUtility.createHttpEntity(any(ActionPlanDTO.class))).thenReturn(httpEntity);
+    when(restTemplate.postForObject(
+            eq(uriComponents.toUri()), eq(httpEntity), eq(ActionPlanDTO.class)))
+        .thenThrow(RestClientException.class);
+
+    // When
+    actionSvcClient.createActionPlan(ACTION_PLAN_NAME, ACTION_PLAN_DESCRIPTION);
+
+    // Then RestClientException is thrown
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
@@ -1,5 +1,24 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_DELETED;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,29 +49,7 @@ import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
 import uk.gov.ons.ctp.response.collection.exercise.state.CollectionExerciseStateTransitionManagerFactory;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.UUID;
-
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
-import static uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_DELETED;
-import static org.mockito.Matchers.any;
-
-/**
- * UnitTests for CollectionExerciseServiceImpl
- */
+/** UnitTests for CollectionExerciseServiceImpl */
 @RunWith(MockitoJUnitRunner.class)
 public class CollectionExerciseServiceImplTest {
 
@@ -61,54 +58,42 @@ public class CollectionExerciseServiceImplTest {
   private static final UUID ACTIONPLANID3 = UUID.fromString("70df56d9-f491-4ac8-b256-a10154290a8b");
   private static final UUID ACTIONPLANID4 = UUID.fromString("80df56d9-f491-4ac8-b256-a10154290a8b");
 
-  @Mock
-  private CaseTypeDefaultRepository caseTypeDefaultRepo;
+  @Mock private CaseTypeDefaultRepository caseTypeDefaultRepo;
 
-  @Mock
-  private CaseTypeOverrideRepository caseTypeOverrideRepo;
+  @Mock private CaseTypeOverrideRepository caseTypeOverrideRepo;
 
-  @Mock
-  private CollectionExerciseRepository collexRepo;
+  @Mock private CollectionExerciseRepository collexRepo;
 
-  @Mock
-  private SampleLinkRepository sampleLinkRepository;
+  @Mock private SampleLinkRepository sampleLinkRepository;
 
+  @Mock private SurveyService surveyService;
 
-  @Mock
-  private SurveyService surveyService;
+  @Mock private ActionSvcClient actionService;
 
-  @Mock
-  private ActionSvcClient actionService;
-
-  @Mock
-  private CollectionInstrumentSvcClient collectionInstrument;
+  @Mock private CollectionInstrumentSvcClient collectionInstrument;
 
   @Spy
-  private StateTransitionManager<?, ?> stateManager = new CollectionExerciseStateTransitionManagerFactory()
-          .getStateTransitionManager(CollectionExerciseStateTransitionManagerFactory.COLLLECTIONEXERCISE_ENTITY);
+  private StateTransitionManager<?, ?> stateManager =
+      new CollectionExerciseStateTransitionManagerFactory()
+          .getStateTransitionManager(
+              CollectionExerciseStateTransitionManagerFactory.COLLLECTIONEXERCISE_ENTITY);
 
-  @InjectMocks
-  @Spy
-  private CollectionExerciseServiceImpl collectionExerciseServiceImpl;
+  @InjectMocks @Spy private CollectionExerciseServiceImpl collectionExerciseServiceImpl;
 
-  /**
-   * Tests that default and override are empty
-   */
+  /** Tests that default and override are empty */
   @Test
   public void givenThatDefaultAndOverrideAreEmptyExpectEmpty() {
     List<CaseTypeDefault> caseTypeDefaultList = new ArrayList<>();
     List<CaseTypeOverride> caseTypeOverrideList = new ArrayList<>();
 
-    Collection<CaseType> caseTypeList = this.collectionExerciseServiceImpl.createCaseTypeList(caseTypeDefaultList,
-        caseTypeOverrideList);
+    Collection<CaseType> caseTypeList =
+        this.collectionExerciseServiceImpl.createCaseTypeList(
+            caseTypeDefaultList, caseTypeOverrideList);
 
     Assert.assertTrue(caseTypeList.isEmpty());
-
   }
 
-  /**
-   * Check that only default are present is Override is empty
-   */
+  /** Check that only default are present is Override is empty */
   @Test
   public void givenThatDefaultIsPopulatedAndOverrideIsEmptyExpectDefaultOnly() {
     List<CaseTypeDefault> caseTypeDefaultList = new ArrayList<>();
@@ -116,8 +101,9 @@ public class CollectionExerciseServiceImplTest {
 
     caseTypeDefaultList.add(createCaseTypeDefault(ACTIONPLANID1, "B"));
 
-    Collection<CaseType> caseTypeList = this.collectionExerciseServiceImpl.createCaseTypeList(caseTypeDefaultList,
-        caseTypeOverrideList);
+    Collection<CaseType> caseTypeList =
+        this.collectionExerciseServiceImpl.createCaseTypeList(
+            caseTypeDefaultList, caseTypeOverrideList);
 
     Assert.assertTrue(caseTypeList.iterator().next().getActionPlanId().equals(ACTIONPLANID1));
   }
@@ -129,8 +115,9 @@ public class CollectionExerciseServiceImplTest {
 
     caseTypeOverrideList.add(createCaseTypeOverride(ACTIONPLANID3, "B"));
 
-    Collection<CaseType> caseTypeList = this.collectionExerciseServiceImpl.createCaseTypeList(caseTypeDefaultList,
-        caseTypeOverrideList);
+    Collection<CaseType> caseTypeList =
+        this.collectionExerciseServiceImpl.createCaseTypeList(
+            caseTypeDefaultList, caseTypeOverrideList);
 
     Assert.assertTrue(caseTypeList.iterator().next().getActionPlanId().equals(ACTIONPLANID3));
   }
@@ -144,15 +131,16 @@ public class CollectionExerciseServiceImplTest {
 
     caseTypeOverrideList.add(createCaseTypeOverride(ACTIONPLANID3, "B"));
 
-    Collection<CaseType> caseTypeList = this.collectionExerciseServiceImpl.createCaseTypeList(caseTypeDefaultList,
-        caseTypeOverrideList);
+    Collection<CaseType> caseTypeList =
+        this.collectionExerciseServiceImpl.createCaseTypeList(
+            caseTypeDefaultList, caseTypeOverrideList);
 
     Assert.assertTrue(caseTypeList.iterator().next().getActionPlanId().equals(ACTIONPLANID3));
-
   }
 
   @Test
-  public void givenThatDefaultIsPopulatedWithMultipleAndOverrideIsPopulatedWithOneExpectOneDefaultAndOneOverride() {
+  public void
+      givenThatDefaultIsPopulatedWithMultipleAndOverrideIsPopulatedWithOneExpectOneDefaultAndOneOverride() {
 
     List<CaseTypeDefault> caseTypeDefaultList = new ArrayList<>();
     List<CaseTypeOverride> caseTypeOverrideList = new ArrayList<>();
@@ -162,16 +150,17 @@ public class CollectionExerciseServiceImplTest {
 
     caseTypeOverrideList.add(createCaseTypeOverride(ACTIONPLANID3, "BI"));
 
-    Collection<CaseType> caseTypeList = this.collectionExerciseServiceImpl.createCaseTypeList(caseTypeDefaultList,
-        caseTypeOverrideList);
+    Collection<CaseType> caseTypeList =
+        this.collectionExerciseServiceImpl.createCaseTypeList(
+            caseTypeDefaultList, caseTypeOverrideList);
     Iterator<CaseType> i = caseTypeList.iterator();
     Assert.assertTrue(i.next().getActionPlanId().equals(ACTIONPLANID1));
     Assert.assertTrue(i.next().getActionPlanId().equals(ACTIONPLANID3));
-
   }
 
   @Test
-  public void givenThatDefaultIsPopulatedWithMultipleAndOverrideIsPopulatedWithMultipleExpectMultipleOverride() {
+  public void
+      givenThatDefaultIsPopulatedWithMultipleAndOverrideIsPopulatedWithMultipleExpectMultipleOverride() {
 
     List<CaseTypeDefault> caseTypeDefaultList = new ArrayList<>();
     List<CaseTypeOverride> caseTypeOverrideList = new ArrayList<>();
@@ -182,50 +171,60 @@ public class CollectionExerciseServiceImplTest {
     caseTypeOverrideList.add(createCaseTypeOverride(ACTIONPLANID3, "B"));
     caseTypeOverrideList.add(createCaseTypeOverride(ACTIONPLANID4, "BI"));
 
-    Collection<CaseType> caseTypeList = this.collectionExerciseServiceImpl.createCaseTypeList(caseTypeDefaultList,
-        caseTypeOverrideList);
+    Collection<CaseType> caseTypeList =
+        this.collectionExerciseServiceImpl.createCaseTypeList(
+            caseTypeDefaultList, caseTypeOverrideList);
 
     Iterator<CaseType> i = caseTypeList.iterator();
     Assert.assertTrue(i.next().getActionPlanId().equals(ACTIONPLANID3));
     Assert.assertTrue(i.next().getActionPlanId().equals(ACTIONPLANID4));
-
   }
 
   /**
    * Creates a Defualt Case Type
+   *
    * @param actionPlanId actionPlanId to be used
    * @param sampleUnitTypeFK sampleUnitTypeFK as string
    * @return CaseTypeDefault
    */
   private CaseTypeDefault createCaseTypeDefault(UUID actionPlanId, String sampleUnitTypeFK) {
     CaseTypeDefault.builder().caseTypeDefaultPK(1).surveyId(UUID.randomUUID());
-    return CaseTypeDefault.builder().actionPlanId(actionPlanId).sampleUnitTypeFK(sampleUnitTypeFK).build();
+    return CaseTypeDefault.builder()
+        .actionPlanId(actionPlanId)
+        .sampleUnitTypeFK(sampleUnitTypeFK)
+        .build();
   }
-
 
   /**
    * Creates a Default Case Type
+   *
    * @param actionPlanId actionPlanId to be used
    * @param sampleUnitTypeFK sampleUnitTypeFK as string
    * @return CaseTypeOverride
    */
   private CaseTypeOverride createCaseTypeOverride(UUID actionPlanId, String sampleUnitTypeFK) {
     CaseTypeOverride.builder().caseTypeOverridePK(1).exerciseFK(1);
-    return CaseTypeOverride.builder().actionPlanId(actionPlanId).sampleUnitTypeFK(sampleUnitTypeFK).build();
+    return CaseTypeOverride.builder()
+        .actionPlanId(actionPlanId)
+        .sampleUnitTypeFK(sampleUnitTypeFK)
+        .build();
   }
 
   /**
    * Tests collection exercise is created with the correct details.
+   *
    * @throws Exception
    */
   @Test
   public void testCreateCollectionExercise() throws Exception {
     // Given
-    CollectionExercise collectionExercise = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExercise collectionExercise =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     when(collexRepo.saveAndFlush(any())).thenReturn(collectionExercise);
 
     SurveyDTO survey = FixtureHelper.loadClassFixtures(SurveyDTO[].class).get(0);
-    CollectionExerciseDTO toCreate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
+    CollectionExerciseDTO toCreate =
+        FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
     when(this.surveyService.findSurvey(UUID.fromString(toCreate.getSurveyId()))).thenReturn(survey);
 
     ActionPlanDTO actionPlanDTO = new ActionPlanDTO();
@@ -250,13 +249,16 @@ public class CollectionExerciseServiceImplTest {
 
   /**
    * Tests that create collection exercise endpoint creates the action plans.
+   *
    * @throws Exception general exception
    */
   @Test
   public void testCreateCollectionExerciseCreatesTheActionPlans() throws Exception {
     // Given
-    CollectionExerciseDTO toCreate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
-    CollectionExercise collectionExercise = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExerciseDTO toCreate =
+        FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
+    CollectionExercise collectionExercise =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     collectionExercise.setExerciseRef(toCreate.getExerciseRef());
     when(collexRepo.saveAndFlush(any())).thenReturn(collectionExercise);
     SurveyDTO survey = FixtureHelper.loadClassFixtures(SurveyDTO[].class).get(0);
@@ -276,14 +278,18 @@ public class CollectionExerciseServiceImplTest {
   }
 
   /**
-   * Tests that creating a collection exercise for which action plans exists does not try to create action plans
+   * Tests that creating a collection exercise for which action plans exists does not try to create
+   * action plans
+   *
    * @throws Exception general exception
    */
   @Test
   public void testCreateCollectionExerciseExistingDefaultActionPlans() throws Exception {
     // Given
-    CollectionExerciseDTO toCreate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
-    CollectionExercise collectionExercise = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExerciseDTO toCreate =
+        FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
+    CollectionExercise collectionExercise =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     collectionExercise.setExerciseRef(toCreate.getExerciseRef());
     when(collexRepo.saveAndFlush(any())).thenReturn(collectionExercise);
     SurveyDTO survey = FixtureHelper.loadClassFixtures(SurveyDTO[].class).get(0);
@@ -292,7 +298,8 @@ public class CollectionExerciseServiceImplTest {
     actionPlanDTO.setId(UUID.randomUUID());
     when(actionService.createActionPlan(any(), any())).thenReturn(actionPlanDTO);
     CaseTypeDefault caseTypedefault = new CaseTypeDefault();
-    when(caseTypeDefaultRepo.findTopBySurveyIdAndSampleUnitTypeFK(any(), any())).thenReturn(caseTypedefault);
+    when(caseTypeDefaultRepo.findTopBySurveyIdAndSampleUnitTypeFK(any(), any()))
+        .thenReturn(caseTypedefault);
 
     // When
     this.collectionExerciseServiceImpl.createCollectionExercise(toCreate, survey);
@@ -303,14 +310,18 @@ public class CollectionExerciseServiceImplTest {
   }
 
   /**
-   * Tests that creating a collection exercise for which action plans exists does not try to create action plans
+   * Tests that creating a collection exercise for which action plans exists does not try to create
+   * action plans
+   *
    * @throws Exception general exception
    */
   @Test
   public void testCreateCollectionExerciseExistingOverrideActionPlans() throws Exception {
     // Given
-    CollectionExerciseDTO toCreate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
-    CollectionExercise collectionExercise = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExerciseDTO toCreate =
+        FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
+    CollectionExercise collectionExercise =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     collectionExercise.setExerciseRef(toCreate.getExerciseRef());
     when(collexRepo.saveAndFlush(any())).thenReturn(collectionExercise);
     SurveyDTO survey = FixtureHelper.loadClassFixtures(SurveyDTO[].class).get(0);
@@ -319,7 +330,8 @@ public class CollectionExerciseServiceImplTest {
     actionPlanDTO.setId(UUID.randomUUID());
     when(actionService.createActionPlan(any(), any())).thenReturn(actionPlanDTO);
     CaseTypeOverride caseTypeOverride = new CaseTypeOverride();
-    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(any(), any())).thenReturn(caseTypeOverride);
+    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(any(), any()))
+        .thenReturn(caseTypeOverride);
 
     // When
     this.collectionExerciseServiceImpl.createCollectionExercise(toCreate, survey);
@@ -331,8 +343,10 @@ public class CollectionExerciseServiceImplTest {
 
   @Test
   public void testUpdateCollectionExercise() throws Exception {
-    CollectionExerciseDTO toUpdate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
-    CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExerciseDTO toUpdate =
+        FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
+    CollectionExercise existing =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     SurveyDTO survey = FixtureHelper.loadClassFixtures(SurveyDTO[].class).get(0);
     UUID surveyId = UUID.fromString(survey.getId());
     existing.setSurveyId(surveyId);
@@ -354,23 +368,27 @@ public class CollectionExerciseServiceImplTest {
 
   @Test
   public void testUpdateCollectionExerciseInvalidSurvey() throws Exception {
-    CollectionExerciseDTO toUpdate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
-    CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExerciseDTO toUpdate =
+        FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
+    CollectionExercise existing =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     existing.setSurveyId(UUID.randomUUID());
     when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
 
     try {
       this.collectionExerciseServiceImpl.updateCollectionExercise(existing.getId(), toUpdate);
       fail("Update collection exercise with null survey succeeded");
-    } catch(CTPException e){
+    } catch (CTPException e) {
       assertEquals(CTPException.Fault.BAD_REQUEST, e.getFault());
     }
   }
 
   @Test
   public void testUpdateCollectionExerciseNonUnique() throws Exception {
-    CollectionExerciseDTO toUpdate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
-    CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExerciseDTO toUpdate =
+        FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
+    CollectionExercise existing =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     existing.setSurveyId(UUID.randomUUID());
     // Set up the mock to return the one we are attempting to update
     when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
@@ -379,34 +397,37 @@ public class CollectionExerciseServiceImplTest {
     CollectionExercise otherExisting = new CollectionExercise();
     otherExisting.setId(uuid);
     // Set up the mock to return a different one with the same exercise ref and survey id
-    when(collexRepo.findByExerciseRefAndSurveyId(toUpdate.getExerciseRef(), UUID.fromString(toUpdate.getSurveyId())))
-            .thenReturn(Arrays.asList(otherExisting));
+    when(collexRepo.findByExerciseRefAndSurveyId(
+            toUpdate.getExerciseRef(), UUID.fromString(toUpdate.getSurveyId())))
+        .thenReturn(Arrays.asList(otherExisting));
 
     try {
       this.collectionExerciseServiceImpl.updateCollectionExercise(existing.getId(), toUpdate);
 
       fail("Update to collection exercise breaking uniqueness constraint succeeded");
-    } catch(CTPException e){
+    } catch (CTPException e) {
       assertEquals(CTPException.Fault.RESOURCE_VERSION_CONFLICT, e.getFault());
     }
   }
 
   @Test
   public void testUpdateCollectionExerciseDoesNotExist() throws Exception {
-    CollectionExerciseDTO toUpdate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
+    CollectionExerciseDTO toUpdate =
+        FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
     UUID updateUuid = UUID.randomUUID();
 
     try {
       this.collectionExerciseServiceImpl.updateCollectionExercise(updateUuid, toUpdate);
       fail("Update of non-existent collection exercise succeeded");
-    } catch(CTPException e){
+    } catch (CTPException e) {
       assertEquals(CTPException.Fault.RESOURCE_NOT_FOUND, e.getFault());
     }
   }
 
   @Test
   public void testDeleteCollectionExercise() throws Exception {
-    CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExercise existing =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
 
     this.collectionExerciseServiceImpl.deleteCollectionExercise(existing.getId());
@@ -419,7 +440,8 @@ public class CollectionExerciseServiceImplTest {
 
   @Test
   public void testUndeleteCollectionExercise() throws Exception {
-    CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExercise existing =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
 
     this.collectionExerciseServiceImpl.undeleteCollectionExercise(existing.getId());
@@ -432,26 +454,29 @@ public class CollectionExerciseServiceImplTest {
 
   @Test
   public void testPatchCollectionExerciseNotExists() throws Exception {
-    CollectionExerciseDTO toUpdate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
+    CollectionExerciseDTO toUpdate =
+        FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
     UUID updateUuid = UUID.randomUUID();
 
     try {
       this.collectionExerciseServiceImpl.patchCollectionExercise(updateUuid, toUpdate);
 
       fail("Attempt to patch non-existent collection exercise succeeded");
-    } catch(CTPException e){
+    } catch (CTPException e) {
       assertEquals(CTPException.Fault.RESOURCE_NOT_FOUND, e.getFault());
     }
   }
 
   /**
-   * Method to setup the member collexRepo with a single collection exercise.  This isn't @Before as not all of the
-   * tests require a collection exercise to be present (some explicitly do not)
+   * Method to setup the member collexRepo with a single collection exercise. This isn't @Before as
+   * not all of the tests require a collection exercise to be present (some explicitly do not)
+   *
    * @return the collection exercise configured
    * @throws Exception throws if error attempting to load fixtures
    */
   private CollectionExercise setupCollectionExercise() throws Exception {
-    CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExercise existing =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     existing.setSurveyId(UUID.randomUUID());
     when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
 
@@ -511,8 +536,10 @@ public class CollectionExerciseServiceImplTest {
 
   @Test
   public void testPatchCollectionExerciseNonUnique() throws Exception {
-    CollectionExerciseDTO toUpdate = FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
-    CollectionExercise existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExerciseDTO toUpdate =
+        FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
+    CollectionExercise existing =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     existing.setSurveyId(UUID.randomUUID());
     // Set up the mock to return the one we are attempting to update
     when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
@@ -521,14 +548,15 @@ public class CollectionExerciseServiceImplTest {
     CollectionExercise otherExisting = new CollectionExercise();
     otherExisting.setId(uuid);
     // Set up the mock to return a different one with the same exercise ref and survey id
-    when(collexRepo.findByExerciseRefAndSurveyId(toUpdate.getExerciseRef(), UUID.fromString(toUpdate.getSurveyId())))
-            .thenReturn(Arrays.asList(otherExisting));
+    when(collexRepo.findByExerciseRefAndSurveyId(
+            toUpdate.getExerciseRef(), UUID.fromString(toUpdate.getSurveyId())))
+        .thenReturn(Arrays.asList(otherExisting));
 
     try {
       this.collectionExerciseServiceImpl.patchCollectionExercise(existing.getId(), toUpdate);
 
       fail("Update to collection exercise breaking uniqueness constraint succeeded");
-    } catch(CTPException e){
+    } catch (CTPException e) {
       assertEquals(CTPException.Fault.RESOURCE_VERSION_CONFLICT, e.getFault());
     }
   }
@@ -536,14 +564,16 @@ public class CollectionExerciseServiceImplTest {
   @Test
   public void testTransitionToReadyToReviewWhenScheduledWithCIsAndSample() throws Exception {
     // Given
-    CollectionExercise exercise = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExercise exercise =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     exercise.setState(CollectionExerciseDTO.CollectionExerciseState.SCHEDULED);
     SampleLink testSampleLink = new SampleLink();
     testSampleLink.setState(SampleLinkState.ACTIVE);
-    given(sampleLinkRepository.findByCollectionExerciseId(
-            exercise.getId())).willReturn(Collections.singletonList(testSampleLink));
-    String searchStringJson = new JSONObject(
-            Collections.singletonMap("COLLECTION_EXERCISE", exercise.getId().toString())).toString();
+    given(sampleLinkRepository.findByCollectionExerciseId(exercise.getId()))
+        .willReturn(Collections.singletonList(testSampleLink));
+    String searchStringJson =
+        new JSONObject(Collections.singletonMap("COLLECTION_EXERCISE", exercise.getId().toString()))
+            .toString();
     given(collectionInstrument.countCollectionInstruments(searchStringJson)).willReturn(1);
 
     // When
@@ -557,11 +587,14 @@ public class CollectionExerciseServiceImplTest {
   @Test
   public void testDoNotTransitionToReadyToReviewWhenScheduledWithCIsAndNoSample() throws Exception {
     // Given
-    CollectionExercise exercise = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExercise exercise =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     exercise.setState(CollectionExerciseDTO.CollectionExerciseState.SCHEDULED);
-    given(sampleLinkRepository.findByCollectionExerciseId(exercise.getId())).willReturn(Collections.emptyList());
-    String searchStringJson = new JSONObject(
-            Collections.singletonMap("COLLECTION_EXERCISE", exercise.getId().toString())).toString();
+    given(sampleLinkRepository.findByCollectionExerciseId(exercise.getId()))
+        .willReturn(Collections.emptyList());
+    String searchStringJson =
+        new JSONObject(Collections.singletonMap("COLLECTION_EXERCISE", exercise.getId().toString()))
+            .toString();
     given(collectionInstrument.countCollectionInstruments(searchStringJson)).willReturn(1);
 
     // When
@@ -575,12 +608,14 @@ public class CollectionExerciseServiceImplTest {
   @Test
   public void testDoNotTransitionToReadyToReviewWhenScheduledWithNoCIsAndSample() throws Exception {
     // Given
-    CollectionExercise exercise = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExercise exercise =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     exercise.setState(CollectionExerciseDTO.CollectionExerciseState.SCHEDULED);
-    given(sampleLinkRepository.findByCollectionExerciseId(exercise.getId())).willReturn(
-            Collections.singletonList(new SampleLink()));
-    String searchStringJson = new JSONObject(
-            Collections.singletonMap("COLLECTION_EXERCISE", exercise.getId().toString())).toString();
+    given(sampleLinkRepository.findByCollectionExerciseId(exercise.getId()))
+        .willReturn(Collections.singletonList(new SampleLink()));
+    String searchStringJson =
+        new JSONObject(Collections.singletonMap("COLLECTION_EXERCISE", exercise.getId().toString()))
+            .toString();
     given(collectionInstrument.countCollectionInstruments(searchStringJson)).willReturn(0);
 
     // When
@@ -591,16 +626,17 @@ public class CollectionExerciseServiceImplTest {
     verify(collexRepo, times(0)).saveAndFlush(exercise);
   }
 
-
   @Test
   public void testDoNotTransitionToReadyToReviewWhenCIsCountFailsAndReturnsNull() throws Exception {
     // Given
-    CollectionExercise exercise = FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    CollectionExercise exercise =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
     exercise.setState(CollectionExerciseDTO.CollectionExerciseState.SCHEDULED);
-    given(sampleLinkRepository
-            .findByCollectionExerciseId(exercise.getId())).willReturn(Collections.singletonList(new SampleLink()));
-    String searchStringJson = new JSONObject(
-            Collections.singletonMap("COLLECTION_EXERCISE", exercise.getId().toString())).toString();
+    given(sampleLinkRepository.findByCollectionExerciseId(exercise.getId()))
+        .willReturn(Collections.singletonList(new SampleLink()));
+    String searchStringJson =
+        new JSONObject(Collections.singletonMap("COLLECTION_EXERCISE", exercise.getId().toString()))
+            .toString();
     given(collectionInstrument.countCollectionInstruments(searchStringJson)).willReturn(null);
 
     // When
@@ -612,19 +648,19 @@ public class CollectionExerciseServiceImplTest {
   }
 
   @Test
-  public void testCreateLink(){
-      UUID sampleSummaryUuid = UUID.randomUUID(),
-           collexUuid = UUID.randomUUID();
+  public void testCreateLink() {
+    UUID sampleSummaryUuid = UUID.randomUUID(), collexUuid = UUID.randomUUID();
 
-      when(this.sampleLinkRepository.saveAndFlush(any(SampleLink.class))).then(returnsFirstArg());
+    when(this.sampleLinkRepository.saveAndFlush(any(SampleLink.class))).then(returnsFirstArg());
 
-      SampleLink sampleLink = this.collectionExerciseServiceImpl.createLink(sampleSummaryUuid, collexUuid);
+    SampleLink sampleLink =
+        this.collectionExerciseServiceImpl.createLink(sampleSummaryUuid, collexUuid);
 
-      assertEquals(sampleSummaryUuid, sampleLink.getSampleSummaryId());
-      assertEquals(collexUuid, sampleLink.getCollectionExerciseId());
-      assertEquals(SampleLinkState.INIT, sampleLink.getState());
+    assertEquals(sampleSummaryUuid, sampleLink.getSampleSummaryId());
+    assertEquals(collexUuid, sampleLink.getCollectionExerciseId());
+    assertEquals(SampleLinkState.INIT, sampleLink.getState());
 
-      verify(sampleLinkRepository, times(1)).saveAndFlush(any());
+    verify(sampleLinkRepository, times(1)).saveAndFlush(any());
   }
 
   public void testRemoveSampleSummaryLink() throws Exception {
@@ -633,18 +669,19 @@ public class CollectionExerciseServiceImplTest {
     final UUID sampleSummaryId = UUID.fromString("87043936-4d38-4696-952a-fcd55a51be96");
     final List<SampleLink> emptySampleLinks = new ArrayList<>();
 
-    doNothing().when(collectionExerciseServiceImpl)
-            .transitionCollectionExercise(collectionExerciseId, CI_SAMPLE_DELETED);
-    when(sampleLinkRepository.findByCollectionExerciseId(collectionExerciseId)).thenReturn(emptySampleLinks);
+    doNothing()
+        .when(collectionExerciseServiceImpl)
+        .transitionCollectionExercise(collectionExerciseId, CI_SAMPLE_DELETED);
+    when(sampleLinkRepository.findByCollectionExerciseId(collectionExerciseId))
+        .thenReturn(emptySampleLinks);
 
     // When
     collectionExerciseServiceImpl.removeSampleSummaryLink(sampleSummaryId, collectionExerciseId);
 
     // Then
     verify(sampleLinkRepository, times(1))
-            .deleteBySampleSummaryIdAndCollectionExerciseId(sampleSummaryId, collectionExerciseId);
+        .deleteBySampleSummaryIdAndCollectionExerciseId(sampleSummaryId, collectionExerciseId);
     verify(collectionExerciseServiceImpl, times(1))
-            .transitionCollectionExercise(collectionExerciseId, CI_SAMPLE_DELETED);
+        .transitionCollectionExercise(collectionExerciseId, CI_SAMPLE_DELETED);
   }
-
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImplTest.java
@@ -1,5 +1,18 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -13,127 +26,98 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
-/**
- * Class containing tests for EventServiceImpl
- */
+/** Class containing tests for EventServiceImpl */
 @RunWith(MockitoJUnitRunner.class)
 public class EventServiceImplTest {
-    @Mock
-    private EventRepository eventRepository;
+  @Mock private EventRepository eventRepository;
 
-    @Mock
-    private CollectionExerciseService collectionExerciseService;
+  @Mock private CollectionExerciseService collectionExerciseService;
 
-    @InjectMocks
-    private EventServiceImpl eventService;
+  @InjectMocks private EventServiceImpl eventService;
 
-    /**
-     * Given collection excercise does not exist
-     * When event is created
-     * Then exception is thrown
-     */
-    @Test
-    public void givenCollectionExcerciseDoesNotExistWhenEventIsCreatedThenExceptionIsThrown() {
-        EventDTO eventDto = new EventDTO();
-        UUID collexUuid = UUID.randomUUID();
-        eventDto.setCollectionExerciseId(collexUuid);
+  /** Given collection excercise does not exist When event is created Then exception is thrown */
+  @Test
+  public void givenCollectionExcerciseDoesNotExistWhenEventIsCreatedThenExceptionIsThrown() {
+    EventDTO eventDto = new EventDTO();
+    UUID collexUuid = UUID.randomUUID();
+    eventDto.setCollectionExerciseId(collexUuid);
 
-        try {
-            eventService.createEvent(eventDto);
+    try {
+      eventService.createEvent(eventDto);
 
-            fail("Created event with non-existent collection exercise");
-        } catch (CTPException e) {
-            // Expected 404
-            assertEquals(CTPException.Fault.RESOURCE_NOT_FOUND, e.getFault());
-        }
+      fail("Created event with non-existent collection exercise");
+    } catch (CTPException e) {
+      // Expected 404
+      assertEquals(CTPException.Fault.RESOURCE_NOT_FOUND, e.getFault());
     }
+  }
 
-    /**
-     * Given event already exists
-     * When event is created
-     * Then exception is thrown
-     */
-    @Test
-    public void givenEventAlreadyExistsWhenEventIsCreatedThenExceptionIsThrown() {
-        String tag = EventService.Tag.mps.name();
-        EventDTO eventDto = new EventDTO();
-        CollectionExercise collex = new CollectionExercise();
-        UUID collexUuid = UUID.randomUUID();
-        eventDto.setCollectionExerciseId(collexUuid);
-        eventDto.setTag(tag);
-        collex.setId(collexUuid);
+  /** Given event already exists When event is created Then exception is thrown */
+  @Test
+  public void givenEventAlreadyExistsWhenEventIsCreatedThenExceptionIsThrown() {
+    String tag = EventService.Tag.mps.name();
+    EventDTO eventDto = new EventDTO();
+    CollectionExercise collex = new CollectionExercise();
+    UUID collexUuid = UUID.randomUUID();
+    eventDto.setCollectionExerciseId(collexUuid);
+    eventDto.setTag(tag);
+    collex.setId(collexUuid);
 
-        when(collectionExerciseService.findCollectionExercise(collexUuid)).thenReturn(collex);
-        when(eventRepository.findOneByCollectionExerciseAndTag(collex, tag)).thenReturn(new Event());
+    when(collectionExerciseService.findCollectionExercise(collexUuid)).thenReturn(collex);
+    when(eventRepository.findOneByCollectionExerciseAndTag(collex, tag)).thenReturn(new Event());
 
-        try {
-            eventService.createEvent(eventDto);
+    try {
+      eventService.createEvent(eventDto);
 
-            fail("Created event with non-existent collection exercise");
-        } catch (CTPException e) {
-            // Expected 409
-            assertEquals(CTPException.Fault.RESOURCE_VERSION_CONFLICT, e.getFault());
-        }
+      fail("Created event with non-existent collection exercise");
+    } catch (CTPException e) {
+      // Expected 409
+      assertEquals(CTPException.Fault.RESOURCE_VERSION_CONFLICT, e.getFault());
     }
+  }
 
-    private static Event createEvent(EventService.Tag tag) {
-        Timestamp eventTime = new Timestamp(new Date().getTime());
-        Event event = new Event();
-        event.setTimestamp(eventTime);
-        event.setTag(tag.name());
+  private static Event createEvent(EventService.Tag tag) {
+    Timestamp eventTime = new Timestamp(new Date().getTime());
+    Event event = new Event();
+    event.setTimestamp(eventTime);
+    event.setTag(tag.name());
 
-        return event;
-    }
+    return event;
+  }
 
-    private List<Event> createEventList(EventService.Tag... tags) {
-        return Arrays.stream(tags)
-                .map(EventServiceImplTest::createEvent)
-                .collect(Collectors.toList());
-    }
+  private List<Event> createEventList(EventService.Tag... tags) {
+    return Arrays.stream(tags).map(EventServiceImplTest::createEvent).collect(Collectors.toList());
+  }
 
-    @Test
-    public void givenNoEventsWhenScheduledIsCheckedThenFalse() throws CTPException {
-        UUID collexUuid = UUID.randomUUID();
-        when(eventRepository.findByCollectionExerciseId(collexUuid)).thenReturn(new ArrayList<>());
+  @Test
+  public void givenNoEventsWhenScheduledIsCheckedThenFalse() throws CTPException {
+    UUID collexUuid = UUID.randomUUID();
+    when(eventRepository.findByCollectionExerciseId(collexUuid)).thenReturn(new ArrayList<>());
 
-        boolean scheduled = this.eventService.isScheduled(collexUuid);
+    boolean scheduled = this.eventService.isScheduled(collexUuid);
 
-        assertFalse(scheduled);
-    }
+    assertFalse(scheduled);
+  }
 
-    @Test
-    public void givenSomeEventsWhenScheduledIsCheckedThenFalse() throws CTPException {
-        UUID collexUuid = UUID.randomUUID();
-        List<Event> events = createEventList(EventService.Tag.mps, EventService.Tag.exercise_end);
-        when(eventRepository.findByCollectionExerciseId(collexUuid)).thenReturn(events);
+  @Test
+  public void givenSomeEventsWhenScheduledIsCheckedThenFalse() throws CTPException {
+    UUID collexUuid = UUID.randomUUID();
+    List<Event> events = createEventList(EventService.Tag.mps, EventService.Tag.exercise_end);
+    when(eventRepository.findByCollectionExerciseId(collexUuid)).thenReturn(events);
 
-        boolean scheduled = this.eventService.isScheduled(collexUuid);
+    boolean scheduled = this.eventService.isScheduled(collexUuid);
 
-        assertFalse(scheduled);
-    }
+    assertFalse(scheduled);
+  }
 
-    @Test
-    public void givenAllEventsWhenScheduledIsCheckedThenTrue() throws CTPException {
-        UUID collexUuid = UUID.randomUUID();
-        List<Event> events = createEventList(EventService.Tag.values());
-        when(eventRepository.findByCollectionExerciseId(collexUuid)).thenReturn(events);
+  @Test
+  public void givenAllEventsWhenScheduledIsCheckedThenTrue() throws CTPException {
+    UUID collexUuid = UUID.randomUUID();
+    List<Event> events = createEventList(EventService.Tag.values());
+    when(eventRepository.findByCollectionExerciseId(collexUuid)).thenReturn(events);
 
-        boolean scheduled = this.eventService.isScheduled(collexUuid);
+    boolean scheduled = this.eventService.isScheduled(collexUuid);
 
-        assertTrue(scheduled);
-    }
+    assertTrue(scheduled);
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventValidatorTest.java
@@ -1,5 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,319 +14,348 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-
 @RunWith(MockitoJUnitRunner.class)
 public class EventValidatorTest {
 
-    private EventValidator validator;
-
-    private List<Event> mandatoryEvents;
-
-    private List<Event> allEvents;
-
-    @Before
-    public void setUp() {
-        this.validator = new EventValidator();
-        this.mandatoryEvents = createMandatoryEvents();
-        this.allEvents = createAllEvents();
-    }
-
-    @Test
-    public void testValidMpsEventUpdate() {
-        long now = System.currentTimeMillis();
-
-        Event mpsEvent = new Event();
-        mpsEvent.setTag(EventService.Tag.mps.toString());
-        mpsEvent.setTimestamp(new Timestamp(now + 1500000));
-
-        assertTrue(this.validator.validate(this.mandatoryEvents, mpsEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testValidGoLiveEventUpdate() {
-        long now = System.currentTimeMillis();
-
-        Event goLiveEvent = new Event();
-        goLiveEvent.setTag(EventService.Tag.go_live.toString());
-        goLiveEvent.setTimestamp(new Timestamp(now + 2500000));
-
-        assertTrue(this.validator.validate(this.mandatoryEvents, goLiveEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testValidReturnByEventUpdate() {
-        long now = System.currentTimeMillis();
-
-        Event returnByEvent = new Event();
-        returnByEvent.setTag(EventService.Tag.return_by.toString());
-        returnByEvent.setTimestamp(new Timestamp(now + 3500000));
-
-        assertTrue(this.validator.validate(this.mandatoryEvents, returnByEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testValidExerciseEndEventUpdate() {
-        long now = System.currentTimeMillis();
-
-        Event exerciseEndEvent = new Event();
-        exerciseEndEvent.setTag(EventService.Tag.exercise_end.toString());
-        exerciseEndEvent.setTimestamp(new Timestamp(now + 4500000));
-
-        assertTrue(this.validator.validate(this.mandatoryEvents, exerciseEndEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testInvalidMpsEventUpdate() {
-        long now = System.currentTimeMillis();
-
-        Event mpsEvent = new Event();
-        mpsEvent.setTag(EventService.Tag.mps.toString());
-        mpsEvent.setTimestamp(new Timestamp(now + 3500000));
-
-        assertFalse(this.validator.validate(this.mandatoryEvents, mpsEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testInvalidGoLiveEventUpdate() {
-        long now = System.currentTimeMillis();
-
-        Event goLiveEvent = new Event();
-        goLiveEvent.setTag(EventService.Tag.go_live.toString());
-        goLiveEvent.setTimestamp(new Timestamp(now + 3500000));
-
-        assertFalse(this.validator.validate(this.mandatoryEvents, goLiveEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testInvalidReturnByEventUpdate() {
-        long now = System.currentTimeMillis();
-
-        Event returnByEvent = new Event();
-        returnByEvent.setTag(EventService.Tag.return_by.toString());
-        returnByEvent.setTimestamp(new Timestamp(now + 4500000));
-
-        assertFalse(this.validator.validate(this.mandatoryEvents, returnByEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testInvalidExerciseEndEventUpdate() {
-        long now = System.currentTimeMillis();
-
-        Event exerciseEndEvent = new Event();
-        exerciseEndEvent.setTag(EventService.Tag.exercise_end.toString());
-        exerciseEndEvent.setTimestamp(new Timestamp(now + 1500000));
-
-        assertFalse(this.validator.validate(this.mandatoryEvents, exerciseEndEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-
-    @Test
-    public void testInvalidEventInPastUpdate() {
-
-        List<Event> eventListWithPastMPS = createMandatoryEvents(-1000000);
-
-        long now = System.currentTimeMillis();
-
-        Event mpsEvent = new Event();
-        mpsEvent.setTag(EventService.Tag.mps.toString());
-        mpsEvent.setTimestamp(new Timestamp(now+1500000));
-
-        assertFalse(this.validator.validate(eventListWithPastMPS, mpsEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testUpdateNonExistentEvent() {
-        List<Event> eventListWithoutExerciseEnd = createMandatoryEvents();
-        eventListWithoutExerciseEnd.remove(eventListWithoutExerciseEnd.size()-1);
-
-        long now = System.currentTimeMillis();
-
-        Event exerciseEndEvent = new Event();
-        exerciseEndEvent.setTag(EventService.Tag.exercise_end.toString());
-        exerciseEndEvent.setTimestamp(new Timestamp(now));
-
-        assertFalse(this.validator.validate(eventListWithoutExerciseEnd, exerciseEndEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testReferencePeriodIncorrectOrder() {
-        long now = System.currentTimeMillis();
-
-        Event referencePeriodStart = new Event();
-        referencePeriodStart.setTag(EventService.Tag.ref_period_start.toString());
-        referencePeriodStart.setTimestamp(new Timestamp(now-1000));
-
-        assertFalse(this.validator.validate(this.allEvents, referencePeriodStart,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testReminderBeforeGoLive() {
-        long now = System.currentTimeMillis();
-
-        Event reminderEvent = new Event();
-        reminderEvent.setTag(EventService.Tag.reminder.toString());
-        reminderEvent.setTimestamp(new Timestamp(now));
-
-        assertFalse(this.validator.validate(this.allEvents, reminderEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testReminderBeforeAfterExerciseEnd() {
-        long now = System.currentTimeMillis();
-
-        Event reminderEvent = new Event();
-        reminderEvent.setTag(EventService.Tag.reminder.toString());
-        reminderEvent.setTimestamp(new Timestamp(now + 5000000));
-
-        assertFalse(this.validator.validate(this.allEvents, reminderEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    @Test
-    public void testCanUpdateReminderWhenReadyForLive() {
-        long now = System.currentTimeMillis();
-
-        Event reminderEvent = new Event();
-        reminderEvent.setTag(EventService.Tag.reminder.toString());
-        reminderEvent.setTimestamp(new Timestamp(now + 3000000));
-
-        assertTrue(this.validator.validate(this.allEvents, reminderEvent,
-                CollectionExerciseDTO.CollectionExerciseState.READY_FOR_LIVE));
-    }
-
-    @Test
-    public void testUpdateNonMandatoryNonReminderWhenReadyForLive() {
-        long now = System.currentTimeMillis();
-
-        Event referencePeriodStart = new Event();
-        referencePeriodStart.setTag(EventService.Tag.ref_period_start.toString());
-        referencePeriodStart.setTimestamp(new Timestamp(now - 20000));
-
-        assertFalse(this.validator.validate(this.allEvents, referencePeriodStart,
-                CollectionExerciseDTO.CollectionExerciseState.READY_FOR_LIVE));
-    }
-
-    @Test
-    public void testUpdateMandatoryEventWhenReadyForLive() {
-        long now = System.currentTimeMillis();
-
-        Event mpsEvent = new Event();
-        mpsEvent.setTag(EventService.Tag.mps.toString());
-        mpsEvent.setTimestamp(new Timestamp(now + 1000000));
-
-        assertFalse(this.validator.validate(this.allEvents, mpsEvent,
-                CollectionExerciseDTO.CollectionExerciseState.READY_FOR_LIVE));
-    }
-
-    @Test
-    public void testCantUpdatePastReminder() {
-        List<Event> events = createMandatoryEvents(-230000);
-        List<Event> nonMandatoryEventsWithPastReminder = createNonMandatoryEvents(-230000);
-
-        events.addAll(nonMandatoryEventsWithPastReminder);
-
-        long now = System.currentTimeMillis();
-
-        Event reminderEvent = new Event();
-        reminderEvent.setTag(EventService.Tag.reminder.toString());
-        reminderEvent.setTimestamp(new Timestamp(now));
-
-        assertFalse(this.validator.validate(events, reminderEvent,
-                CollectionExerciseDTO.CollectionExerciseState.CREATED));
-    }
-
-    private List<Event> createAllEvents() {
-        List<Event> events = createMandatoryEvents();
-        events.addAll(createNonMandatoryEvents());
-        return events;
-    }
-
-    private List<Event> createNonMandatoryEvents() {
-        return createNonMandatoryEvents(0);
-    }
-
-    private List<Event> createNonMandatoryEvents(final long offset) {
-        List<Event> nonMandatoryEvents = new ArrayList<>();
-
-        long now = System.currentTimeMillis();
-
-        Event reminder = new Event();
-        reminder.setTag(EventService.Tag.reminder.toString());
-        reminder.setTimestamp(new Timestamp(now + 3000000 + offset));
-        nonMandatoryEvents.add(reminder);
-
-        Event reminder2 = new Event();
-        reminder2.setTag(EventService.Tag.reminder2.toString());
-        reminder2.setTimestamp(new Timestamp(now + 3000000 + offset));
-        nonMandatoryEvents.add(reminder2);
-
-        Event reminder3 = new Event();
-        reminder3.setTag(EventService.Tag.reminder3.toString());
-        reminder3.setTimestamp(new Timestamp(now + 3000000 + offset));
-        nonMandatoryEvents.add(reminder2);
-
-        Event refPeriodStart = new Event();
-        refPeriodStart.setTag(EventService.Tag.ref_period_start.toString());
-        refPeriodStart.setTimestamp(new Timestamp(now - 20000 + offset));
-        nonMandatoryEvents.add(refPeriodStart);
-
-        Event refPeriodEnd = new Event();
-        refPeriodEnd.setTag(EventService.Tag.ref_period_end.toString());
-        refPeriodEnd.setTimestamp(new Timestamp(now - 10000 + offset));
-        nonMandatoryEvents.add(refPeriodEnd);
-
-        return nonMandatoryEvents;
-    }
-
-    private List<Event> createMandatoryEvents() {
-        return createMandatoryEvents(0);
-    }
-
-    private List<Event> createMandatoryEvents(final long offset) {
-        List<Event> eventList = new ArrayList<>();
-
-        long now = System.currentTimeMillis();
-
-        Event mpsEvent = new Event();
-        mpsEvent.setTag(EventService.Tag.mps.toString());
-        mpsEvent.setTimestamp(new Timestamp(now + 1000000 + offset));
-        eventList.add(mpsEvent);
-
-
-        Event goLiveEvent = new Event();
-        goLiveEvent.setTag(EventService.Tag.go_live.toString());
-        goLiveEvent.setTimestamp(new Timestamp(now + 2000000 + offset));
-        eventList.add(goLiveEvent);
-
-        Event returnByEvent = new Event();
-        returnByEvent.setTag(EventService.Tag.return_by.toString());
-        returnByEvent.setTimestamp(new Timestamp(now + 3000000 + offset));
-        eventList.add(returnByEvent);
-
-        Event exerciseEndEvent = new Event();
-        exerciseEndEvent.setTag(EventService.Tag.exercise_end.toString());
-        exerciseEndEvent.setTimestamp(new Timestamp(now + 4000000 + offset));
-        eventList.add(exerciseEndEvent);
-
-        return eventList;
-    }
+  private EventValidator validator;
+
+  private List<Event> mandatoryEvents;
+
+  private List<Event> allEvents;
+
+  @Before
+  public void setUp() {
+    this.validator = new EventValidator();
+    this.mandatoryEvents = createMandatoryEvents();
+    this.allEvents = createAllEvents();
+  }
+
+  @Test
+  public void testValidMpsEventUpdate() {
+    long now = System.currentTimeMillis();
+
+    Event mpsEvent = new Event();
+    mpsEvent.setTag(EventService.Tag.mps.toString());
+    mpsEvent.setTimestamp(new Timestamp(now + 1500000));
+
+    assertTrue(
+        this.validator.validate(
+            this.mandatoryEvents, mpsEvent, CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testValidGoLiveEventUpdate() {
+    long now = System.currentTimeMillis();
+
+    Event goLiveEvent = new Event();
+    goLiveEvent.setTag(EventService.Tag.go_live.toString());
+    goLiveEvent.setTimestamp(new Timestamp(now + 2500000));
+
+    assertTrue(
+        this.validator.validate(
+            this.mandatoryEvents,
+            goLiveEvent,
+            CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testValidReturnByEventUpdate() {
+    long now = System.currentTimeMillis();
+
+    Event returnByEvent = new Event();
+    returnByEvent.setTag(EventService.Tag.return_by.toString());
+    returnByEvent.setTimestamp(new Timestamp(now + 3500000));
+
+    assertTrue(
+        this.validator.validate(
+            this.mandatoryEvents,
+            returnByEvent,
+            CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testValidExerciseEndEventUpdate() {
+    long now = System.currentTimeMillis();
+
+    Event exerciseEndEvent = new Event();
+    exerciseEndEvent.setTag(EventService.Tag.exercise_end.toString());
+    exerciseEndEvent.setTimestamp(new Timestamp(now + 4500000));
+
+    assertTrue(
+        this.validator.validate(
+            this.mandatoryEvents,
+            exerciseEndEvent,
+            CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testInvalidMpsEventUpdate() {
+    long now = System.currentTimeMillis();
+
+    Event mpsEvent = new Event();
+    mpsEvent.setTag(EventService.Tag.mps.toString());
+    mpsEvent.setTimestamp(new Timestamp(now + 3500000));
+
+    assertFalse(
+        this.validator.validate(
+            this.mandatoryEvents, mpsEvent, CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testInvalidGoLiveEventUpdate() {
+    long now = System.currentTimeMillis();
+
+    Event goLiveEvent = new Event();
+    goLiveEvent.setTag(EventService.Tag.go_live.toString());
+    goLiveEvent.setTimestamp(new Timestamp(now + 3500000));
+
+    assertFalse(
+        this.validator.validate(
+            this.mandatoryEvents,
+            goLiveEvent,
+            CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testInvalidReturnByEventUpdate() {
+    long now = System.currentTimeMillis();
+
+    Event returnByEvent = new Event();
+    returnByEvent.setTag(EventService.Tag.return_by.toString());
+    returnByEvent.setTimestamp(new Timestamp(now + 4500000));
+
+    assertFalse(
+        this.validator.validate(
+            this.mandatoryEvents,
+            returnByEvent,
+            CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testInvalidExerciseEndEventUpdate() {
+    long now = System.currentTimeMillis();
+
+    Event exerciseEndEvent = new Event();
+    exerciseEndEvent.setTag(EventService.Tag.exercise_end.toString());
+    exerciseEndEvent.setTimestamp(new Timestamp(now + 1500000));
+
+    assertFalse(
+        this.validator.validate(
+            this.mandatoryEvents,
+            exerciseEndEvent,
+            CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testInvalidEventInPastUpdate() {
+
+    List<Event> eventListWithPastMPS = createMandatoryEvents(-1000000);
+
+    long now = System.currentTimeMillis();
+
+    Event mpsEvent = new Event();
+    mpsEvent.setTag(EventService.Tag.mps.toString());
+    mpsEvent.setTimestamp(new Timestamp(now + 1500000));
+
+    assertFalse(
+        this.validator.validate(
+            eventListWithPastMPS, mpsEvent, CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testUpdateNonExistentEvent() {
+    List<Event> eventListWithoutExerciseEnd = createMandatoryEvents();
+    eventListWithoutExerciseEnd.remove(eventListWithoutExerciseEnd.size() - 1);
+
+    long now = System.currentTimeMillis();
+
+    Event exerciseEndEvent = new Event();
+    exerciseEndEvent.setTag(EventService.Tag.exercise_end.toString());
+    exerciseEndEvent.setTimestamp(new Timestamp(now));
+
+    assertFalse(
+        this.validator.validate(
+            eventListWithoutExerciseEnd,
+            exerciseEndEvent,
+            CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testReferencePeriodIncorrectOrder() {
+    long now = System.currentTimeMillis();
+
+    Event referencePeriodStart = new Event();
+    referencePeriodStart.setTag(EventService.Tag.ref_period_start.toString());
+    referencePeriodStart.setTimestamp(new Timestamp(now - 1000));
+
+    assertFalse(
+        this.validator.validate(
+            this.allEvents,
+            referencePeriodStart,
+            CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testReminderBeforeGoLive() {
+    long now = System.currentTimeMillis();
+
+    Event reminderEvent = new Event();
+    reminderEvent.setTag(EventService.Tag.reminder.toString());
+    reminderEvent.setTimestamp(new Timestamp(now));
+
+    assertFalse(
+        this.validator.validate(
+            this.allEvents, reminderEvent, CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testReminderBeforeAfterExerciseEnd() {
+    long now = System.currentTimeMillis();
+
+    Event reminderEvent = new Event();
+    reminderEvent.setTag(EventService.Tag.reminder.toString());
+    reminderEvent.setTimestamp(new Timestamp(now + 5000000));
+
+    assertFalse(
+        this.validator.validate(
+            this.allEvents, reminderEvent, CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  @Test
+  public void testCanUpdateReminderWhenReadyForLive() {
+    long now = System.currentTimeMillis();
+
+    Event reminderEvent = new Event();
+    reminderEvent.setTag(EventService.Tag.reminder.toString());
+    reminderEvent.setTimestamp(new Timestamp(now + 3000000));
+
+    assertTrue(
+        this.validator.validate(
+            this.allEvents,
+            reminderEvent,
+            CollectionExerciseDTO.CollectionExerciseState.READY_FOR_LIVE));
+  }
+
+  @Test
+  public void testUpdateNonMandatoryNonReminderWhenReadyForLive() {
+    long now = System.currentTimeMillis();
+
+    Event referencePeriodStart = new Event();
+    referencePeriodStart.setTag(EventService.Tag.ref_period_start.toString());
+    referencePeriodStart.setTimestamp(new Timestamp(now - 20000));
+
+    assertFalse(
+        this.validator.validate(
+            this.allEvents,
+            referencePeriodStart,
+            CollectionExerciseDTO.CollectionExerciseState.READY_FOR_LIVE));
+  }
+
+  @Test
+  public void testUpdateMandatoryEventWhenReadyForLive() {
+    long now = System.currentTimeMillis();
+
+    Event mpsEvent = new Event();
+    mpsEvent.setTag(EventService.Tag.mps.toString());
+    mpsEvent.setTimestamp(new Timestamp(now + 1000000));
+
+    assertFalse(
+        this.validator.validate(
+            this.allEvents,
+            mpsEvent,
+            CollectionExerciseDTO.CollectionExerciseState.READY_FOR_LIVE));
+  }
+
+  @Test
+  public void testCantUpdatePastReminder() {
+    List<Event> events = createMandatoryEvents(-230000);
+    List<Event> nonMandatoryEventsWithPastReminder = createNonMandatoryEvents(-230000);
+
+    events.addAll(nonMandatoryEventsWithPastReminder);
+
+    long now = System.currentTimeMillis();
+
+    Event reminderEvent = new Event();
+    reminderEvent.setTag(EventService.Tag.reminder.toString());
+    reminderEvent.setTimestamp(new Timestamp(now));
+
+    assertFalse(
+        this.validator.validate(
+            events, reminderEvent, CollectionExerciseDTO.CollectionExerciseState.CREATED));
+  }
+
+  private List<Event> createAllEvents() {
+    List<Event> events = createMandatoryEvents();
+    events.addAll(createNonMandatoryEvents());
+    return events;
+  }
+
+  private List<Event> createNonMandatoryEvents() {
+    return createNonMandatoryEvents(0);
+  }
+
+  private List<Event> createNonMandatoryEvents(final long offset) {
+    List<Event> nonMandatoryEvents = new ArrayList<>();
+
+    long now = System.currentTimeMillis();
+
+    Event reminder = new Event();
+    reminder.setTag(EventService.Tag.reminder.toString());
+    reminder.setTimestamp(new Timestamp(now + 3000000 + offset));
+    nonMandatoryEvents.add(reminder);
+
+    Event reminder2 = new Event();
+    reminder2.setTag(EventService.Tag.reminder2.toString());
+    reminder2.setTimestamp(new Timestamp(now + 3000000 + offset));
+    nonMandatoryEvents.add(reminder2);
+
+    Event reminder3 = new Event();
+    reminder3.setTag(EventService.Tag.reminder3.toString());
+    reminder3.setTimestamp(new Timestamp(now + 3000000 + offset));
+    nonMandatoryEvents.add(reminder2);
+
+    Event refPeriodStart = new Event();
+    refPeriodStart.setTag(EventService.Tag.ref_period_start.toString());
+    refPeriodStart.setTimestamp(new Timestamp(now - 20000 + offset));
+    nonMandatoryEvents.add(refPeriodStart);
+
+    Event refPeriodEnd = new Event();
+    refPeriodEnd.setTag(EventService.Tag.ref_period_end.toString());
+    refPeriodEnd.setTimestamp(new Timestamp(now - 10000 + offset));
+    nonMandatoryEvents.add(refPeriodEnd);
+
+    return nonMandatoryEvents;
+  }
+
+  private List<Event> createMandatoryEvents() {
+    return createMandatoryEvents(0);
+  }
+
+  private List<Event> createMandatoryEvents(final long offset) {
+    List<Event> eventList = new ArrayList<>();
+
+    long now = System.currentTimeMillis();
+
+    Event mpsEvent = new Event();
+    mpsEvent.setTag(EventService.Tag.mps.toString());
+    mpsEvent.setTimestamp(new Timestamp(now + 1000000 + offset));
+    eventList.add(mpsEvent);
+
+    Event goLiveEvent = new Event();
+    goLiveEvent.setTag(EventService.Tag.go_live.toString());
+    goLiveEvent.setTimestamp(new Timestamp(now + 2000000 + offset));
+    eventList.add(goLiveEvent);
+
+    Event returnByEvent = new Event();
+    returnByEvent.setTag(EventService.Tag.return_by.toString());
+    returnByEvent.setTimestamp(new Timestamp(now + 3000000 + offset));
+    eventList.add(returnByEvent);
+
+    Event exerciseEndEvent = new Event();
+    exerciseEndEvent.setTag(EventService.Tag.exercise_end.toString());
+    exerciseEndEvent.setTimestamp(new Timestamp(now + 4000000 + offset));
+    eventList.add(exerciseEndEvent);
+
+    return eventList;
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduleEventTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduleEventTests.java
@@ -1,5 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl.change;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,116 +20,89 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEventPublisher;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
-import java.sql.Timestamp;
-import java.util.Date;
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
-
-/**
- * Test class for ScheduleEvent
- */
+/** Test class for ScheduleEvent */
 @RunWith(MockitoJUnitRunner.class)
 public class ScheduleEventTests {
 
-    /**
-     * Test timestamp to use
-     */
-    private static final Date EVENT_TIMESTAMP = new Date();
-    /**
-     * Random collection exercise id
-     */
-    private static final UUID COLLECTION_EXERCISE_ID = UUID.randomUUID();
-    /**
-     * Random collection exercise event id
-     */
-    private static final UUID EVENT_ID = UUID.randomUUID();
-    /**
-     * Scheduler mock
-     */
-    @Mock
-    private EventService eventService;
-    /**
-     * Schedule event object under test
-     */
-    @InjectMocks
-    private ScheduleEvent scheduleEvent;
-    /**
-     * Test event
-     */
-    private Event event;
+  /** Test timestamp to use */
+  private static final Date EVENT_TIMESTAMP = new Date();
+  /** Random collection exercise id */
+  private static final UUID COLLECTION_EXERCISE_ID = UUID.randomUUID();
+  /** Random collection exercise event id */
+  private static final UUID EVENT_ID = UUID.randomUUID();
+  /** Scheduler mock */
+  @Mock private EventService eventService;
+  /** Schedule event object under test */
+  @InjectMocks private ScheduleEvent scheduleEvent;
+  /** Test event */
+  private Event event;
 
-    /**
-     * Setup method - creates an Event for testing
-     */
-    @Before
-    public void setUp() {
-        Event newEvent = new Event();
+  /** Setup method - creates an Event for testing */
+  @Before
+  public void setUp() {
+    Event newEvent = new Event();
 
-        newEvent.setTimestamp(new Timestamp(EVENT_TIMESTAMP.getTime()));
-        newEvent.setTag(EventService.Tag.go_live.name());
-        newEvent.setId(EVENT_ID);
+    newEvent.setTimestamp(new Timestamp(EVENT_TIMESTAMP.getTime()));
+    newEvent.setTag(EventService.Tag.go_live.name());
+    newEvent.setId(EVENT_ID);
 
-        CollectionExercise collex = new CollectionExercise();
-        collex.setId(COLLECTION_EXERCISE_ID);
+    CollectionExercise collex = new CollectionExercise();
+    collex.setId(COLLECTION_EXERCISE_ID);
 
-        newEvent.setCollectionExercise(collex);
+    newEvent.setCollectionExercise(collex);
 
-        this.event = newEvent;
-    }
+    this.event = newEvent;
+  }
 
-    /**
-     * Given all fields
-     * When created
-     * Then schedule event
-     *
-     * @throws CTPException thrown if error occurs
-     * @throws SchedulerException thrown if error occurs
-     */
-    @Test
-    public void givenAllFieldsWhenCreatedThenScheduleEvent() throws CTPException, SchedulerException {
-        this.scheduleEvent.handleEventLifecycle(CollectionExerciseEventPublisher.MessageType.EventCreated, this.event);
+  /**
+   * Given all fields When created Then schedule event
+   *
+   * @throws CTPException thrown if error occurs
+   * @throws SchedulerException thrown if error occurs
+   */
+  @Test
+  public void givenAllFieldsWhenCreatedThenScheduleEvent() throws CTPException, SchedulerException {
+    this.scheduleEvent.handleEventLifecycle(
+        CollectionExerciseEventPublisher.MessageType.EventCreated, this.event);
 
-        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        verify(this.eventService).scheduleEvent(eventCaptor.capture());
+    ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+    verify(this.eventService).scheduleEvent(eventCaptor.capture());
 
-        assertEquals(this.event, eventCaptor.getValue());
-    }
+    assertEquals(this.event, eventCaptor.getValue());
+  }
 
-    /**
-     * Given all fields
-     * When updated
-     * Then schedule event
-     *
-     * @throws CTPException thrown if error occurs
-     * @throws SchedulerException thrown if error occurs
-     */
-    @Test
-    public void givenAllFieldsWhenUpdatedThenScheduleEvent() throws CTPException, SchedulerException {
-        this.scheduleEvent.handleEventLifecycle(CollectionExerciseEventPublisher.MessageType.EventUpdated, this.event);
+  /**
+   * Given all fields When updated Then schedule event
+   *
+   * @throws CTPException thrown if error occurs
+   * @throws SchedulerException thrown if error occurs
+   */
+  @Test
+  public void givenAllFieldsWhenUpdatedThenScheduleEvent() throws CTPException, SchedulerException {
+    this.scheduleEvent.handleEventLifecycle(
+        CollectionExerciseEventPublisher.MessageType.EventUpdated, this.event);
 
-        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        verify(this.eventService).scheduleEvent(eventCaptor.capture());
+    ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+    verify(this.eventService).scheduleEvent(eventCaptor.capture());
 
-        assertEquals(this.event, eventCaptor.getValue());
-    }
+    assertEquals(this.event, eventCaptor.getValue());
+  }
 
-    /**
-     * Given all fields
-     * When deleted
-     * Then unschedule event
-     *
-     * @throws CTPException thrown if error occurs
-     * @throws SchedulerException thrown if error occurs
-     */
-    @Test
-    public void givenAllFieldsWhenDeletedThenUnscheduleEvent() throws CTPException, SchedulerException {
-        this.scheduleEvent.handleEventLifecycle(CollectionExerciseEventPublisher.MessageType.EventDeleted, this.event);
+  /**
+   * Given all fields When deleted Then unschedule event
+   *
+   * @throws CTPException thrown if error occurs
+   * @throws SchedulerException thrown if error occurs
+   */
+  @Test
+  public void givenAllFieldsWhenDeletedThenUnscheduleEvent()
+      throws CTPException, SchedulerException {
+    this.scheduleEvent.handleEventLifecycle(
+        CollectionExerciseEventPublisher.MessageType.EventDeleted, this.event);
 
-        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        verify(this.eventService).unscheduleEvent(eventCaptor.capture());
+    ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+    verify(this.eventService).unscheduleEvent(eventCaptor.capture());
 
-        assertEquals(this.event, eventCaptor.getValue());
-    }
+    assertEquals(this.event, eventCaptor.getValue());
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/CollectionInstrumentClassifierTypesTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/CollectionInstrumentClassifierTypesTest.java
@@ -3,18 +3,13 @@ package uk.gov.ons.ctp.response.collection.exercise.validation;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 
-/**
- * Test ClassifierTypes expected from Survey service
- *
- */
+/** Test ClassifierTypes expected from Survey service */
 @RunWith(MockitoJUnitRunner.class)
 public class CollectionInstrumentClassifierTypesTest {
 
@@ -30,19 +25,20 @@ public class CollectionInstrumentClassifierTypesTest {
   @Test
   public void testApply() throws Exception {
 
-    List<ExerciseSampleUnit> sampleUnits = FixtureHelper.loadClassFixtures(ExerciseSampleUnit[].class);
+    List<ExerciseSampleUnit> sampleUnits =
+        FixtureHelper.loadClassFixtures(ExerciseSampleUnit[].class);
     ExerciseSampleUnit sampleUnit = sampleUnits.get(0);
-    CollectionInstrumentClassifierTypes classifierTypeCollectionExercise = CollectionInstrumentClassifierTypes
-        .valueOf(COLLECTION_EXERCISE);
-    assertEquals("14fb3e68-4dca-46db-bf49-04b84e07e77c", classifierTypeCollectionExercise.apply(sampleUnit));
+    CollectionInstrumentClassifierTypes classifierTypeCollectionExercise =
+        CollectionInstrumentClassifierTypes.valueOf(COLLECTION_EXERCISE);
+    assertEquals(
+        "14fb3e68-4dca-46db-bf49-04b84e07e77c", classifierTypeCollectionExercise.apply(sampleUnit));
 
-    CollectionInstrumentClassifierTypes classifierTypeSampleUnitRef = CollectionInstrumentClassifierTypes
-        .valueOf(RU_REF);
+    CollectionInstrumentClassifierTypes classifierTypeSampleUnitRef =
+        CollectionInstrumentClassifierTypes.valueOf(RU_REF);
     assertEquals("50000065975", classifierTypeSampleUnitRef.apply(sampleUnit));
 
-    CollectionInstrumentClassifierTypes classifierTypeFormType = CollectionInstrumentClassifierTypes
-            .valueOf(FORM_TYPE);
+    CollectionInstrumentClassifierTypes classifierTypeFormType =
+        CollectionInstrumentClassifierTypes.valueOf(FORM_TYPE);
     assertEquals("0015", classifierTypeFormType.apply(sampleUnit));
-
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
@@ -1,6 +1,22 @@
 package uk.gov.ons.ctp.response.collection.exercise.validation;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,67 +58,38 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitTyp
 import uk.gov.ons.response.survey.representation.SurveyClassifierDTO;
 import uk.gov.ons.response.survey.representation.SurveyClassifierTypeDTO;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-/**
- * Tests for the ValidatesSampleTest
- */
+/** Tests for the ValidatesSampleTest */
 @RunWith(MockitoJUnitRunner.class)
 public class ValidateSampleUnitsTest {
 
-  @Mock
-  private DistributedListManager<Integer> sampleValidationListManager;
+  @Mock private DistributedListManager<Integer> sampleValidationListManager;
+
+  @Mock private CollectionExerciseRepository collectRepo;
+
+  @Mock private ExerciseSampleUnitGroupService sampleUnitGroupSvc;
+
+  @Mock private ExerciseSampleUnitService sampleUnitSvc;
+
+  @Mock private SurveySvcClient surveySvcClient;
+
+  @Mock private PartySvcRestClientImpl partySvcClient;
+
+  @Mock private CollectionInstrumentSvcClient collectionInstrumentSvcClient;
 
   @Mock
-  private CollectionExerciseRepository collectRepo;
-
-  @Mock
-  private ExerciseSampleUnitGroupService sampleUnitGroupSvc;
-
-  @Mock
-  private ExerciseSampleUnitService sampleUnitSvc;
-
-  @Mock
-  private SurveySvcClient surveySvcClient;
-
-  @Mock
-  private PartySvcRestClientImpl partySvcClient;
-
-  @Mock
-  private CollectionInstrumentSvcClient collectionInstrumentSvcClient;
-
-  @Mock
-  private StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent> collectionExerciseTransitionState;
+  private StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent>
+      collectionExerciseTransitionState;
 
   @Mock
   private StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent> sampleUnitGroupState;
 
-  @Mock
-  private AppConfig appConfig;
+  @Mock private AppConfig appConfig;
 
-  @Mock
-  private ScheduleSettings scheduleSettings;
+  @Mock private ScheduleSettings scheduleSettings;
 
-  @Mock
-  private CollectionExerciseService collectionExerciseService;
+  @Mock private CollectionExerciseService collectionExerciseService;
 
-  @InjectMocks
-  private ValidateSampleUnits validateSampleUnits;
+  @InjectMocks private ValidateSampleUnits validateSampleUnits;
 
   private static final Integer DISTRIBUTION_SCHEDULE_RETRIEVAL_MAX = 10;
   private static final int IMPOSSIBLE_ID = Integer.MAX_VALUE;
@@ -111,26 +98,27 @@ public class ValidateSampleUnitsTest {
   private static final String COLLECTION_EXERCISE_ID_2 = "14fb3e68-4dca-46db-bf49-04b84e07e77d";
   private static final String SAMPLE_UNIT_REF = "50000065975";
 
-  private static final Map<String, String> CI_1_SVC_SEARCH = ImmutableMap.<String, String>builder()
+  private static final Map<String, String> CI_1_SVC_SEARCH =
+      ImmutableMap.<String, String>builder()
           .put("RU_REF", SAMPLE_UNIT_REF)
           .put("COLLECTION_EXERCISE", COLLECTION_EXERCISE_ID_1)
           .put("SURVEY_ID", "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87")
           .build();
-  private static final Map<String, String> CI_2_SVC_SEARCH = ImmutableMap.<String, String>builder()
+  private static final Map<String, String> CI_2_SVC_SEARCH =
+      ImmutableMap.<String, String>builder()
           .put("RU_REF", SAMPLE_UNIT_REF)
           .put("COLLECTION_EXERCISE", COLLECTION_EXERCISE_ID_2)
           .put("SURVEY_ID", "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87")
           .build();
 
-  private static final List<String> RESULT_COLLECTION_ID =Arrays.asList(COLLECTION_EXERCISE_ID_1, COLLECTION_EXERCISE_ID_2);
+  private static final List<String> RESULT_COLLECTION_ID =
+      Arrays.asList(COLLECTION_EXERCISE_ID_1, COLLECTION_EXERCISE_ID_2);
 
   private List<CollectionExercise> collectionExercises;
 
-  @Captor
-  private ArgumentCaptor<ExerciseSampleUnitGroup> sampleUnitGroupSave;
+  @Captor private ArgumentCaptor<ExerciseSampleUnitGroup> sampleUnitGroupSave;
 
-  @Captor
-  private ArgumentCaptor<List<ExerciseSampleUnit>> sampleUnitSave;
+  @Captor private ArgumentCaptor<List<ExerciseSampleUnit>> sampleUnitSave;
 
   /**
    * Setup Mock responses when all created and injected into test subject.
@@ -140,44 +128,48 @@ public class ValidateSampleUnitsTest {
   @Before
   public void setUp() throws Exception {
     when(appConfig.getSchedules()).thenReturn(scheduleSettings);
-    when(scheduleSettings.getValidationScheduleRetrievalMax()).thenReturn(DISTRIBUTION_SCHEDULE_RETRIEVAL_MAX);
+    when(scheduleSettings.getValidationScheduleRetrievalMax())
+        .thenReturn(DISTRIBUTION_SCHEDULE_RETRIEVAL_MAX);
 
     // Mock data layer domain objects CollectionExercise, SampleUnitGroup,
     // SampleUnit
     collectionExercises = FixtureHelper.loadClassFixtures(CollectionExercise[].class);
     when(collectRepo.findByState(CollectionExerciseDTO.CollectionExerciseState.EXECUTED))
-            .thenReturn(collectionExercises);
-    when(collectionExerciseService.findByState(CollectionExerciseDTO.CollectionExerciseState.EXECUTED))
+        .thenReturn(collectionExercises);
+    when(collectionExerciseService.findByState(
+            CollectionExerciseDTO.CollectionExerciseState.EXECUTED))
         .thenReturn(collectionExercises);
 
-    List<ExerciseSampleUnitGroup> sampleUnitGroups = FixtureHelper.loadClassFixtures(ExerciseSampleUnitGroup[].class);
+    List<ExerciseSampleUnitGroup> sampleUnitGroups =
+        FixtureHelper.loadClassFixtures(ExerciseSampleUnitGroup[].class);
     when(sampleUnitGroupSvc
-        .findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
-            SampleUnitGroupDTO.SampleUnitGroupState.INIT,
-            collectionExercises,
-            Collections.singletonList(IMPOSSIBLE_ID),
-            new PageRequest(0, DISTRIBUTION_SCHEDULE_RETRIEVAL_MAX)))
-                .thenReturn(sampleUnitGroups);
+            .findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
+                SampleUnitGroupDTO.SampleUnitGroupState.INIT,
+                collectionExercises,
+                Collections.singletonList(IMPOSSIBLE_ID),
+                new PageRequest(0, DISTRIBUTION_SCHEDULE_RETRIEVAL_MAX)))
+        .thenReturn(sampleUnitGroups);
     when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
-        eq(SampleUnitGroupDTO.SampleUnitGroupState.INIT),
-        any()))
-            .thenReturn(0L);
-    when(sampleUnitGroupSvc
-        .countByStateFKAndCollectionExercise(eq(SampleUnitGroupDTO.SampleUnitGroupState.VALIDATED), any()))
-            .thenReturn(2L);
-    when(sampleUnitGroupSvc
-        .countByStateFKAndCollectionExercise(eq(SampleUnitGroupDTO.SampleUnitGroupState.FAILEDVALIDATION), any()))
-            .thenReturn(0L);
+            eq(SampleUnitGroupDTO.SampleUnitGroupState.INIT), any()))
+        .thenReturn(0L);
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupDTO.SampleUnitGroupState.VALIDATED), any()))
+        .thenReturn(2L);
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupDTO.SampleUnitGroupState.FAILEDVALIDATION), any()))
+        .thenReturn(0L);
 
-    List<ExerciseSampleUnit> sampleUnits = FixtureHelper.loadClassFixtures(ExerciseSampleUnit[].class);
+    List<ExerciseSampleUnit> sampleUnits =
+        FixtureHelper.loadClassFixtures(ExerciseSampleUnit[].class);
     when(sampleUnitSvc.findBySampleUnitGroup(any())).thenReturn(sampleUnits);
 
     // Mock client Rest calls
-    List<SurveyClassifierDTO> classifierTypeSelectors = FixtureHelper.loadClassFixtures(SurveyClassifierDTO[].class);
+    List<SurveyClassifierDTO> classifierTypeSelectors =
+        FixtureHelper.loadClassFixtures(SurveyClassifierDTO[].class);
     when(surveySvcClient.requestClassifierTypeSelectors(any())).thenReturn(classifierTypeSelectors);
 
-    List<SurveyClassifierTypeDTO> classifierTypeSelector = FixtureHelper
-        .loadClassFixtures(SurveyClassifierTypeDTO[].class);
+    List<SurveyClassifierTypeDTO> classifierTypeSelector =
+        FixtureHelper.loadClassFixtures(SurveyClassifierTypeDTO[].class);
     when(surveySvcClient.requestClassifierTypeSelector(any(), any()))
         .thenReturn(classifierTypeSelector.get(0));
 
@@ -185,35 +177,41 @@ public class ValidateSampleUnitsTest {
     when(partySvcClient.requestParty(SampleUnitDTO.SampleUnitType.B, SAMPLE_UNIT_REF))
         .thenReturn(partyJson.get(0));
 
-    List<CollectionInstrumentDTO> collectionInstruments = FixtureHelper
-        .loadClassFixtures(CollectionInstrumentDTO[].class);
+    List<CollectionInstrumentDTO> collectionInstruments =
+        FixtureHelper.loadClassFixtures(CollectionInstrumentDTO[].class);
     when(collectionInstrumentSvcClient.requestCollectionInstruments(
             new JSONObject(CI_1_SVC_SEARCH).toString()))
-            .thenReturn(collectionInstruments);
+        .thenReturn(collectionInstruments);
     when(collectionInstrumentSvcClient.requestCollectionInstruments(
             new JSONObject(CI_2_SVC_SEARCH).toString()))
-            .thenReturn(collectionInstruments);
+        .thenReturn(collectionInstruments);
 
     // Mock transition Managers
-    when(collectionExerciseTransitionState.transition(CollectionExerciseState.EXECUTED,
-        CollectionExerciseEvent.VALIDATE)).thenReturn(CollectionExerciseState.VALIDATED);
-    when(collectionExerciseTransitionState.transition(CollectionExerciseState.EXECUTED,
-        CollectionExerciseEvent.INVALIDATE)).thenReturn(CollectionExerciseState.FAILEDVALIDATION);
+    when(collectionExerciseTransitionState.transition(
+            CollectionExerciseState.EXECUTED, CollectionExerciseEvent.VALIDATE))
+        .thenReturn(CollectionExerciseState.VALIDATED);
+    when(collectionExerciseTransitionState.transition(
+            CollectionExerciseState.EXECUTED, CollectionExerciseEvent.INVALIDATE))
+        .thenReturn(CollectionExerciseState.FAILEDVALIDATION);
 
     when(sampleUnitGroupState.transition(SampleUnitGroupState.INIT, SampleUnitGroupEvent.VALIDATE))
         .thenReturn(SampleUnitGroupState.VALIDATED);
-    when(sampleUnitGroupState.transition(SampleUnitGroupState.INIT, SampleUnitGroupEvent.INVALIDATE))
+    when(sampleUnitGroupState.transition(
+            SampleUnitGroupState.INIT, SampleUnitGroupEvent.INVALIDATE))
         .thenReturn(SampleUnitGroupState.FAILEDVALIDATION);
   }
 
   /**
-   * Test happy path through to validate all SampleUnitGroups and
-   * CollectionExercises.
+   * Test happy path through to validate all SampleUnitGroups and CollectionExercises.
+   *
    * @throws CTPException
    */
   @Test
   public void validateSampleUnitsOK() throws CTPException {
-    List<String> PARTY_ID = Arrays.asList("4eed610a-39f7-437b-a37d-9de1f905cb39", "4625df99-7c20-4610-a18c-2f93daffce2a",
+    List<String> PARTY_ID =
+        Arrays.asList(
+            "4eed610a-39f7-437b-a37d-9de1f905cb39",
+            "4625df99-7c20-4610-a18c-2f93daffce2a",
             "45297c23-763d-46a9-b4e5-c37ff5b4fbe8");
 
     validateSampleUnits.validateSampleUnits();
@@ -221,48 +219,71 @@ public class ValidateSampleUnitsTest {
     // Two collectionExercises with two SampleUnitGroups each with one
     // sampleUnit per group. Test data configuration. All read the same
     // sampleUnit instance data
-    verify(sampleUnitGroupSvc, times(4)).storeExerciseSampleUnitGroup(sampleUnitGroupSave.capture(),
-        sampleUnitSave.capture());
+    verify(sampleUnitGroupSvc, times(4))
+        .storeExerciseSampleUnitGroup(sampleUnitGroupSave.capture(), sampleUnitSave.capture());
     List<List<ExerciseSampleUnit>> savedSampleUnits = sampleUnitSave.getAllValues();
     assertTrue(savedSampleUnits.size() == 4);
-    savedSampleUnits.forEach((sampleUnits) -> {
-      assertTrue(sampleUnits.stream().filter(item -> item.getSampleUnitType() == SampleUnitType.BI).count() == 1L);
-      assertTrue(sampleUnits.stream().filter(item -> item.getSampleUnitType() == SampleUnitType.B).count() == 1L);
-      sampleUnits.forEach((unit) -> {
-        assertTrue(PARTY_ID.contains(unit.getPartyId().toString()));
-        assertEquals("5ca1afd6-4d01-4e13-bb73-acae62e2e540", unit.getCollectionInstrumentId().toString());
-        assertEquals(SAMPLE_UNIT_REF, unit.getSampleUnitRef());
-      });
-    });
+    savedSampleUnits.forEach(
+        (sampleUnits) -> {
+          assertTrue(
+              sampleUnits
+                      .stream()
+                      .filter(item -> item.getSampleUnitType() == SampleUnitType.BI)
+                      .count()
+                  == 1L);
+          assertTrue(
+              sampleUnits
+                      .stream()
+                      .filter(item -> item.getSampleUnitType() == SampleUnitType.B)
+                      .count()
+                  == 1L);
+          sampleUnits.forEach(
+              (unit) -> {
+                assertTrue(PARTY_ID.contains(unit.getPartyId().toString()));
+                assertEquals(
+                    "5ca1afd6-4d01-4e13-bb73-acae62e2e540",
+                    unit.getCollectionInstrumentId().toString());
+                assertEquals(SAMPLE_UNIT_REF, unit.getSampleUnitRef());
+              });
+        });
 
     List<ExerciseSampleUnitGroup> savedSampleUnitGroups = sampleUnitGroupSave.getAllValues();
     assertTrue(savedSampleUnitGroups.size() == 4);
-    savedSampleUnitGroups.forEach((group) -> {
-      assertTrue(RESULT_COLLECTION_ID.contains(group.getCollectionExercise().getId().toString()));
-      assertEquals(SampleUnitGroupState.VALIDATED, group.getStateFK());
-      assertEquals("0015", group.getFormType());
-    });
+    savedSampleUnitGroups.forEach(
+        (group) -> {
+          assertTrue(
+              RESULT_COLLECTION_ID.contains(group.getCollectionExercise().getId().toString()));
+          assertEquals(SampleUnitGroupState.VALIDATED, group.getStateFK());
+          assertEquals("0015", group.getFormType());
+        });
 
-    ArgumentCaptor<CollectionExercise> collexTransition = ArgumentCaptor.forClass(CollectionExercise.class);
-    ArgumentCaptor<CollectionExerciseEvent> collexEvent = ArgumentCaptor.forClass(CollectionExerciseEvent.class);
-    verify(collectionExerciseService, times(2)).transitionCollectionExercise(
-            collexTransition.capture(), collexEvent.capture());
+    ArgumentCaptor<CollectionExercise> collexTransition =
+        ArgumentCaptor.forClass(CollectionExercise.class);
+    ArgumentCaptor<CollectionExerciseEvent> collexEvent =
+        ArgumentCaptor.forClass(CollectionExerciseEvent.class);
+    verify(collectionExerciseService, times(2))
+        .transitionCollectionExercise(collexTransition.capture(), collexEvent.capture());
 
     List<CollectionExercise> exercises = collexTransition.getAllValues();
     assertTrue(exercises.size() == 2);
-    exercises.forEach((exercise) -> {
-      assertTrue(RESULT_COLLECTION_ID.contains(exercise.getId().toString()));
-    });
+    exercises.forEach(
+        (exercise) -> {
+          assertTrue(RESULT_COLLECTION_ID.contains(exercise.getId().toString()));
+        });
     List<CollectionExerciseEvent> events = collexEvent.getAllValues();
 
-    assertEquals(2, events
+    assertEquals(
+        2,
+        events
             .stream()
             .filter(e -> e.equals(CollectionExerciseEvent.VALIDATE))
-            .collect(Collectors.toList()).size());
+            .collect(Collectors.toList())
+            .size());
   }
 
   /**
    * Test of party service client failure.
+   *
    * @throws CTPException
    */
   @Test
@@ -271,51 +292,61 @@ public class ValidateSampleUnitsTest {
     // Override happy path scenario to receive error from party service client
     when(partySvcClient.requestParty(SampleUnitDTO.SampleUnitType.B, SAMPLE_UNIT_REF))
         .thenThrow(new RestClientException("Test failure of Party service"));
-    when(sampleUnitGroupSvc
-        .countByStateFKAndCollectionExercise(eq(SampleUnitGroupDTO.SampleUnitGroupState.VALIDATED), any()))
-            .thenReturn(0L);
-    when(sampleUnitGroupSvc
-        .countByStateFKAndCollectionExercise(eq(SampleUnitGroupDTO.SampleUnitGroupState.FAILEDVALIDATION), any()))
-            .thenReturn(2L);
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupDTO.SampleUnitGroupState.VALIDATED), any()))
+        .thenReturn(0L);
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupDTO.SampleUnitGroupState.FAILEDVALIDATION), any()))
+        .thenReturn(2L);
 
     validateSampleUnits.validateSampleUnits();
 
-    verify(sampleUnitGroupSvc, times(4)).storeExerciseSampleUnitGroup(sampleUnitGroupSave.capture(),
-        sampleUnitSave.capture());
+    verify(sampleUnitGroupSvc, times(4))
+        .storeExerciseSampleUnitGroup(sampleUnitGroupSave.capture(), sampleUnitSave.capture());
     List<List<ExerciseSampleUnit>> savedSampleUnits = sampleUnitSave.getAllValues();
     assertTrue(savedSampleUnits.size() == 4);
-    savedSampleUnits.forEach((sampleUnits) -> {
-      assertTrue(sampleUnits.size() == 0);
-    });
+    savedSampleUnits.forEach(
+        (sampleUnits) -> {
+          assertTrue(sampleUnits.size() == 0);
+        });
 
     List<ExerciseSampleUnitGroup> savedSampleUnitGroups = sampleUnitGroupSave.getAllValues();
     assertTrue(savedSampleUnitGroups.size() == 4);
-    savedSampleUnitGroups.forEach((group) -> {
-      assertTrue(RESULT_COLLECTION_ID.contains(group.getCollectionExercise().getId().toString()));
-      assertEquals(SampleUnitGroupState.FAILEDVALIDATION, group.getStateFK());
-      assertEquals("0015", group.getFormType());
-    });
+    savedSampleUnitGroups.forEach(
+        (group) -> {
+          assertTrue(
+              RESULT_COLLECTION_ID.contains(group.getCollectionExercise().getId().toString()));
+          assertEquals(SampleUnitGroupState.FAILEDVALIDATION, group.getStateFK());
+          assertEquals("0015", group.getFormType());
+        });
 
-    ArgumentCaptor<CollectionExercise> collexTransition = ArgumentCaptor.forClass(CollectionExercise.class);
-    ArgumentCaptor<CollectionExerciseEvent> collexEvent = ArgumentCaptor.forClass(CollectionExerciseEvent.class);
-    verify(collectionExerciseService, times(2)).transitionCollectionExercise(
-            collexTransition.capture(), collexEvent.capture());
+    ArgumentCaptor<CollectionExercise> collexTransition =
+        ArgumentCaptor.forClass(CollectionExercise.class);
+    ArgumentCaptor<CollectionExerciseEvent> collexEvent =
+        ArgumentCaptor.forClass(CollectionExerciseEvent.class);
+    verify(collectionExerciseService, times(2))
+        .transitionCollectionExercise(collexTransition.capture(), collexEvent.capture());
 
     List<CollectionExercise> exercises = collexTransition.getAllValues();
     assertTrue(exercises.size() == 2);
-    exercises.forEach((exercise) -> {
-      assertTrue(RESULT_COLLECTION_ID.contains(exercise.getId().toString()));
-    });
+    exercises.forEach(
+        (exercise) -> {
+          assertTrue(RESULT_COLLECTION_ID.contains(exercise.getId().toString()));
+        });
     List<CollectionExerciseEvent> events = collexEvent.getAllValues();
 
-    assertEquals(2, events
+    assertEquals(
+        2,
+        events
             .stream()
             .filter(e -> e.equals(CollectionExerciseEvent.INVALIDATE))
-            .collect(Collectors.toList()).size());
+            .collect(Collectors.toList())
+            .size());
   }
 
   /**
    * Test of collection instrument client service failure.
+   *
    * @throws CTPException
    */
   @Test
@@ -324,63 +355,69 @@ public class ValidateSampleUnitsTest {
     // Override happy path scenario to receive error from collection instrument
     // service.
     when(collectionInstrumentSvcClient.requestCollectionInstruments(anyString()))
-            .thenThrow(new RestClientException("Test failure of Collection Instrument service"));
+        .thenThrow(new RestClientException("Test failure of Collection Instrument service"));
 
-    when(sampleUnitGroupSvc
-        .countByStateFKAndCollectionExercise(eq(SampleUnitGroupDTO.SampleUnitGroupState.VALIDATED), any()))
-            .thenReturn(0L);
-    when(sampleUnitGroupSvc
-        .countByStateFKAndCollectionExercise(eq(SampleUnitGroupDTO.SampleUnitGroupState.FAILEDVALIDATION), any()))
-            .thenReturn(2L);
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupDTO.SampleUnitGroupState.VALIDATED), any()))
+        .thenReturn(0L);
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupDTO.SampleUnitGroupState.FAILEDVALIDATION), any()))
+        .thenReturn(2L);
 
     validateSampleUnits.validateSampleUnits();
 
-    verify(sampleUnitGroupSvc, times(4)).storeExerciseSampleUnitGroup(sampleUnitGroupSave.capture(),
-        sampleUnitSave.capture());
+    verify(sampleUnitGroupSvc, times(4))
+        .storeExerciseSampleUnitGroup(sampleUnitGroupSave.capture(), sampleUnitSave.capture());
     List<List<ExerciseSampleUnit>> savedSampleUnits = sampleUnitSave.getAllValues();
     assertEquals(4, savedSampleUnits.size());
     savedSampleUnits.forEach((sampleUnits) -> assertEquals(0, sampleUnits.size()));
 
     List<ExerciseSampleUnitGroup> savedSampleUnitGroups = sampleUnitGroupSave.getAllValues();
     assertTrue(savedSampleUnitGroups.size() == 4);
-    savedSampleUnitGroups.forEach((group) -> {
-      assertTrue(RESULT_COLLECTION_ID.contains(group.getCollectionExercise().getId().toString()));
-      assertEquals(SampleUnitGroupState.FAILEDVALIDATION, group.getStateFK());
-      assertEquals("0015", group.getFormType());
-    });
+    savedSampleUnitGroups.forEach(
+        (group) -> {
+          assertTrue(
+              RESULT_COLLECTION_ID.contains(group.getCollectionExercise().getId().toString()));
+          assertEquals(SampleUnitGroupState.FAILEDVALIDATION, group.getStateFK());
+          assertEquals("0015", group.getFormType());
+        });
 
-    ArgumentCaptor<CollectionExercise> collexTransition = ArgumentCaptor.forClass(CollectionExercise.class);
-    ArgumentCaptor<CollectionExerciseEvent> collexEvent = ArgumentCaptor.forClass(CollectionExerciseEvent.class);
-    verify(collectionExerciseService, times(2)).transitionCollectionExercise(
-            collexTransition.capture(), collexEvent.capture());
+    ArgumentCaptor<CollectionExercise> collexTransition =
+        ArgumentCaptor.forClass(CollectionExercise.class);
+    ArgumentCaptor<CollectionExerciseEvent> collexEvent =
+        ArgumentCaptor.forClass(CollectionExerciseEvent.class);
+    verify(collectionExerciseService, times(2))
+        .transitionCollectionExercise(collexTransition.capture(), collexEvent.capture());
 
     List<CollectionExercise> exercises = collexTransition.getAllValues();
     assertTrue(exercises.size() == 2);
-    exercises.forEach((exercise) -> {
-      assertTrue(RESULT_COLLECTION_ID.contains(exercise.getId().toString()));
-    });
+    exercises.forEach(
+        (exercise) -> {
+          assertTrue(RESULT_COLLECTION_ID.contains(exercise.getId().toString()));
+        });
     List<CollectionExerciseEvent> events = collexEvent.getAllValues();
 
-    assertEquals(2, events
-                    .stream()
-                    .filter(e -> e.equals(CollectionExerciseEvent.INVALIDATE))
-                    .collect(Collectors.toList()).size());
+    assertEquals(
+        2,
+        events
+            .stream()
+            .filter(e -> e.equals(CollectionExerciseEvent.INVALIDATE))
+            .collect(Collectors.toList())
+            .size());
   }
 
-  /**
-   * Test of no sampleUnitGroups in state INIT - none to validate.
-   */
+  /** Test of no sampleUnitGroups in state INIT - none to validate. */
   @Test
   public void validateSampleUnitsNoneToValidate() {
     // Override happy path scenario to return any empty list querying for
     // sampleUnitGroups.
     when(sampleUnitGroupSvc
-        .findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
-            SampleUnitGroupDTO.SampleUnitGroupState.INIT,
-            collectionExercises,
-            Collections.singletonList(IMPOSSIBLE_ID),
-            new PageRequest(0, DISTRIBUTION_SCHEDULE_RETRIEVAL_MAX)))
-                .thenReturn(new ArrayList<>());
+            .findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
+                SampleUnitGroupDTO.SampleUnitGroupState.INIT,
+                collectionExercises,
+                Collections.singletonList(IMPOSSIBLE_ID),
+                new PageRequest(0, DISTRIBUTION_SCHEDULE_RETRIEVAL_MAX)))
+        .thenReturn(new ArrayList<>());
 
     validateSampleUnits.validateSampleUnits();
 
@@ -388,9 +425,7 @@ public class ValidateSampleUnitsTest {
     verify(collectRepo, never()).saveAndFlush(any());
   }
 
-  /**
-   * Test of LockingException thrown by DistributedListManager.
-   */
+  /** Test of LockingException thrown by DistributedListManager. */
   @Test
   public void validateSampleUnitsDistributedListManagerLockingException() throws LockingException {
     when(sampleValidationListManager.findList(any(String.class), any(boolean.class)))
@@ -411,21 +446,22 @@ public class ValidateSampleUnitsTest {
 
     // Then expect SURVEY_ID in 4 CI requests
     verify(collectionInstrumentSvcClient, times(4))
-            .requestCollectionInstruments(new JSONObject(CI_1_SVC_SEARCH).toString());
+        .requestCollectionInstruments(new JSONObject(CI_1_SVC_SEARCH).toString());
   }
 
   @Test
   public void testSurveyClassifierInRequestToCollectionInstrumentWhenClassifierSearchFails() {
     // Given classifier search fails
     when(surveySvcClient.requestClassifierTypeSelector(any(), any()))
-            .thenThrow(new RestClientException("Test failure of Survey service"));
+        .thenThrow(new RestClientException("Test failure of Survey service"));
 
     // When
     validateSampleUnits.validateSampleUnits();
 
     // Then
-    Map<String, String> searchString = ImmutableMap.of("SURVEY_ID", "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87");
+    Map<String, String> searchString =
+        ImmutableMap.of("SURVEY_ID", "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87");
     verify(collectionInstrumentSvcClient, times(4))
-            .requestCollectionInstruments(new JSONObject(searchString).toString());
+        .requestCollectionInstruments(new JSONObject(searchString).toString());
   }
 }


### PR DESCRIPTION
# Motivation and Context
Adding maven plugin to format the java code automatically on builds. The
style of the formatter is opinionated favouring googles formatting. The
benefit of this is it allows us to easily plugin in googles check style
file. The checkstyle.xml has been made more lenient to ignore things
like missing javadoc and abbreviations.

# What has changed
Inherit new checkstyle configuration from parent pom
Inerit formatting from parent pom
Travis to fail on invalid style or checkstyle

# How to test?
1. Checkout branch
1. Mess up format
1. Run mvn install
1. Check format is fixed

# Links
Formatter plugin: https://github.com/google/coveo/fmt-maven-plugin
Checkstyle plugin: https://github.com/google/checkstyle/checkstyle
Intellij formatter: https://github.com/google/google/google-java-format#intellij
Eclipse formatter: https://github.com/google/google-java-format#eclipse
