### PR TITLE
Stop IT running twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk: openjdk8
 
 before_install: "cp .maven.settings.xml $HOME/.m2/settings.xml"
 
-install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmaven.javadoc.skip=true -B -V
+install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmaven.javadoc.skip=true -Dhttp.wait.skip -B -V
 script: mvn fmt:check cobertura:cobertura-integration-test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jdk: openjdk8
 
 before_install: "cp .maven.settings.xml $HOME/.m2/settings.xml"
 
+install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmaven.javadoc.skip=true -B -V
 script: mvn fmt:check cobertura:cobertura-integration-test
 
 after_success:


### PR DESCRIPTION
# Motivation and Context
Travis will run mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V on the install step by default which runs the integration tests
and builds the docker containers which makes the build take twice as
long. Changing it to skip docker and integration tests

https://docs.travis-ci.com/user/languages/java/

# What has changed
Add install phase that skips docker and integration tests

# How to test?
Check integration tests aren't ran in `install` step on travis

# Links
https://docs.travis-ci.com/user/languages/java/
