### PR TITLE
Add wait in pre-integration-test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
                 </goals>
                 <configuration>
                     <url>http://localhost:38151/info</url>
-                    <timeout>30000</timeout>
+                    <timeout>60000</timeout>
                 </configuration>
             </execution>
             <execution>
@@ -370,7 +370,7 @@
                 </goals>
                 <configuration>
                     <url>http://localhost:18080/info</url>
-                    <timeout>30000</timeout>
+                    <timeout>60000</timeout>
                 </configuration>
             </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -349,22 +349,30 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.8</version>
+        <groupId>se.thinkcode.wait</groupId>
+        <artifactId>http</artifactId>
+        <version>1.0.0</version>
         <executions>
-          <execution>
-            <id>sleep-for-a-while</id>
-            <phase>pre-integration-test</phase>
-            <configuration>
-              <target>
-                <sleep seconds="10" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
+            <execution>
+                <id>wait-for-action</id>
+                <goals>
+                    <goal>wait</goal>
+                </goals>
+                <configuration>
+                    <url>http://localhost:38151/info</url>
+                    <timeout>30000</timeout>
+                </configuration>
+            </execution>
+            <execution>
+                <id>wait-for-survey</id>
+                <goals>
+                    <goal>wait</goal>
+                </goals>
+                <configuration>
+                    <url>http://localhost:18080/info</url>
+                    <timeout>30000</timeout>
+                </configuration>
+            </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
# Motivation and Context
The integration tests are hit and miss and it's likely a timing issue
with action taking too long to start. We were waiting an arbitrary 10s
which might not have been enough.

# What has changed
This change uses a different maven plugin to check the healthcheck/info
api waiting up to 30 seconds for it to return a 200.

# How to test?
* Run `mvn install` observing the tests pass and the sections that are waiting for the service to be up
```

[INFO] --- http:1.0.0:wait (wait-for-action) @ collectionexercisesvc ---
[INFO] Waiting for http://localhost:38151/info
[INFO] Waited for 26093ms for http://localhost:38151/info
[INFO]
[INFO] --- http:1.0.0:wait (wait-for-survey) @ collectionexercisesvc ---
[INFO] Waiting for http://localhost:18080/info
[INFO] Waited for 109ms for http://localhost:18080/info
```
