### PR TITLE
Create Action Rules when Events Created

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# top-most EditorConfig file
+root = true
+
+[*.java]
+indent_style = space
+indent_size = 2

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.product</groupId>
             <artifactId>actionsvc-api</artifactId>
-            <version>10.49.21</version>
+            <version>10.49.22</version>
         </dependency>
 
         <dependency>
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.common</groupId>
             <artifactId>framework</artifactId>
-            <version>10.49.14</version>
+            <version>10.49.16</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
@@ -1,8 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.client;
 
+import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.UUID;
 import org.springframework.web.client.RestClientException;
 import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
 
 /** HTTP RestClient implementation for calls to the Action service. */
 public interface ActionSvcClient {
@@ -17,5 +20,26 @@ public interface ActionSvcClient {
    * @throws RestClientException for failed connection to action service
    */
   ActionPlanDTO createActionPlan(String name, String description, HashMap<String, String> selectors)
+      throws RestClientException;
+
+  /**
+   * Request action rule is created.
+   *
+   * @param name name of action rule
+   * @param description description of action rule
+   * @param actionTypeName name of action type
+   * @param triggerDateTime date time to trigger action rule
+   * @param priority priority number
+   * @param actionPlanId uuid of the action plan this action type is for
+   * @return ActionRuleDTO representation of the created action plan
+   * @throws RestClientException for failed connection to action service
+   */
+  ActionRuleDTO createActionRule(
+      String name,
+      String description,
+      String actionTypeName,
+      OffsetDateTime triggerDateTime,
+      int priority,
+      UUID actionPlanId)
       throws RestClientException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -1,6 +1,8 @@
 package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 
+import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -13,6 +15,8 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import uk.gov.ons.ctp.common.rest.RestUtility;
 import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionRulePostRequestDTO;
 import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 
@@ -69,5 +73,38 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
         "Successfully posted to action service to create action plan, ActionPlanId: {}",
         createdActionPlan.getId());
     return createdActionPlan;
+  }
+
+  @Override
+  public ActionRuleDTO createActionRule(
+      final String name,
+      final String description,
+      final String actionTypeName,
+      final OffsetDateTime triggerDateTime,
+      final int priority,
+      final UUID actionPlanId)
+      throws RestClientException {
+    log.debug("Posting to action service to create action rule");
+    final UriComponents uriComponents =
+        restUtility.createUriComponents(appConfig.getActionSvc().getActionRulesPath(), null);
+
+    final ActionRulePostRequestDTO actionRulePostRequestDTO = new ActionRulePostRequestDTO();
+    actionRulePostRequestDTO.setName(name);
+    actionRulePostRequestDTO.setActionTypeName(actionTypeName);
+    actionRulePostRequestDTO.setDescription(description);
+    actionRulePostRequestDTO.setActionPlanId(actionPlanId);
+    actionRulePostRequestDTO.setTriggerDateTime(triggerDateTime);
+    actionRulePostRequestDTO.setPriority(priority);
+
+    final HttpEntity<ActionRulePostRequestDTO> httpEntity =
+        restUtility.createHttpEntity(actionRulePostRequestDTO);
+    final ActionRuleDTO createdActionRule =
+        restTemplate.postForObject(uriComponents.toUri(), httpEntity, ActionRuleDTO.class);
+    log.debug(
+        "Successfully posted to action service to create action rule,"
+            + "ActionPlanId: {}, ActionRuleId: {}",
+        actionPlanId,
+        createdActionRule.getId());
+    return createdActionRule;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/ActionSvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/ActionSvc.java
@@ -10,4 +10,5 @@ import uk.gov.ons.ctp.common.rest.RestUtilityConfig;
 public class ActionSvc {
   private RestUtilityConfig connectionConfig;
   private String actionPlansPath;
+  private String actionRulesPath;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -424,32 +424,24 @@ public class CollectionExerciseEndpoint {
         "Creating collection exercise, ExerciseRef: {}, SurveyRef: {}",
         collex.getExerciseRef(),
         collex.getSurveyRef());
-    String surveyId = collex.getSurveyId();
-    String surveyRef = collex.getSurveyRef();
-    SurveyDTO survey;
+    SurveyDTO survey = getSurveyFromCollex(collex);
 
-    // Retrieve survey from survey service if it exists
-    if (!StringUtils.isBlank(surveyId)) {
-      survey = this.surveyService.findSurvey(UUID.fromString(collex.getSurveyId()));
-    } else if (!StringUtils.isBlank(surveyRef)) {
-      survey = this.surveyService.findSurveyByRef(surveyRef);
-      // Downstream expects the surveyId to be present so add it now
-      collex.setSurveyId(survey.getId());
-    } else {
-      throw new CTPException(CTPException.Fault.BAD_REQUEST, "No survey specified");
-    }
     if (survey == null) {
-      throw new CTPException(CTPException.Fault.BAD_REQUEST, "Invalid survey: " + surveyId);
+      throw new CTPException(
+          CTPException.Fault.BAD_REQUEST, "Invalid survey: " + collex.getSurveyId());
     }
+
+    collex.setSurveyId(survey.getId());
     // Check if collection exercise already exists
     CollectionExercise existing =
         this.collectionExerciseService.findCollectionExercise(collex.getExerciseRef(), survey);
+
     if (existing != null) {
       throw new CTPException(
           CTPException.Fault.RESOURCE_VERSION_CONFLICT,
           String.format(
               "Collection exercise already exists, ExerciseRef: %s, SurveyRef: %s",
-              collex.getExerciseRef(), surveyRef));
+              collex.getExerciseRef(), collex.getSurveyRef()));
     }
 
     CollectionExercise newCollex =
