### PR TITLE
Increased memory allocated to collection exercise service in cf

### DIFF
--- a/manifest-no-envs.yml
+++ b/manifest-no-envs.yml
@@ -2,7 +2,7 @@ applications:
 - name: collectionexercisesvc
   instances: 1
   timeout: 180
-  memory: 1024M
+  memory: 1536M
   path: target/collectionexercisesvc.jar
   services:
     - rm-pg-db


### PR DESCRIPTION
to 1.5Gb (1536Mb)

# Motivation and Context
The collection exercise service in the cloudfoundry CI space has taken to crashing regularly (pretty much every time the acceptance tests are run 2-3 times).  Careful analysis showed that it was running out of memory (metaspace to be precise).  Although the exact cause is currently unknown, the service has been running near the limit for some time so we decided it best to increase the amount of memory allocated to this service from 1Gb to 1.5Gb

# What has changed
- increase the memory parameter in the cloudfoundy manifest file to 1.5Gb from 1Gb

# How to test?
- cf app rm-collection-exercise-service-ci 
- check memory usage in output

