### PR TITLE
Add implementation for events to be returned with collection exercise

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.product</groupId>
             <artifactId>collectionexercisesvc-api</artifactId>
-            <version>10.49.14-SNAPSHOT</version>
+            <version>10.49.14</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.product</groupId>
             <artifactId>collectionexercisesvc-api</artifactId>
-            <version>10.49.13</version>
+            <version>10.49.14-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -117,6 +117,8 @@ public class CollectionExerciseEndpoint {
   public ResponseEntity<List<CollectionExerciseDTO>> getCollectionExercisesForSurvey(
       @PathVariable("id") final UUID id) throws CTPException {
 
+    log.info("Retrieving collection exercises by survey id {}", id);
+
     SurveyDTO survey = surveyService.findSurvey(id);
 
     List<CollectionExerciseDTO> collectionExerciseSummaryDTOList;
@@ -616,6 +618,7 @@ public class CollectionExerciseEndpoint {
    */
   private CollectionExerciseDTO getCollectionExerciseDTO(
       final CollectionExercise collectionExercise) {
+    log.debug("Populating data for requested collection exercise {}", collectionExercise.getId());
     Collection<CaseType> caseTypeList =
         collectionExerciseService.getCaseTypesList(collectionExercise);
     List<CaseTypeDTO> caseTypeDTOList = mapperFacade.mapAsList(caseTypeList, CaseTypeDTO.class);
@@ -639,6 +642,21 @@ public class CollectionExerciseEndpoint {
           this.sampleService.getValidationErrors(collectionExercise.getId());
 
       collectionExerciseDTO.setValidationErrors(errors);
+    }
+
+    try {
+      List<EventDTO> eventList =
+          this.eventService
+              .getEvents(collectionExercise.getId())
+              .stream()
+              .map(EventService::createEventDTOFromEvent)
+              .collect(Collectors.toList());
+
+      collectionExerciseDTO.setEvents(eventList);
+    } catch (CTPException e) {
+      log.debug(
+          "Error retrieving events for collection exercise Id {}",
+          collectionExercise.getId().toString());
     }
 
     return collectionExerciseDTO;

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -158,7 +158,8 @@ public class CollectionExerciseEndpoint {
       @PathVariable("surveyRef") final String surveyRef)
       throws CTPException {
 
-    log.info("Retrieving collection exercise with surveyRef={} and period={}", surveyRef, exerciseRef);
+    log.info(
+        "Retrieving collection exercise with surveyRef={} and period={}", surveyRef, exerciseRef);
 
     CollectionExercise collex =
         this.collectionExerciseService.findCollectionExercise(surveyRef, exerciseRef);
@@ -168,9 +169,13 @@ public class CollectionExerciseEndpoint {
           CTPException.Fault.RESOURCE_NOT_FOUND,
           String.format(
               "Cannot find collection exercise for surveyRef={} and period={}",
-              surveyRef, exerciseRef));
+              surveyRef,
+              exerciseRef));
     } else {
-      log.info("Successfully retrieved collection exercise using surveyRef={} and period={}", surveyRef, exerciseRef);
+      log.info(
+          "Successfully retrieved collection exercise using surveyRef={} and period={}",
+          surveyRef,
+          exerciseRef);
       return ResponseEntity.ok(getCollectionExerciseDTO(collex));
     }
   }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -117,7 +117,7 @@ public class CollectionExerciseEndpoint {
   public ResponseEntity<List<CollectionExerciseDTO>> getCollectionExercisesForSurvey(
       @PathVariable("id") final UUID id) throws CTPException {
 
-    log.info("Retrieving collection exercises by survey id {}", id);
+    log.info("Retrieving collection exercises by surveyId={}", id);
 
     SurveyDTO survey = surveyService.findSurvey(id);
 
@@ -127,7 +127,7 @@ public class CollectionExerciseEndpoint {
       throw new CTPException(
           CTPException.Fault.RESOURCE_NOT_FOUND, String.format("%s %s", RETURN_SURVEYNOTFOUND, id));
     } else {
-      log.debug("Entering collection exercise fetch with survey Id {}", id);
+      log.debug("Entering collection exercise fetch with surveyId={}", id);
       List<CollectionExercise> collectionExerciseList =
           collectionExerciseService.findCollectionExercisesForSurvey(survey);
       collectionExerciseSummaryDTOList =
@@ -140,6 +140,7 @@ public class CollectionExerciseEndpoint {
       }
     }
 
+    log.info("Sucessfully retrieved collection exercises for surveyId={}", id);
     return ResponseEntity.ok(collectionExerciseSummaryDTOList);
   }
 
@@ -156,6 +157,9 @@ public class CollectionExerciseEndpoint {
       @PathVariable("exerciseRef") final String exerciseRef,
       @PathVariable("surveyRef") final String surveyRef)
       throws CTPException {
+
+    log.info("Retrieving collection exercise with surveyRef={} and period={}", surveyRef, exerciseRef);
+
     CollectionExercise collex =
         this.collectionExerciseService.findCollectionExercise(surveyRef, exerciseRef);
 
@@ -163,9 +167,10 @@ public class CollectionExerciseEndpoint {
       throw new CTPException(
           CTPException.Fault.RESOURCE_NOT_FOUND,
           String.format(
-              "Cannot find collection exercise for survey %s and period %s",
+              "Cannot find collection exercise for surveyRef={} and period={}",
               surveyRef, exerciseRef));
     } else {
+      log.info("Successfully retrieved collection exercise using surveyRef={} and period={}", surveyRef, exerciseRef);
       return ResponseEntity.ok(getCollectionExerciseDTO(collex));
     }
   }
@@ -181,7 +186,7 @@ public class CollectionExerciseEndpoint {
   @RequestMapping(value = "/{id}", method = RequestMethod.GET)
   public ResponseEntity<CollectionExerciseDTO> getCollectionExercise(
       @PathVariable("id") final UUID id) throws CTPException {
-    log.debug("Entering collection exercise fetch with collection exercise Id {}", id);
+    log.debug("Entering collection exercise fetch with collectionExerciseId={}", id);
     CollectionExercise collectionExercise = collectionExerciseService.findCollectionExercise(id);
     if (collectionExercise == null) {
       throw new CTPException(
@@ -191,6 +196,7 @@ public class CollectionExerciseEndpoint {
 
     CollectionExerciseDTO collectionExerciseDTO = getCollectionExerciseDTO(collectionExercise);
 
+    log.info("Successfully retrieved collection exercise with collectionExerciseId={}", id);
     return ResponseEntity.ok(collectionExerciseDTO);
   }
 
@@ -201,7 +207,7 @@ public class CollectionExerciseEndpoint {
    */
   @RequestMapping(method = RequestMethod.GET)
   public ResponseEntity<List<CollectionExerciseDTO>> getAllCollectionExercises() {
-    log.debug("Entering fetch all collection exercise");
+    log.debug("Entering fetch all collection exercises");
     List<CollectionExercise> collectionExercises =
         collectionExerciseService.findAllCollectionExercise();
     List<CollectionExerciseDTO> result = new ArrayList<>();
@@ -210,6 +216,7 @@ public class CollectionExerciseEndpoint {
       CollectionExerciseDTO collectionExerciseDTO = getCollectionExerciseDTO(collectionExercise);
       result.add(collectionExerciseDTO);
     }
+    log.debug("Successfully retrieved all collection exercises");
     return ResponseEntity.ok(result);
   }
 
@@ -227,10 +234,11 @@ public class CollectionExerciseEndpoint {
       final @Validated(CollectionExerciseDTO.PutValidation.class) @RequestBody CollectionExerciseDTO
               collexDto)
       throws CTPException {
-    log.info("Updating collection exercise {}", id);
+    log.info("Updating collection exercise with collectionExerciseId={}", id);
 
     this.collectionExerciseService.updateCollectionExercise(id, collexDto);
 
+    log.info("Sucessfully updated collection exercise with collectionExerciseId={}", id);
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -654,7 +654,7 @@ public class CollectionExerciseEndpoint {
 
       collectionExerciseDTO.setEvents(eventList);
     } catch (CTPException e) {
-      log.debug(
+      log.error(
           "Error retrieving events for collection exercise Id {}",
           collectionExercise.getId().toString());
     }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -277,11 +277,9 @@ public class CollectionExerciseEndpointUnitTests {
     MockHttpServletRequestBuilder json =
         getJson(String.format("/collectionexercises/%s", COLLECTIONEXERCISE_ID1));
 
-    log.info("json: {}", json);
 
     ResultActions actions = mockCollectionExerciseMvc.perform(json);
 
-    log.info("actions: {}", actions);
 
     actions
         .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -282,7 +282,17 @@ public class CollectionExerciseEndpointUnitTests {
 
     log.info("actions: {}", actions);
 
-    actions.andExpect(status().isOk());
+    actions
+        .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
+        .andExpect(handler().methodName("getCollectionExercise"))
+        .andExpect(jsonPath("$.id", is(COLLECTIONEXERCISE_ID1.toString())))
+        .andExpect(jsonPath("$.surveyId", is(SURVEY_ID_1.toString())))
+        .andExpect(jsonPath("$.name", is(COLLECTIONEXERCISE_NAME)))
+        .andExpect(jsonPath("$.state", is(COLLECTIONEXERCISE_STATE)))
+        .andExpect(jsonPath("$.caseTypes[*]", hasSize(1)))
+        .andExpect(jsonPath("$.caseTypes[*].*", hasSize(2)))
+        .andExpect(
+            jsonPath("$.caseTypes[*].actionPlanId", containsInAnyOrder(ACTIONPLANID.toString())));
   }
 
   /**

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -259,7 +259,7 @@ public class CollectionExerciseEndpointUnitTests {
   /**
    * Test to get collection exercise with get events throws CTP Exception.
    *
-   * @throws CTPException exception thrown
+   * @throws Exception exception thrown
    */
   @Test
   public void
@@ -277,9 +277,7 @@ public class CollectionExerciseEndpointUnitTests {
     MockHttpServletRequestBuilder json =
         getJson(String.format("/collectionexercises/%s", COLLECTIONEXERCISE_ID1));
 
-
     ResultActions actions = mockCollectionExerciseMvc.perform(json);
-
 
     actions
         .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -271,7 +271,8 @@ public class CollectionExerciseEndpointUnitTests {
         .thenReturn(caseTypeDefaultResults);
     when(surveyService.findSurvey(UUID.fromString("31ec898e-f370-429a-bca4-eab1045aff4e")))
         .thenReturn(surveyDtoResults.get(0));
-    when(eventService.getEvents(COLLECTIONEXERCISE_ID1)).thenThrow(CTPException.class);
+    when(eventService.getEvents(COLLECTIONEXERCISE_ID1))
+        .thenThrow(new CTPException(CTPException.Fault.SYSTEM_ERROR));
 
     MockHttpServletRequestBuilder json =
         getJson(String.format("/collectionexercises/%s", COLLECTIONEXERCISE_ID1));

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -257,6 +257,35 @@ public class CollectionExerciseEndpointUnitTests {
   }
 
   /**
+   * Test to get collection exercise with get events throws CTP Exception.
+   *
+   * @throws CTPException exception thrown
+   */
+  @Test
+  public void
+      findCollectionExerciseGetEventsThrowsCTPExceptionSuccessfullyRetrievesCollectionExercise()
+          throws Exception {
+    when(collectionExerciseService.findCollectionExercise(COLLECTIONEXERCISE_ID1))
+        .thenReturn(collectionExerciseResults.get(0));
+    when(collectionExerciseService.getCaseTypesList(collectionExerciseResults.get(0)))
+        .thenReturn(caseTypeDefaultResults);
+    when(surveyService.findSurvey(UUID.fromString("31ec898e-f370-429a-bca4-eab1045aff4e")))
+        .thenReturn(surveyDtoResults.get(0));
+    when(eventService.getEvents(COLLECTIONEXERCISE_ID1)).thenThrow(CTPException.class);
+
+    MockHttpServletRequestBuilder json =
+        getJson(String.format("/collectionexercises/%s", COLLECTIONEXERCISE_ID1));
+
+    log.info("json: {}", json);
+
+    ResultActions actions = mockCollectionExerciseMvc.perform(json);
+
+    log.info("actions: {}", actions);
+
+    actions.andExpect(status().isOk());
+  }
+
+  /**
    * Test to get all collection exercises.
    *
    * @throws Exception exception thrown


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Return events when returning a collection exercise. Should mean fewer API calls.

# What has changed
<!--- What code changes has been made -->
Return events when returning collection exercise using collection exercise dto.
<!--- Has there been any refactoring -->
Add some logging.
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
Ran with api changes hit one of the get endpoints for a collection exercise check events are returned for a collection exercise with events.
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
[Trello] https://trello.com/c/PLkePSlW
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

Requires this to be merged first: 
https://github.com/ONSdigital/rm-collectionexercisesvc-api/pull/16
