### PR TITLE
Remove bi/create actionplan selectors at ce creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.product</groupId>
             <artifactId>actionsvc-api</artifactId>
-            <version>10.49.10</version>
+            <version>10.49.21</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.collection.exercise.client;
 
+import java.util.HashMap;
 import org.springframework.web.client.RestClientException;
 import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
 
@@ -14,5 +15,6 @@ public interface ActionSvcClient {
    * @return ActionPlanDTO representation of the created action plan
    * @throws RestClientException for failed connection to action service
    */
-  ActionPlanDTO createActionPlan(String name, String description) throws RestClientException;
+  ActionPlanDTO createActionPlan(String name, String description, HashMap<String, String> selectors)
+      throws RestClientException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
@@ -12,6 +12,7 @@ public interface ActionSvcClient {
    *
    * @param name name of action plan
    * @param description description of action plan
+   * @param selectors Map of selectors for actionplans as key value pairs
    * @return ActionPlanDTO representation of the created action plan
    * @throws RestClientException for failed connection to action service
    */

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 
+import java.util.HashMap;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -48,7 +49,8 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
       maxAttemptsExpression = "#{${retries.maxAttempts}}",
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
-  public ActionPlanDTO createActionPlan(final String name, String description)
+  public ActionPlanDTO createActionPlan(
+      final String name, String description, HashMap<String, String> selectors)
       throws RestClientException {
     log.debug("Posting to action service to create action plan");
     UriComponents uriComponents =
@@ -58,6 +60,7 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
     actionPlanDTO.setName(name);
     actionPlanDTO.setDescription(description);
     actionPlanDTO.setCreatedBy("SYSTEM");
+    actionPlanDTO.setSelectors(selectors);
     HttpEntity<ActionPlanDTO> httpEntity = restUtility.createHttpEntity(actionPlanDTO);
 
     ActionPlanDTO createdActionPlan =

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -50,7 +50,7 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
   public ActionPlanDTO createActionPlan(
-      final String name, String description, HashMap<String, String> selectors)
+      final String name, final String description, HashMap<String, String> selectors)
       throws RestClientException {
     log.debug("Posting to action service to create action plan");
     UriComponents uriComponents =

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -50,7 +50,7 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
   public ActionPlanDTO createActionPlan(
-      final String name, final String description, HashMap<String, String> selectors)
+      final String name, final String description, final HashMap<String, String> selectors)
       throws RestClientException {
     log.debug("Posting to action service to create action plan");
     UriComponents uriComponents =

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -452,8 +452,8 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
     HashMap<String, String> selectors = new HashMap<>();
     selectors.put("exerciseRef", exerciseRef);
     selectors.put("surveyRef", survey.getSurveyRef());
-    if (!sampleUnitType.equals("H") && !sampleUnitType.equals("HI")) {
-      String activeEnrolment = Boolean.toString(sampleUnitType.equals("BI"));
+    if (!"H".equals(sampleUnitType) && !"HI".equals(sampleUnitType)) {
+      String activeEnrolment = Boolean.toString("BI".equals(sampleUnitType));
       selectors.put("activeEnrolment", activeEnrolment);
     }
     String shortName = survey.getShortName();

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -383,13 +383,7 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
     String shortName = survey.getShortName();
     String name = String.format("%s %s", shortName, sampleUnitType);
     String description = String.format("%s %s Case", shortName, sampleUnitType);
-    HashMap<String, String> selectors = new HashMap<>();
-    selectors.put("surveyRef", survey.getSurveyRef());
-    if (!sampleUnitType.equals("H") && !sampleUnitType.equals("HI")) {
-      String activeEnrolment = Boolean.toString(sampleUnitType.equals("BI"));
-      selectors.put("activeEnrolment", activeEnrolment);
-    }
-    ActionPlanDTO actionPlan = actionSvcClient.createActionPlan(name, description, selectors);
+    ActionPlanDTO actionPlan = actionSvcClient.createActionPlan(name, description, null);
     createCaseTypeDefault(survey, sampleUnitType, actionPlan);
     log.debug(
         "Successfully created default action plan,"

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -383,7 +383,13 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
     String shortName = survey.getShortName();
     String name = String.format("%s %s", shortName, sampleUnitType);
     String description = String.format("%s %s Case", shortName, sampleUnitType);
-    ActionPlanDTO actionPlan = actionSvcClient.createActionPlan(name, description);
+    HashMap<String, String> selectors = new HashMap<>();
+    selectors.put("surveyRef", survey.getSurveyRef());
+    if (!sampleUnitType.equals("H") && !sampleUnitType.equals("HI")) {
+      String activeEnrolment = Boolean.toString(sampleUnitType.equals("BI"));
+      selectors.put("activeEnrolment", activeEnrolment);
+    }
+    ActionPlanDTO actionPlan = actionSvcClient.createActionPlan(name, description, selectors);
     createCaseTypeDefault(survey, sampleUnitType, actionPlan);
     log.debug(
         "Successfully created default action plan,"
@@ -449,10 +455,17 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
 
     // Create action plan with appropriate name and description
     String exerciseRef = collectionExercise.getExerciseRef();
+    HashMap<String, String> selectors = new HashMap<>();
+    selectors.put("exerciseRef", exerciseRef);
+    selectors.put("surveyRef", survey.getSurveyRef());
+    if (!sampleUnitType.equals("H") && !sampleUnitType.equals("HI")) {
+      String activeEnrolment = Boolean.toString(sampleUnitType.equals("BI"));
+      selectors.put("activeEnrolment", activeEnrolment);
+    }
     String shortName = survey.getShortName();
     String name = String.format("%s %s %s", shortName, sampleUnitType, exerciseRef);
     String description = String.format("%s %s Case %s", shortName, sampleUnitType, exerciseRef);
-    ActionPlanDTO actionPlan = actionSvcClient.createActionPlan(name, description);
+    ActionPlanDTO actionPlan = actionSvcClient.createActionPlan(name, description, selectors);
 
     // Create casetypeoverride linking collection exercise and sample unit type to the action plan
     createCaseTypeOverride(collectionExercise, sampleUnitType, actionPlan);

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ActionSvcClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ActionSvcClientImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -62,6 +63,9 @@ public class ActionSvcClientImplTest {
     actionPlanDTO.setName(ACTION_PLAN_NAME);
     actionPlanDTO.setDescription(ACTION_PLAN_DESCRIPTION);
     actionPlanDTO.setCreatedBy("SYSTEM");
+    HashMap<String, String> selectors = new HashMap<>();
+    selectors.put("testSelector", "testValue");
+    actionPlanDTO.setSelectors(selectors);
 
     HttpEntity httpEntity = new HttpEntity<>(actionPlanDTO, null);
     when(restUtility.createHttpEntity(any(ActionPlanDTO.class))).thenReturn(httpEntity);
@@ -71,7 +75,7 @@ public class ActionSvcClientImplTest {
 
     // When
     ActionPlanDTO createdActionPlanDTO =
-        actionSvcClient.createActionPlan(ACTION_PLAN_NAME, ACTION_PLAN_DESCRIPTION);
+        actionSvcClient.createActionPlan(ACTION_PLAN_NAME, ACTION_PLAN_DESCRIPTION, selectors);
 
     // Then
     verify(restTemplate)
@@ -106,6 +110,9 @@ public class ActionSvcClientImplTest {
     actionPlanDTO.setName(ACTION_PLAN_NAME);
     actionPlanDTO.setDescription(ACTION_PLAN_DESCRIPTION);
     actionPlanDTO.setCreatedBy("SYSTEM");
+    HashMap<String, String> selectors = new HashMap<>();
+    selectors.put("testSelector", "testValue");
+    actionPlanDTO.setSelectors(selectors);
     HttpEntity httpEntity = new HttpEntity<>(actionPlanDTO, null);
     when(restUtility.createHttpEntity(any(ActionPlanDTO.class))).thenReturn(httpEntity);
     when(restTemplate.postForObject(
@@ -113,7 +120,7 @@ public class ActionSvcClientImplTest {
         .thenThrow(RestClientException.class);
 
     // When
-    actionSvcClient.createActionPlan(ACTION_PLAN_NAME, ACTION_PLAN_DESCRIPTION);
+    actionSvcClient.createActionPlan(ACTION_PLAN_NAME, ACTION_PLAN_DESCRIPTION, selectors);
 
     // Then RestClientException is thrown
   }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
@@ -276,18 +276,11 @@ public class CollectionExerciseServiceImplTest {
     this.collectionExerciseServiceImpl.createCollectionExercise(toCreate, survey);
 
     // Then check that all actionplans are created in the correct state
+    verify(actionService, times(1)).createActionPlan("BRES B", "BRES B Case", null);
+    verify(actionService, times(1)).createActionPlan("BRES BI", "BRES BI Case", null);
+
     String exerciseRef = collectionExercise.getExerciseRef();
     String surveyRef = survey.getSurveyRef();
-    HashMap<String, String> defaultBSelectors = new HashMap<>();
-    defaultBSelectors.put("surveyRef", surveyRef);
-    defaultBSelectors.put("activeEnrolment", "false");
-    verify(actionService, times(1)).createActionPlan("BRES B", "BRES B Case", defaultBSelectors);
-
-    HashMap<String, String> defaultBISelectors = new HashMap<>();
-    defaultBISelectors.put("surveyRef", surveyRef);
-    defaultBISelectors.put("activeEnrolment", "true");
-    verify(actionService, times(1)).createActionPlan("BRES BI", "BRES BI Case", defaultBISelectors);
-
     HashMap<String, String> overrideBSelectors = new HashMap<>();
     overrideBSelectors.put("surveyRef", surveyRef);
     overrideBSelectors.put("exerciseRef", exerciseRef);
@@ -330,16 +323,8 @@ public class CollectionExerciseServiceImplTest {
     this.collectionExerciseServiceImpl.createCollectionExercise(toCreate, survey);
 
     // Then
-    String surveyRef = survey.getSurveyRef();
-    HashMap<String, String> defaultBSelectors = new HashMap<>();
-    defaultBSelectors.put("surveyRef", surveyRef);
-    defaultBSelectors.put("activeEnrolment", "false");
-    verify(actionService, times(0)).createActionPlan("BRES B", "BRES B Case", defaultBSelectors);
-
-    HashMap<String, String> defaultBISelectors = new HashMap<>();
-    defaultBISelectors.put("surveyRef", surveyRef);
-    defaultBISelectors.put("activeEnrolment", "true");
-    verify(actionService, times(0)).createActionPlan("BRES BI", "BRES BI Case", defaultBISelectors);
+    verify(actionService, times(0)).createActionPlan("BRES B", "BRES B Case", null);
+    verify(actionService, times(0)).createActionPlan("BRES BI", "BRES BI Case", null);
   }
 
   /**

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
@@ -15,6 +15,7 @@ import static uk.gov.ons.ctp.response.collection.exercise.representation.Collect
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -237,7 +238,7 @@ public class CollectionExerciseServiceImplTest {
 
     ActionPlanDTO actionPlanDTO = new ActionPlanDTO();
     actionPlanDTO.setId(UUID.randomUUID());
-    when(actionService.createActionPlan(any(), any())).thenReturn(actionPlanDTO);
+    when(actionService.createActionPlan(any(), any(), any())).thenReturn(actionPlanDTO);
     when(caseTypeDefaultRepo.findTopBySurveyIdAndSampleUnitTypeFK(any(), any())).thenReturn(null);
 
     // When
@@ -269,21 +270,42 @@ public class CollectionExerciseServiceImplTest {
     when(this.surveyService.findSurvey(UUID.fromString(toCreate.getSurveyId()))).thenReturn(survey);
     ActionPlanDTO actionPlanDTO = new ActionPlanDTO();
     actionPlanDTO.setId(UUID.randomUUID());
-    when(actionService.createActionPlan(any(), any())).thenReturn(actionPlanDTO);
+    when(actionService.createActionPlan(any(), any(), any())).thenReturn(actionPlanDTO);
 
     // When
     this.collectionExerciseServiceImpl.createCollectionExercise(toCreate, survey);
 
-    // Then
-    verify(actionService, times(1)).createActionPlan("BRES B", "BRES B Case");
-    verify(actionService, times(1)).createActionPlan("BRES BI", "BRES BI Case");
-    verify(actionService, times(1)).createActionPlan("BRES B 202103", "BRES B Case 202103");
-    verify(actionService, times(1)).createActionPlan("BRES BI 202103", "BRES BI Case 202103");
+    // Then check that all actionplans are created in the correct state
+    String exerciseRef = collectionExercise.getExerciseRef();
+    String surveyRef = survey.getSurveyRef();
+    HashMap<String, String> defaultBSelectors = new HashMap<>();
+    defaultBSelectors.put("surveyRef", surveyRef);
+    defaultBSelectors.put("activeEnrolment", "false");
+    verify(actionService, times(1)).createActionPlan("BRES B", "BRES B Case", defaultBSelectors);
+
+    HashMap<String, String> defaultBISelectors = new HashMap<>();
+    defaultBISelectors.put("surveyRef", surveyRef);
+    defaultBISelectors.put("activeEnrolment", "true");
+    verify(actionService, times(1)).createActionPlan("BRES BI", "BRES BI Case", defaultBISelectors);
+
+    HashMap<String, String> overrideBSelectors = new HashMap<>();
+    overrideBSelectors.put("surveyRef", surveyRef);
+    overrideBSelectors.put("exerciseRef", exerciseRef);
+    overrideBSelectors.put("activeEnrolment", "false");
+    verify(actionService, times(1))
+        .createActionPlan("BRES B 202103", "BRES B Case 202103", overrideBSelectors);
+
+    HashMap<String, String> overrideBISelectors = new HashMap<>();
+    overrideBISelectors.put("surveyRef", surveyRef);
+    overrideBISelectors.put("exerciseRef", exerciseRef);
+    overrideBISelectors.put("activeEnrolment", "true");
+    verify(actionService, times(1))
+        .createActionPlan("BRES BI 202103", "BRES BI Case 202103", overrideBISelectors);
   }
 
   /**
    * Tests that creating a collection exercise for which action plans exists does not try to create
-   * action plans
+   * existing default action plans
    */
   @Test
   public void testCreateCollectionExerciseExistingDefaultActionPlans() throws Exception {
@@ -295,10 +317,11 @@ public class CollectionExerciseServiceImplTest {
     collectionExercise.setExerciseRef(toCreate.getExerciseRef());
     when(collexRepo.saveAndFlush(any())).thenReturn(collectionExercise);
     SurveyDTO survey = FixtureHelper.loadClassFixtures(SurveyDTO[].class).get(0);
+
     when(this.surveyService.findSurvey(UUID.fromString(toCreate.getSurveyId()))).thenReturn(survey);
     ActionPlanDTO actionPlanDTO = new ActionPlanDTO();
     actionPlanDTO.setId(UUID.randomUUID());
-    when(actionService.createActionPlan(any(), any())).thenReturn(actionPlanDTO);
+    when(actionService.createActionPlan(any(), any(), any())).thenReturn(actionPlanDTO);
     CaseTypeDefault caseTypedefault = new CaseTypeDefault();
     when(caseTypeDefaultRepo.findTopBySurveyIdAndSampleUnitTypeFK(any(), any()))
         .thenReturn(caseTypedefault);
@@ -307,13 +330,21 @@ public class CollectionExerciseServiceImplTest {
     this.collectionExerciseServiceImpl.createCollectionExercise(toCreate, survey);
 
     // Then
-    verify(actionService, times(0)).createActionPlan("BRES B", "BRES B Case");
-    verify(actionService, times(0)).createActionPlan("BRES BI", "BRES BI Case");
+    String surveyRef = survey.getSurveyRef();
+    HashMap<String, String> defaultBSelectors = new HashMap<>();
+    defaultBSelectors.put("surveyRef", surveyRef);
+    defaultBSelectors.put("activeEnrolment", "false");
+    verify(actionService, times(0)).createActionPlan("BRES B", "BRES B Case", defaultBSelectors);
+
+    HashMap<String, String> defaultBISelectors = new HashMap<>();
+    defaultBISelectors.put("surveyRef", surveyRef);
+    defaultBISelectors.put("activeEnrolment", "true");
+    verify(actionService, times(0)).createActionPlan("BRES BI", "BRES BI Case", defaultBISelectors);
   }
 
   /**
    * Tests that creating a collection exercise for which action plans exists does not try to create
-   * action plans
+   * existing override action plans
    */
   @Test
   public void testCreateCollectionExerciseExistingOverrideActionPlans() throws Exception {
@@ -325,10 +356,11 @@ public class CollectionExerciseServiceImplTest {
     collectionExercise.setExerciseRef(toCreate.getExerciseRef());
     when(collexRepo.saveAndFlush(any())).thenReturn(collectionExercise);
     SurveyDTO survey = FixtureHelper.loadClassFixtures(SurveyDTO[].class).get(0);
+
     when(this.surveyService.findSurvey(UUID.fromString(toCreate.getSurveyId()))).thenReturn(survey);
     ActionPlanDTO actionPlanDTO = new ActionPlanDTO();
     actionPlanDTO.setId(UUID.randomUUID());
-    when(actionService.createActionPlan(any(), any())).thenReturn(actionPlanDTO);
+    when(actionService.createActionPlan(any(), any(), any())).thenReturn(actionPlanDTO);
     CaseTypeOverride caseTypeOverride = new CaseTypeOverride();
     when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(any(), any()))
         .thenReturn(caseTypeOverride);
@@ -337,8 +369,21 @@ public class CollectionExerciseServiceImplTest {
     this.collectionExerciseServiceImpl.createCollectionExercise(toCreate, survey);
 
     // Then
-    verify(actionService, times(0)).createActionPlan("BRES B 202103", "BRES B Case 202103");
-    verify(actionService, times(0)).createActionPlan("BRES BI 202103", "BRES BI Case 202103");
+    String exerciseRef = collectionExercise.getExerciseRef();
+    String surveyRef = survey.getSurveyRef();
+    HashMap<String, String> overrideBSelectors = new HashMap<>();
+    overrideBSelectors.put("surveyRef", surveyRef);
+    overrideBSelectors.put("exerciseRef", exerciseRef);
+    overrideBSelectors.put("activeEnrolment", "false");
+    verify(actionService, times(0))
+        .createActionPlan("BRES B 202103", "BRES B Case 202103", overrideBSelectors);
+
+    HashMap<String, String> overrideBISelectors = new HashMap<>();
+    overrideBISelectors.put("surveyRef", surveyRef);
+    overrideBISelectors.put("exerciseRef", exerciseRef);
+    overrideBISelectors.put("activeEnrolment", "true");
+    verify(actionService, times(0))
+        .createActionPlan("BRES BI 202103", "BRES BI Case 202103", overrideBISelectors);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImplTest.java
@@ -106,7 +106,9 @@ public class SampleServiceImplTest {
     ArgumentCaptor<ExerciseSampleUnit> sampleUnitArgumentCaptor =
         ArgumentCaptor.forClass(ExerciseSampleUnit.class);
     verify(sampleUnitRepo).saveAndFlush(sampleUnitArgumentCaptor.capture());
-    assertEquals(sampleUnitGroupArgumentCaptor.getValue(), sampleUnitArgumentCaptor.getValue().getSampleUnitGroup());
+    assertEquals(
+        sampleUnitGroupArgumentCaptor.getValue(),
+        sampleUnitArgumentCaptor.getValue().getSampleUnitGroup());
     assertEquals("REF123", sampleUnitArgumentCaptor.getValue().getSampleUnitRef());
     assertEquals(SampleUnitType.B, sampleUnitArgumentCaptor.getValue().getSampleUnitType());
     assertEquals(SAMPLE_ID, sampleUnitArgumentCaptor.getValue().getSampleUnitId());


### PR DESCRIPTION
# Motivation and Context
When we remove BI cases we will stop using `casetypeoverrides` and instead use the action plan selectors which have been recently added to the action service.
When we initially create action plans we will want to also create the appropriate action plan selectors

# What has changed
Added selectors fields to requests for creating override action plans
The selectors we are concerned with are `surveyRef`, `activeEnrolments` and `exerciseRef`

# How to test?
After running `make setup` in the acceptance tests the created action plans in the database should have it's `selectors` fields filled in

To test for a single case exercise the create collection exercise endpoint either directly or through the UI and check that action plans are created with the appropriate selectors

# Links
[Trello](https://trello.com/c/VmIr3Qwp/280-add-action-plan-selectors-when-creating-collection-exercises-m)