@@ -463,6 +455,24 @@ public class CollectionExerciseEndpoint {
     log.info(
         "Successfully created collection exercise, CollectionExerciseId: {}", newCollex.getId());
     return ResponseEntity.created(location).build();
+  }
+
+  private SurveyDTO getSurveyFromCollex(
+      @Validated(CollectionExerciseDTO.PostValidation.class) @RequestBody
+          final CollectionExerciseDTO collex)
+      throws CTPException {
+    final String surveyId = collex.getSurveyId();
+    final String surveyRef = collex.getSurveyRef();
+
+    if (!StringUtils.isBlank(surveyId)) {
+      return surveyService.findSurvey(UUID.fromString(collex.getSurveyId()));
+    }
+
+    if (!StringUtils.isBlank(surveyRef)) {
+      return surveyService.findSurveyByRef(surveyRef);
+    }
+
+    throw new CTPException(CTPException.Fault.BAD_REQUEST, "No survey specified");
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/ActionRuleCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/ActionRuleCreator.java
@@ -1,0 +1,13 @@
+package uk.gov.ons.ctp.response.collection.exercise.service;
+
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+
+public interface ActionRuleCreator {
+  void execute(
+      Event collectionExerciseEvent,
+      CaseTypeOverride businessCaseTypeOverride,
+      CaseTypeOverride businessIndividualCaseTypeOverride,
+      SurveyDTO survey);
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
@@ -1,9 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.service;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 
@@ -20,7 +22,7 @@ public interface EventService {
     reminder3(false),
     ref_period_start(false),
     ref_period_end(false),
-    employment_date(false);
+    employment(false);
 
     Tag(final boolean mandatory) {
       this.mandatory = mandatory;
@@ -31,6 +33,12 @@ public interface EventService {
     }
 
     private boolean mandatory;
+
+    public boolean isActionable() {
+      List<Tag> actionableEvents = Arrays.asList(mps, go_live, reminder, reminder2, reminder3);
+
+      return actionableEvents.contains(this);
+    }
   }
 
   Event createEvent(EventDTO eventDto) throws CTPException;
@@ -79,4 +87,14 @@ public interface EventService {
    * @throws CTPException thrown if error occurred scheduling event
    */
   void scheduleEvent(Event event) throws CTPException;
+
+  /**
+   * Create action rules for collection exercise event
+   *
+   * @param event the event to create action rules for
+   * @param collectionExercise the event is for
+   * @throws CTPException on error
+   */
+  void createActionRulesForEvent(Event event, CollectionExercise collectionExercise)
+      throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleCreator.java
@@ -1,0 +1,53 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleCreator;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+
+@Component
+public final class GoLiveActionRuleCreator implements ActionRuleCreator {
+  private final ActionSvcClient actionSvcClient;
+
+  public GoLiveActionRuleCreator(final ActionSvcClient actionSvcClient) {
+    this.actionSvcClient = actionSvcClient;
+  }
+
+  @Override
+  public void execute(
+      final Event collectionExerciseEvent,
+      final CaseTypeOverride businessCaseTypeOverride,
+      final CaseTypeOverride businessIndividualCaseTypeOverride,
+      final SurveyDTO survey) {
+    if (survey.getSurveyType() != SurveyDTO.SurveyType.Business) {
+      return;
+    }
+
+    if (!isGoLive(collectionExerciseEvent)) {
+      return;
+    }
+
+    final Instant instant = Instant.ofEpochMilli(collectionExerciseEvent.getTimestamp().getTime());
+    final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(instant, ZoneId.systemDefault());
+    final CollectionExercise collectionExercise = collectionExerciseEvent.getCollectionExercise();
+
+    actionSvcClient.createActionRule(
+        survey.getShortName() + "NOTE",
+        survey.getShortName() + " Notification Email " + collectionExercise.getExerciseRef(),
+        "BSNE",
+        offsetDateTime,
+        3,
+        businessIndividualCaseTypeOverride.getActionPlanId());
+  }
+
+  private boolean isGoLive(final Event collectionExerciseEvent) {
+    return Tag.valueOf(collectionExerciseEvent.getTag()).equals(Tag.go_live);
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreator.java
@@ -1,0 +1,54 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleCreator;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+
+@Component
+public final class MpsActionRuleCreator implements ActionRuleCreator {
+
+  private final ActionSvcClient actionSvcClient;
+
+  public MpsActionRuleCreator(final ActionSvcClient actionSvcClient) {
+    this.actionSvcClient = actionSvcClient;
+  }
+
+  @Override
+  public void execute(
+      final Event collectionExerciseEvent,
+      final CaseTypeOverride businessCaseTypeOverride,
+      final CaseTypeOverride businessIndividualCaseTypeOverride,
+      final SurveyDTO survey) {
+    if (survey.getSurveyType() != SurveyDTO.SurveyType.Business) {
+      return;
+    }
+
+    if (!isMps(collectionExerciseEvent)) {
+      return;
+    }
+
+    final Instant instant = Instant.ofEpochMilli(collectionExerciseEvent.getTimestamp().getTime());
+    final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(instant, ZoneId.systemDefault());
+    final CollectionExercise collectionExercise = collectionExerciseEvent.getCollectionExercise();
+
+    actionSvcClient.createActionRule(
+        survey.getShortName() + "NOTF",
+        survey.getShortName() + " Notification File " + collectionExercise.getExerciseRef(),
+        "BSNL",
+        offsetDateTime,
+        3,
+        businessCaseTypeOverride.getActionPlanId());
+  }
+
+  private boolean isMps(final Event collectionExerciseEvent) {
+    return Tag.valueOf(collectionExerciseEvent.getTag()).equals(Tag.mps);
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreator.java
@@ -1,0 +1,64 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleCreator;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
+
+@Component
+public final class ReminderActionRuleCreator implements ActionRuleCreator {
+  private final ActionSvcClient actionSvcClient;
+
+  public ReminderActionRuleCreator(final ActionSvcClient actionSvcClient) {
+    this.actionSvcClient = actionSvcClient;
+  }
+
+  @Override
+  public void execute(
+      final Event collectionExerciseEvent,
+      final CaseTypeOverride businessCaseTypeOverride,
+      final CaseTypeOverride businessIndividualCaseTypeOverride,
+      final SurveyDTO survey) {
+    if (survey.getSurveyType() != SurveyType.Business) {
+      return;
+    }
+
+    if (!isReminder(collectionExerciseEvent)) {
+      return;
+    }
+
+    final Instant instant = Instant.ofEpochMilli(collectionExerciseEvent.getTimestamp().getTime());
+    final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(instant, ZoneId.systemDefault());
+    final CollectionExercise collectionExercise = collectionExerciseEvent.getCollectionExercise();
+
+    actionSvcClient.createActionRule(
+        survey.getShortName() + "REME",
+        survey.getShortName() + " Reminder Email " + collectionExercise.getExerciseRef(),
+        "BSRE",
+        offsetDateTime,
+        3,
+        businessIndividualCaseTypeOverride.getActionPlanId());
+
+    actionSvcClient.createActionRule(
+        survey.getShortName() + "REMF",
+        survey.getShortName() + " Reminder File " + collectionExercise.getExerciseRef(),
+        "BSRL",
+        offsetDateTime,
+        3,
+        businessCaseTypeOverride.getActionPlanId());
+  }
+
+  private boolean isReminder(final Event collectionExerciseEvent) {
+    return Arrays.asList(Tag.reminder, Tag.reminder2, Tag.reminder3)
+        .contains(Tag.valueOf(collectionExerciseEvent.getTag()));
+  }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -13,9 +13,17 @@ sample-svc:
   connection-config:
     port: 18002
 
+collection-instrument-svc:
+    connection-config:
+        port: 18002
+
+party-svc:
+    connection-config:
+        port: 18002
+
 action-svc:
   connection-config:
-    port: 38151
+    port: 18002
 
 redisson-config:
   address: localhost:17379
@@ -27,12 +35,4 @@ rabbitmq:
 schedules:
   validation-schedule-delay-milli-seconds: 5000
   distribution-schedule-delay-milli-seconds: 5000
-
-collection-instrument-svc:
-    connection-config:
-        port: 18002
-
-party-svc:
-    connection-config:
-        port: 18002
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,7 @@ survey-svc:
 
 action-svc:
   action-plans-path: /actionplans
+  action-rules-path: /actionrules
   connection-config:
     scheme: http
     host: localhost

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/EventServiceTest.java
@@ -1,0 +1,39 @@
+package uk.gov.ons.ctp.response.collection.exercise.service;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+
+public class EventServiceTest {
+  @Test
+  public void testTagShouldHaveMpsAsIsActionable() {
+    assertThat(Tag.mps.isActionable(), is(true));
+  }
+
+  @Test
+  public void testTagShouldHaveGoLiveAsIsAnActionableTag() {
+    assertThat(Tag.go_live.isActionable(), is(true));
+  }
+
+  @Test
+  public void testTagShouldHaveExerciseEndAsNotIsAnActionableTag() {
+    assertThat(Tag.exercise_end.isActionable(), is(false));
+  }
+
+  @Test
+  public void testTagShouldHaveReminderAsAnActionableTag() {
+    assertThat(Tag.reminder.isActionable(), is(true));
+  }
+
+  @Test
+  public void testTagShouldHaveReminder2AsAnActionableTag() {
+    assertThat(Tag.reminder2.isActionable(), is(true));
+  }
+
+  @Test
+  public void testTagShouldHaveReminder3AsAnActionableTag() {
+    assertThat(Tag.reminder3.isActionable(), is(true));
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ActionSvcClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ActionSvcClientImplTest.java
@@ -6,7 +6,9 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -20,6 +22,8 @@ import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.ons.ctp.common.rest.RestUtility;
 import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionRulePostRequestDTO;
 import uk.gov.ons.ctp.response.collection.exercise.client.impl.ActionSvcRestClientImpl;
 import uk.gov.ons.ctp.response.collection.exercise.config.ActionSvc;
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
@@ -28,6 +32,7 @@ import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 public class ActionSvcClientImplTest {
 
   private static final String ACTION_PATH = "/actions";
+  private static final String ACTION_RULE_PATH = "/actionrules";
   private static final String HTTP = "http";
   private static final String LOCALHOST = "localhost";
   private static final String ACTION_PLAN_NAME = "example";
@@ -123,5 +128,104 @@ public class ActionSvcClientImplTest {
     actionSvcClient.createActionPlan(ACTION_PLAN_NAME, ACTION_PLAN_DESCRIPTION, selectors);
 
     // Then RestClientException is thrown
+  }
+
+  /** Test that the action service is called with the correct details when creating action rules. */
+  @Test
+  public void testCreateActionRule() {
+    // Given
+    ActionSvc actionSvcConfig = new ActionSvc();
+    actionSvcConfig.setActionRulesPath(ACTION_RULE_PATH);
+    when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
+
+    UriComponents uriComponents =
+        UriComponentsBuilder.newInstance()
+            .scheme(HTTP)
+            .host(LOCALHOST)
+            .port(80)
+            .path(ACTION_PATH)
+            .build();
+    when(restUtility.createUriComponents(any(String.class), any(MultiValueMap.class)))
+        .thenReturn(uriComponents);
+
+    ActionRulePostRequestDTO actionRulePostRequestDTO = getActionRulePostRequestDTO();
+
+    ActionRuleDTO actionRuleDTO = getActionRuleDTO();
+
+    HttpEntity httpEntity = new HttpEntity<>(actionRulePostRequestDTO, null);
+    when(restUtility.createHttpEntity(any(ActionRulePostRequestDTO.class))).thenReturn(httpEntity);
+    when(restTemplate.postForObject(
+            eq(uriComponents.toUri()), eq(httpEntity), eq(ActionRuleDTO.class)))
+        .thenReturn(actionRuleDTO);
+
+    // When
+    ActionRuleDTO createdActionRuleDTO =
+        actionSvcClient.createActionRule(
+            actionRulePostRequestDTO.getName(),
+            actionRulePostRequestDTO.getDescription(),
+            actionRulePostRequestDTO.getActionTypeName(),
+            actionRulePostRequestDTO.getTriggerDateTime(),
+            actionRulePostRequestDTO.getPriority(),
+            actionRulePostRequestDTO.getActionPlanId());
+
+    // Then
+    verify(restTemplate)
+        .postForObject(eq(uriComponents.toUri()), eq(httpEntity), eq(ActionRuleDTO.class));
+    verify(restUtility).createHttpEntity(eq(actionRulePostRequestDTO));
+    assertEquals(createdActionRuleDTO.getName(), actionRuleDTO.getName());
+    assertEquals(createdActionRuleDTO.getDescription(), actionRuleDTO.getDescription());
+    assertEquals(createdActionRuleDTO.getActionTypeName(), actionRuleDTO.getActionTypeName());
+    assertEquals(createdActionRuleDTO.getId(), actionRuleDTO.getId());
+  }
+
+  /**
+   * Test that a rest client exception is thrown when issues contacting the action service to create
+   * an action rule.
+   */
+  @Test(expected = RestClientException.class)
+  public void testCreateActionRuleRestClientException() {
+    // Given
+    ActionSvc actionSvcConfig = new ActionSvc();
+    actionSvcConfig.setActionRulesPath(ACTION_RULE_PATH);
+    when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
+
+    when(restUtility.createUriComponents(any(String.class), any(MultiValueMap.class)))
+        .thenReturn(UriComponentsBuilder.newInstance().build());
+
+    when(restTemplate.postForObject(any(), any(), any())).thenThrow(RestClientException.class);
+
+    // When
+    actionSvcClient.createActionRule(
+        "BSREM+45",
+        "Enrolment Reminder Letter(+45 days)",
+        "BSREM",
+        OffsetDateTime.now().plusDays(45),
+        3,
+        UUID.fromString("003e587a-843f-11e8-adc0-fa7ae01bbebc"));
+
+    // Then RestClientException is thrown
+  }
+
+  private ActionRulePostRequestDTO getActionRulePostRequestDTO() {
+    ActionRulePostRequestDTO actionRulePostRequestDTO = new ActionRulePostRequestDTO();
+    actionRulePostRequestDTO.setName("BSREM+45");
+    actionRulePostRequestDTO.setActionTypeName("BSREM");
+    actionRulePostRequestDTO.setDescription("Enrolment Reminder Letter(+45 days)");
+    actionRulePostRequestDTO.setActionPlanId(
+        UUID.fromString("003e587a-843f-11e8-adc0-fa7ae01bbebc"));
+    actionRulePostRequestDTO.setTriggerDateTime(OffsetDateTime.now());
+    actionRulePostRequestDTO.setPriority(3);
+    return actionRulePostRequestDTO;
+  }
+
+  private ActionRuleDTO getActionRuleDTO() {
+    ActionRuleDTO actionRuleDTO = new ActionRuleDTO();
+    actionRuleDTO.setName("BSREM+45");
+    actionRuleDTO.setActionTypeName("BSREM");
+    actionRuleDTO.setDescription("Enrolment Reminder Letter(+45 days)");
+    actionRuleDTO.setId(UUID.fromString("714356ba-7236-4179-8007-f09190eed323"));
+    actionRuleDTO.setTriggerDateTime(OffsetDateTime.now());
+    actionRuleDTO.setPriority(3);
+    return actionRuleDTO;
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImplTest.java
@@ -4,9 +4,12 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -17,23 +20,49 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.client.SurveySvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.repository.CaseTypeOverrideRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.EventRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleCreator;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
-import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /** Class containing tests for EventServiceImpl */
 @RunWith(MockitoJUnitRunner.class)
 public class EventServiceImplTest {
+  public static final UUID SURVEY_ID = UUID.fromString("4ca97b1b-de9c-4fed-9898-fac594d1565f");
+  @Mock private SurveySvcClient surveySvcClient;
+
   @Mock private EventRepository eventRepository;
+
+  @Mock private CaseTypeOverrideRepository caseTypeOverrideRepo;
 
   @Mock private CollectionExerciseService collectionExerciseService;
 
+  @Mock private ActionRuleCreator actionRuleCreator;
+
+  @Mock private ActionRuleCreator actionRuleCreator2;
+
+  @Spy private List<ActionRuleCreator> actionRuleCreators = new ArrayList<ActionRuleCreator>();
+
   @InjectMocks private EventServiceImpl eventService;
+
+  private static Event createEvent(Tag tag) {
+    Timestamp eventTime = new Timestamp(new Date().getTime());
+    Event event = new Event();
+    event.setTimestamp(eventTime);
+    event.setTag(tag.name());
+
+    return event;
+  }
 
   /* Given collection excercise does not exist When event is created Then exception is thrown */
   @Test
@@ -54,8 +83,8 @@ public class EventServiceImplTest {
 
   /* Given event already exists When event is created Then exception is thrown */
   @Test
-  public void givenEventAlreadyExistsWhenEventIsCreatedThenExceptionIsThrown() {
-    String tag = EventService.Tag.mps.name();
+  public void givenEventAlreadyExistsWhenEventIsCreatedThenExceptionIsThrown() throws CTPException {
+    String tag = Tag.mps.name();
     EventDTO eventDto = new EventDTO();
     CollectionExercise collex = new CollectionExercise();
     UUID collexUuid = UUID.randomUUID();
@@ -76,16 +105,114 @@ public class EventServiceImplTest {
     }
   }
 
-  private static Event createEvent(EventService.Tag tag) {
-    Timestamp eventTime = new Timestamp(new Date().getTime());
+  /**
+   * Test CTP exception thrown if no business case type override found, so no action plans have been
+   * associated to CE
+   */
+  @Test
+  public void testCreateActionRulesRaisesCTPExceptionIfNoBCaseOverRide() {
     Event event = new Event();
-    event.setTimestamp(eventTime);
-    event.setTag(tag.name());
+    CollectionExercise collex = new CollectionExercise();
+    CaseTypeOverride biCaseTypeOverride = new CaseTypeOverride();
+    collex.setExercisePK(1);
+    event.setTag(Tag.mps.name());
 
-    return event;
+    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(1, "B")).thenReturn(null);
+    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(1, "BI"))
+        .thenReturn(biCaseTypeOverride);
+    try {
+      eventService.createActionRulesForEvent(event, collex);
+      fail("Trying to create action rules when no action plans associated");
+    } catch (CTPException e) {
+      assertEquals(CTPException.Fault.RESOURCE_NOT_FOUND, e.getFault());
+    }
   }
 
-  private List<Event> createEventList(EventService.Tag... tags) {
+  /**
+   * Test CTP exception thrown if no business individual case type override found, so no action
+   * plans have been associated to CE
+   */
+  @Test
+  public void testCreateActionRulesRaisesCTPExceptionIfNoBICaseOverRide() {
+    String tag = Tag.mps.name();
+    Event event = new Event();
+    CollectionExercise collex = new CollectionExercise();
+    CaseTypeOverride bCaseTypeOverride = new CaseTypeOverride();
+    collex.setExercisePK(1);
+    event.setTag(tag);
+
+    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(1, "B"))
+        .thenReturn(bCaseTypeOverride);
+    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(1, "BI")).thenReturn(null);
+    try {
+      eventService.createActionRulesForEvent(event, collex);
+      fail("Trying to create action rules when no action plans associated");
+    } catch (CTPException e) {
+      assertEquals(CTPException.Fault.RESOURCE_NOT_FOUND, e.getFault());
+    }
+  }
+
+  @Test
+  public void testCreateCorrectActionRulesForAnyEvent() throws CTPException {
+    // Given
+    String businessSampleType = "B";
+    String businessIndividualSampleType = "BI";
+    Event collectionExerciseEvent = new Event();
+
+    CollectionExercise collex = new CollectionExercise();
+    int exercisePk = 6433;
+    collex.setExercisePK(exercisePk);
+    collex.setSurveyId(SURVEY_ID);
+
+    SurveyDTO surveyDto = new SurveyDTO();
+    when(surveySvcClient.findSurvey(SURVEY_ID)).thenReturn(surveyDto);
+
+    CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    UUID businessActionPlanId = UUID.randomUUID();
+    businessCaseTypeOverride.setActionPlanId(businessActionPlanId);
+
+    CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    UUID businessIndividualActionPlanId = UUID.randomUUID();
+    businessIndividualCaseTypeOverride.setActionPlanId(businessIndividualActionPlanId);
+
+    Instant eventTriggerInstant = Instant.now();
+    Timestamp eventTriggerDate = new Timestamp(eventTriggerInstant.toEpochMilli());
+
+    collectionExerciseEvent.setCollectionExercise(collex);
+    collectionExerciseEvent.setTag(Tag.mps.name());
+    collectionExerciseEvent.setTimestamp(eventTriggerDate);
+    UUID collectionExerciseEventId = UUID.fromString("ba6a92c1-9869-41ca-b0d8-12c27fc30e23");
+    collectionExerciseEvent.setId(collectionExerciseEventId);
+
+    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(
+            exercisePk, businessSampleType))
+        .thenReturn(businessCaseTypeOverride);
+    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(
+            exercisePk, businessIndividualSampleType))
+        .thenReturn(businessIndividualCaseTypeOverride);
+
+    actionRuleCreators.add(actionRuleCreator);
+    actionRuleCreators.add(actionRuleCreator2);
+
+    // When
+    eventService.createActionRulesForEvent(collectionExerciseEvent, collex);
+
+    // Then
+    verify(actionRuleCreator)
+        .execute(
+            eq(collectionExerciseEvent),
+            eq(businessCaseTypeOverride),
+            eq(businessIndividualCaseTypeOverride),
+            eq(surveyDto));
+    verify(actionRuleCreator2)
+        .execute(
+            eq(collectionExerciseEvent),
+            eq(businessCaseTypeOverride),
+            eq(businessIndividualCaseTypeOverride),
+            eq(surveyDto));
+  }
+
+  private List<Event> createEventList(Tag... tags) {
     return Arrays.stream(tags).map(EventServiceImplTest::createEvent).collect(Collectors.toList());
   }
 
@@ -102,7 +229,7 @@ public class EventServiceImplTest {
   @Test
   public void givenSomeEventsWhenScheduledIsCheckedThenFalse() throws CTPException {
     UUID collexUuid = UUID.randomUUID();
-    List<Event> events = createEventList(EventService.Tag.mps, EventService.Tag.exercise_end);
+    List<Event> events = createEventList(Tag.mps, Tag.exercise_end);
     when(eventRepository.findByCollectionExerciseId(collexUuid)).thenReturn(events);
 
     boolean scheduled = this.eventService.isScheduled(collexUuid);
@@ -113,7 +240,7 @@ public class EventServiceImplTest {
   @Test
   public void givenAllEventsWhenScheduledIsCheckedThenTrue() throws CTPException {
     UUID collexUuid = UUID.randomUUID();
-    List<Event> events = createEventList(EventService.Tag.values());
+    List<Event> events = createEventList(Tag.values());
     when(eventRepository.findByCollectionExerciseId(collexUuid)).thenReturn(events);
 
     boolean scheduled = this.eventService.isScheduled(collexUuid);

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleCreatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleCreatorTest.java
@@ -1,0 +1,142 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.repository.CaseTypeOverrideRepository;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleCreator;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoLiveActionRuleCreatorTest {
+
+  public static final String EXERCISE_REF = "201802";
+  public static final String SURVEY_SHORT_NAME = "TEST_SURVEY";
+  @Mock private ActionSvcClient actionSvcClient;
+
+  @Mock private CaseTypeOverrideRepository caseTypeOverrideRepo;
+
+  @InjectMocks private GoLiveActionRuleCreator goLiveActionRuleCreator;
+  public static final UUID BUSINESS_INDIVIDUAL_ACTION_PLAN_ID = UUID.randomUUID();
+  public static final int EXERCISE_PK = 6433;
+
+  @Test
+  public void isActionRuleCreator() {
+    assertThat(goLiveActionRuleCreator, instanceOf(ActionRuleCreator.class));
+  }
+
+  @Test
+  public void doNothingIfNotBusinessSurveyEvent() {
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Social);
+
+    goLiveActionRuleCreator.execute(
+        new Event(), new CaseTypeOverride(), new CaseTypeOverride(), survey);
+    verify(actionSvcClient, times(0))
+        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void doNothingIfNotGoLiveEvent() {
+    String tag = EventService.Tag.mps.name();
+    Event collectionExerciseEvent = new Event();
+    CollectionExercise collex = new CollectionExercise();
+    SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    collectionExerciseEvent.setTag(tag);
+    collectionExerciseEvent.setCollectionExercise(collex);
+
+    CaseTypeOverride bCaseTypeOverride = new CaseTypeOverride();
+    goLiveActionRuleCreator.execute(collectionExerciseEvent, bCaseTypeOverride, null, survey);
+    verify(actionSvcClient, times(0))
+        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void testCreateCorrectActionRulesForGoLiveEvent() {
+    // Given
+    Instant eventTriggerInstant = Instant.now();
+    Timestamp eventTriggerDate = new Timestamp(eventTriggerInstant.toEpochMilli());
+
+    String tag = EventService.Tag.go_live.name();
+    CollectionExercise collex = createCollectionExercise();
+    Event collectionExerciseEvent = createCollectionExerciseEvent(tag, eventTriggerDate, collex);
+
+    SurveyDTO survey = new SurveyDTO();
+    survey.setShortName(SURVEY_SHORT_NAME);
+    survey.setSurveyType(SurveyType.Business);
+
+    CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID);
+
+    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(EXERCISE_PK, "BI"))
+        .thenReturn(businessIndividualCaseTypeOverride);
+
+    OffsetDateTime eventTriggerOffsetDateTime =
+        OffsetDateTime.ofInstant(eventTriggerInstant, ZoneId.systemDefault());
+    when(actionSvcClient.createActionRule(
+            anyString(),
+            anyString(),
+            eq("BSNE"),
+            eq(eventTriggerOffsetDateTime),
+            eq(3),
+            eq(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID)))
+        .thenReturn(new ActionRuleDTO());
+
+    // When
+    goLiveActionRuleCreator.execute(
+        collectionExerciseEvent, null, businessIndividualCaseTypeOverride, survey);
+
+    // Then
+    verify(actionSvcClient)
+        .createActionRule(
+            eq(SURVEY_SHORT_NAME + "NOTE"),
+            eq(SURVEY_SHORT_NAME + " Notification Email " + EXERCISE_REF),
+            eq("BSNE"),
+            eq(eventTriggerOffsetDateTime),
+            eq(3),
+            eq(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID));
+  }
+
+  private Event createCollectionExerciseEvent(
+      final String tag, final Timestamp eventTriggerDate, final CollectionExercise collex) {
+    final Event collectionExerciseEvent = new Event();
+    final UUID collectionExerciseEventId = UUID.fromString("ba6a92c1-9869-41ca-b0d8-12c27fc30e24");
+    collectionExerciseEvent.setCollectionExercise(collex);
+    collectionExerciseEvent.setTag(tag);
+    collectionExerciseEvent.setTimestamp(eventTriggerDate);
+    collectionExerciseEvent.setId(collectionExerciseEventId);
+
+    return collectionExerciseEvent;
+  }
+
+  private CollectionExercise createCollectionExercise() {
+    final CollectionExercise collex = new CollectionExercise();
+    collex.setExercisePK(GoLiveActionRuleCreatorTest.EXERCISE_PK);
+    collex.setExerciseRef(EXERCISE_REF);
+    return collex;
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreatorTest.java
@@ -1,0 +1,146 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.repository.CaseTypeOverrideRepository;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleCreator;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MpsActionRuleCreatorTest {
+
+  private static final String SURVEY_SHORT_NAME = "TEST_SURVEY";
+  private static final String EXERCISE_REF = "201808";
+  @Mock private ActionSvcClient actionSvcClient;
+
+  @Mock private CaseTypeOverrideRepository caseTypeOverrideRepo;
+
+  @InjectMocks private MpsActionRuleCreator mpsActionRuleCreator;
+  private static final UUID BUSINESS_ACTION_PLAN_ID = UUID.randomUUID();
+  private static final int EXERCISE_PK = 6433;
+
+  @Test
+  public void isActionRuleCreator() {
+    assertThat(mpsActionRuleCreator, instanceOf(ActionRuleCreator.class));
+  }
+
+  @Test
+  public void doNothingIfNotBusinessSurveyEvent() {
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Social);
+
+    mpsActionRuleCreator.execute(
+        new Event(), new CaseTypeOverride(), new CaseTypeOverride(), survey);
+    verify(actionSvcClient, times(0))
+        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void doNothingIfNotMpsEvent() {
+
+    String tag = EventService.Tag.go_live.name();
+    Event collectionExerciseEvent = new Event();
+    CollectionExercise collex = new CollectionExercise();
+
+    collectionExerciseEvent.setTag(tag);
+    collectionExerciseEvent.setCollectionExercise(collex);
+
+    SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride bCaseTypeOverride = new CaseTypeOverride();
+    mpsActionRuleCreator.execute(collectionExerciseEvent, bCaseTypeOverride, null, survey);
+    verify(actionSvcClient, times(0))
+        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void testCreateCorrectActionRulesForMPSEvent() {
+    // Given
+    Instant eventTriggerInstant = Instant.now();
+    Timestamp eventTriggerDate = new Timestamp(eventTriggerInstant.toEpochMilli());
+
+    String tag = EventService.Tag.mps.name();
+    CollectionExercise collex = createCollectionExercise();
+    Event collectionExerciseEvent = createCollectionExerciseEvent(tag, eventTriggerDate, collex);
+
+    String businessSampleType = "B";
+
+    CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    businessCaseTypeOverride.setActionPlanId(BUSINESS_ACTION_PLAN_ID);
+
+    SurveyDTO survey = new SurveyDTO();
+    survey.setShortName(SURVEY_SHORT_NAME);
+    survey.setSurveyType(SurveyType.Business);
+
+    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(
+            EXERCISE_PK, businessSampleType))
+        .thenReturn(businessCaseTypeOverride);
+
+    OffsetDateTime eventTriggerOffsetDateTime =
+        OffsetDateTime.ofInstant(eventTriggerInstant, ZoneId.systemDefault());
+    when(actionSvcClient.createActionRule(
+            anyString(),
+            anyString(),
+            eq("BSNL"),
+            eq(eventTriggerOffsetDateTime),
+            eq(3),
+            eq(BUSINESS_ACTION_PLAN_ID)))
+        .thenReturn(new ActionRuleDTO());
+
+    // When
+    mpsActionRuleCreator.execute(collectionExerciseEvent, businessCaseTypeOverride, null, survey);
+
+    // Then
+    verify(actionSvcClient)
+        .createActionRule(
+            eq(SURVEY_SHORT_NAME + "NOTF"),
+            eq(SURVEY_SHORT_NAME + " Notification File " + EXERCISE_REF),
+            eq("BSNL"),
+            eq(eventTriggerOffsetDateTime),
+            eq(3),
+            eq(BUSINESS_ACTION_PLAN_ID));
+  }
+
+  private Event createCollectionExerciseEvent(
+      final String tag, final Timestamp eventTriggerDate, final CollectionExercise collex) {
+    final Event collectionExerciseEvent = new Event();
+    final UUID collectionExerciseEventId = UUID.fromString("ba6a92c1-9869-41ca-b0d8-12c27fc30e25");
+    collectionExerciseEvent.setCollectionExercise(collex);
+    collectionExerciseEvent.setTag(tag);
+    collectionExerciseEvent.setTimestamp(eventTriggerDate);
+    collectionExerciseEvent.setId(collectionExerciseEventId);
+
+    return collectionExerciseEvent;
+  }
+
+  private CollectionExercise createCollectionExercise() {
+    final CollectionExercise collex = new CollectionExercise();
+    collex.setExercisePK(MpsActionRuleCreatorTest.EXERCISE_PK);
+    collex.setExerciseRef(EXERCISE_REF);
+    return collex;
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreatorTest.java
@@ -1,0 +1,186 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.repository.CaseTypeOverrideRepository;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleCreator;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReminderActionRuleCreatorTest {
+
+  private static final String SURVEY_SHORT_NAME = "TEST_SURVEY";
+  private static final String EXERCISE_REF = "201809";
+  private static final UUID BUSINESS_ACTION_PLAN_ID = UUID.randomUUID();
+  private static final UUID BUSINESS_INDIVIDUAL_ACTION_PLAN_ID = UUID.randomUUID();
+  private static final int EXERCISE_PK = 6433;
+  @Mock private ActionSvcClient actionSvcClient;
+  @Mock private CaseTypeOverrideRepository caseTypeOverrideRepo;
+  @InjectMocks private ReminderActionRuleCreator reminderActionRuleCreator;
+
+  @Test
+  public void isActionRuleCreator() {
+    assertThat(reminderActionRuleCreator, instanceOf(ActionRuleCreator.class));
+  }
+
+  @Test
+  public void doNothingIfNotBusinessSurveyEvent() {
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Social);
+
+    reminderActionRuleCreator.execute(
+        new Event(), new CaseTypeOverride(), new CaseTypeOverride(), survey);
+    verify(actionSvcClient, times(0))
+        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void doNothingIfNotReminderEvent() {
+    String tag = Tag.go_live.name();
+    Event collectionExerciseEvent = new Event();
+    CollectionExercise collex = new CollectionExercise();
+
+    collectionExerciseEvent.setTag(tag);
+    collectionExerciseEvent.setCollectionExercise(collex);
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    reminderActionRuleCreator.execute(
+        collectionExerciseEvent, new CaseTypeOverride(), new CaseTypeOverride(), survey);
+    verify(actionSvcClient, times(0))
+        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void testCreateCorrectActionRulesForReminderEvent() {
+    // Given
+    testReminderTagCreatesActionRules(Tag.reminder.name());
+  }
+
+  /** Test correct action rules are created for new mps event */
+  @Test
+  public void testCreateCorrectActionRulesForReminder2Event() {
+    // Given
+    testReminderTagCreatesActionRules(Tag.reminder2.name());
+  }
+
+  /** Test correct action rules are created for new mps event */
+  @Test
+  public void testCreateCorrectActionRulesForReminder3Event() {
+    // Given
+    testReminderTagCreatesActionRules(Tag.reminder3.name());
+  }
+
+  private Event createCollectionExerciseEvent(
+      final String tag, final Timestamp eventTriggerDate, final CollectionExercise collex) {
+    Event collectionExerciseEvent = new Event();
+    UUID collectionExerciseEventId = UUID.fromString("ba6a92c1-9869-41ca-b0d8-12c27fc30e23");
+    collectionExerciseEvent.setCollectionExercise(collex);
+    collectionExerciseEvent.setTag(tag);
+    collectionExerciseEvent.setTimestamp(eventTriggerDate);
+    collectionExerciseEvent.setId(collectionExerciseEventId);
+
+    return collectionExerciseEvent;
+  }
+
+  private CollectionExercise createCollectionExercise() {
+    CollectionExercise collex = new CollectionExercise();
+    collex.setExercisePK(EXERCISE_PK);
+    collex.setExerciseRef(EXERCISE_REF);
+    return collex;
+  }
+
+  private void testReminderTagCreatesActionRules(final String tag) {
+    Instant eventTriggerInstant = Instant.now();
+    Timestamp eventTriggerDate = new Timestamp(eventTriggerInstant.toEpochMilli());
+
+    CollectionExercise collectionExercise = createCollectionExercise();
+    Event collectionExerciseEvent =
+        createCollectionExerciseEvent(tag, eventTriggerDate, collectionExercise);
+
+    CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    businessCaseTypeOverride.setActionPlanId(BUSINESS_ACTION_PLAN_ID);
+
+    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(EXERCISE_PK, "B"))
+        .thenReturn(businessCaseTypeOverride);
+
+    CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID);
+
+    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(EXERCISE_PK, "BI"))
+        .thenReturn(businessIndividualCaseTypeOverride);
+
+    OffsetDateTime eventTriggerOffsetDateTime =
+        OffsetDateTime.ofInstant(eventTriggerInstant, ZoneId.systemDefault());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setShortName(SURVEY_SHORT_NAME);
+    survey.setSurveyType(SurveyType.Business);
+
+    when(actionSvcClient.createActionRule(
+            anyString(),
+            anyString(),
+            eq("BSRE"),
+            eq(eventTriggerOffsetDateTime),
+            eq(3),
+            eq(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID)))
+        .thenReturn(new ActionRuleDTO());
+    when(actionSvcClient.createActionRule(
+            anyString(),
+            anyString(),
+            eq("BSRL"),
+            eq(eventTriggerOffsetDateTime),
+            eq(3),
+            eq(BUSINESS_ACTION_PLAN_ID)))
+        .thenReturn(new ActionRuleDTO());
+
+    // When
+    reminderActionRuleCreator.execute(
+        collectionExerciseEvent,
+        businessCaseTypeOverride,
+        businessIndividualCaseTypeOverride,
+        survey);
+
+    // Then
+    verify(actionSvcClient)
+        .createActionRule(
+            eq(SURVEY_SHORT_NAME + "REME"),
+            eq(SURVEY_SHORT_NAME + " Reminder Email " + EXERCISE_REF),
+            eq("BSRE"),
+            eq(eventTriggerOffsetDateTime),
+            eq(3),
+            eq(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID));
+    verify(actionSvcClient)
+        .createActionRule(
+            eq(SURVEY_SHORT_NAME + "REMF"),
+            eq(SURVEY_SHORT_NAME + " Reminder File " + EXERCISE_REF),
+            eq("BSRL"),
+            eq(eventTriggerOffsetDateTime),
+            eq(3),
+            eq(BUSINESS_ACTION_PLAN_ID));
+  }
+}


### PR DESCRIPTION
Currently there is nothing to automatically create the action rules that
cause letters and emails to be sent when a collection exercise's events
are created. This will fix that so letters & emails will be sent without
manual intervention.
    
Updating these dates is out of scope for this ticket.

<!--- Why is this change required? What problem does it solve? -->

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/Eknzy8H2/119-tbl123-link-action-rules-to-action-plans-at-create-time-create
Dependant on: ONSdigital/rm-action-service#69