### PR TITLE
Run fmt:check and integration tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk: openjdk8
 
 before_install: "cp .maven.settings.xml $HOME/.m2/settings.xml"
 
-script: "mvn cobertura:cobertura"
+script: mvn fmt:check cobertura:cobertura-integration-test
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then


### PR DESCRIPTION
# Motivation and Context
Run fmt:check and integration tests in travis

# What has changed
* fmt:check will prevent code being merged that hasn't been formatted
* cobertura:cobertura-integration-test will make cobertura run
  integration tests as they aren't being ran in travis at the moment

# How to test?
Check travis build logs to see has ran CollectionExerciseEndpointIT and `fmt-maven-plugin:2.5.0:check` in the logs
```
[INFO] --- fmt-maven-plugin:2.5.0:check (default-cli) @ collectionexercisesvc ---
[debug] Using Google style
[INFO] Processed 92 files (0 non-complying).
```

# Links
https://trello.com/c/WnTGaznV/152-rm-collection-exercise-service-integration-tests-are-not-running-in-travis