### PR TITLE
Bump http wait plugin for skip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,17 +27,11 @@
             <version>10.49.13</version>
         </dependency>
 
-        <dependency>
-            <groupId>uk.gov.ons.ctp.product</groupId>
-            <artifactId>actionsvc-api</artifactId>
-            <version>10.49.10</version>
-        </dependency>
-
-        <dependency>
-            <groupId>uk.gov.ons.ctp.product</groupId>
-            <artifactId>surveysvc-api</artifactId>
-            <version>10.49.8</version>
-        </dependency>
+    <dependency>
+      <groupId>uk.gov.ons.ctp.product</groupId>
+      <artifactId>surveysvc-api</artifactId>
+      <version>10.49.8</version>
+    </dependency>
 
         <dependency>
             <groupId>uk.gov.ons.ctp.product</groupId>
@@ -391,7 +385,7 @@
             <plugin>
                 <groupId>se.thinkcode.wait</groupId>
                 <artifactId>http</artifactId>
-                <version>1.0.0</version>
+                <version>1.1.0</version>
                 <executions>
                     <execution>
                         <id>wait-for-action</id>

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,17 @@
             <version>10.49.13</version>
         </dependency>
 
-    <dependency>
-      <groupId>uk.gov.ons.ctp.product</groupId>
-      <artifactId>surveysvc-api</artifactId>
-      <version>10.49.8</version>
-    </dependency>
+        <dependency>
+            <groupId>uk.gov.ons.ctp.product</groupId>
+            <artifactId>actionsvc-api</artifactId>
+            <version>10.49.10</version>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.ons.ctp.product</groupId>
+            <artifactId>surveysvc-api</artifactId>
+            <version>10.49.8</version>
+        </dependency>
 
         <dependency>
             <groupId>uk.gov.ons.ctp.product</groupId>


### PR DESCRIPTION
# Motivation and Context
We need to be able to skip the http wait when we're skipping the
integration tests otherwise it will cause failures when the services do
not start up.

https://github.com/tsundberg/maven-wait-plugin/pull/1 added in the
ability to skip the wait with -Dhttp.wait.skip

# What has changed
Bump the wait plugin version

# How to test?
1. Run `mvn install -Ddocker.skip -Ddockerfile.skip -Dhttp.wait.skip -DskipTests` on master and observe hang then failure
1. Run `mvn install -Ddocker.skip -Ddockerfile.skip -Dhttp.wait.skip -DskipTests` on master and
passing build

# Links
https://github.com/tsundberg/maven-wait-plugin/pull/1
