### PR TITLE
Fix for Collection Exercise getting stuck in EXECUTION_STARTED state

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
 
@@ -39,18 +40,10 @@ public interface SampleUnitRepository extends JpaRepository<ExerciseSampleUnit, 
   /**
    * Count the number of SampleUnits for the CollectionExercise.
    *
-   * @param id of CollectionExercise for which to count SampleUnits.
-   * @return int of SampleUnit total for given exercisePK.
+   * @param collectionExercise is CollectionExercise for which to count SampleUnits.
+   * @return int of SampleUnit total for given collectionExercise.
    */
-  @Query(
-      value =
-          "select count(*) from "
-              + "collectionexercise.sampleunit su, "
-              + "collectionexercise.sampleunitgroup sg "
-              + "where sg.exercisefk = :p_exercisefk and "
-              + "su.sampleunitgroupfk = sg.sampleunitgrouppk;",
-      nativeQuery = true)
-  int totalByExercisePK(@Param("p_exercisefk") Integer id);
+  int countBySampleUnitGroupCollectionExercise(CollectionExercise collectionExercise);
 
   /**
    * Query repository for SampleUnits belonging to a SampleUnitGroup.

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -165,7 +165,7 @@ public class SampleServiceImpl implements SampleService {
 
         sampleUnitRepo.saveAndFlush(exerciseSampleUnit);
 
-        if (sampleUnitRepo.totalByExercisePK(collectionExercise.getExercisePK())
+        if (sampleUnitRepo.countBySampleUnitGroupCollectionExercise(collectionExercise)
             == collectionExercise.getSampleSize()) {
           collectionExercise.setState(
               collectionExerciseTransitionState.transition(

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImplTest.java
@@ -1,0 +1,113 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.state.StateTransitionManager;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
+import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
+import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
+import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitGroupRepository;
+import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitRepository;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
+import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitType;
+import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SampleServiceImplTest {
+  private static final UUID COLLEX_ID = UUID.randomUUID();
+  private static final UUID SAMPLE_ID = UUID.randomUUID();
+
+  @Mock private SampleUnitRepository sampleUnitRepo;
+
+  @Mock private SampleUnitGroupRepository sampleUnitGroupRepo;
+
+  @Mock private CollectionExerciseRepository collectRepo;
+
+  @Mock
+  private StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent>
+      collectionExerciseTransitionState;
+
+  @InjectMocks private SampleServiceImpl underTest;
+
+  @Test
+  public void testAcceptSampleUnit_CountNotEqual() throws CTPException {
+    CollectionExercise collex = new CollectionExercise();
+    collex.setSampleSize(50);
+    collex.setState(CollectionExerciseState.EXECUTION_STARTED);
+
+    acceptSampleUnitWithCollex(collex);
+
+    verify(collectRepo, never()).saveAndFlush(any());
+    verify(collectionExerciseTransitionState, never()).transition(any(), any());
+  }
+
+  @Test
+  public void testAcceptSampleUnit_CountEqual() throws CTPException {
+    CollectionExercise collex = new CollectionExercise();
+    collex.setSampleSize(99);
+    collex.setState(CollectionExerciseState.EXECUTION_STARTED);
+
+    when(collectionExerciseTransitionState.transition(any(), any()))
+        .thenReturn(CollectionExerciseState.EXECUTED);
+
+    acceptSampleUnitWithCollex(collex);
+
+    ArgumentCaptor<CollectionExercise> collexArgumentCaptor =
+        ArgumentCaptor.forClass(CollectionExercise.class);
+    verify(collectRepo).saveAndFlush(collexArgumentCaptor.capture());
+    assertEquals(CollectionExerciseState.EXECUTED, collexArgumentCaptor.getValue().getState());
+    assertNotNull(collexArgumentCaptor.getValue().getActualExecutionDateTime());
+  }
+
+  private void acceptSampleUnitWithCollex(CollectionExercise collex) throws CTPException {
+    SampleUnit sampleUnit =
+        SampleUnit.builder()
+            .withId(SAMPLE_ID.toString())
+            .withFormType("X")
+            .withSampleUnitRef("REF123")
+            .withSampleUnitType("B")
+            .withCollectionExerciseId(COLLEX_ID.toString())
+            .build();
+
+    ExerciseSampleUnitGroup sampleUnitGroup = new ExerciseSampleUnitGroup();
+
+    when(collectRepo.findOneById(any())).thenReturn(collex);
+    when(sampleUnitGroupRepo.saveAndFlush(any())).thenReturn(sampleUnitGroup);
+    when(sampleUnitRepo.tupleExists(any(), any(), any())).thenReturn(false);
+    when(sampleUnitRepo.countBySampleUnitGroupCollectionExercise(any())).thenReturn(99);
+
+    underTest.acceptSampleUnit(sampleUnit);
+
+    ArgumentCaptor<ExerciseSampleUnitGroup> sampleUnitGroupArgumentCaptor =
+        ArgumentCaptor.forClass(ExerciseSampleUnitGroup.class);
+    verify(sampleUnitGroupRepo).saveAndFlush(sampleUnitGroupArgumentCaptor.capture());
+    assertEquals(collex, sampleUnitGroupArgumentCaptor.getValue().getCollectionExercise());
+    assertEquals(SampleUnitGroupState.INIT, sampleUnitGroupArgumentCaptor.getValue().getStateFK());
+    assertEquals("X", sampleUnitGroupArgumentCaptor.getValue().getFormType());
+    assertNotNull(sampleUnitGroupArgumentCaptor.getValue().getCreatedDateTime());
+
+    ArgumentCaptor<ExerciseSampleUnit> sampleUnitArgumentCaptor =
+        ArgumentCaptor.forClass(ExerciseSampleUnit.class);
+    verify(sampleUnitRepo).saveAndFlush(sampleUnitArgumentCaptor.capture());
+    assertEquals(sampleUnitGroup, sampleUnitArgumentCaptor.getValue().getSampleUnitGroup());
+    assertEquals("REF123", sampleUnitArgumentCaptor.getValue().getSampleUnitRef());
+    assertEquals(SampleUnitType.B, sampleUnitArgumentCaptor.getValue().getSampleUnitType());
+    assertEquals(SAMPLE_ID, sampleUnitArgumentCaptor.getValue().getSampleUnitId());
+  }
+}


### PR DESCRIPTION
# Motivation and Context
We have been experiencing an intermittent fault in production where Sample Units aren't getting properly verified and the Collection Exercise gets permanently stuck in EXECUTION_STARTED state.

It was theorised that this could be a thread race condition issue. During investigation, it seemed likely that a native SQL query was bypassing Spring Data JPA and Hibernate, which could be causing an incorrect count of rows to be returned versus what's in Hibernate's session cache.

This is a speculative fix, because the bug is hard to reproduce locally - it's only ever been seen in production.

# What has changed
SampleUnitRepository has a new method called countBySampleUnitGroupCollectionExercise, which uses JPA and Hibernate correctly. The native query has been removed.

SampleServiceImpl.acceptSampleUnit has been changed to use the new repo method.

A unit test class with two tests has been created for the SampleServiceImpl class, which tests the behaviour when the count is not equal to the number of expected sample units, and the behaviour when the count does equal and the state of the collection exercise should be changed.

# How to test?
Unit tests and acceptance tests have been run locally and are all passing without failures.

Additionally, there have been 3 successful runs of a sample file containing 5,000 sample units, run locally, making sure the collection exercise is fully validating without issues.

# Links
Trello: https://trello.com/c/278uXMkJ/95-rsi-1805-sample-load-and-exercise-execution-sampleserviceimpl-acceptsampleunit-logic