### PR TITLE
Fix collection exercise transition message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: java
 jdk: openjdk8
 
 before_install:
-- cp .maven.settings.xml $HOME/.m2/settings.xml"
+- cp .maven.settings.xml $HOME/.m2/settings.xml
 - mvn fmt:check
 
 install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmaven.javadoc.skip=true -Dhttp.wait.skip -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,24 @@
 sudo: required
 
 services:
-  - docker
+- docker
 
 language: java
 jdk: openjdk8
 
-before_install: "cp .maven.settings.xml $HOME/.m2/settings.xml"
+before_install:
+- cp .maven.settings.xml $HOME/.m2/settings.xml"
+- mvn fmt:check
 
 install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmaven.javadoc.skip=true -Dhttp.wait.skip -B -V
-script: mvn fmt:check cobertura:cobertura-integration-test
+script: mvn cobertura:cobertura-integration-test
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-    docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-    docker push sdcplatform/collectionexercisesvc;
-    fi
-  - bash <(curl -s https://codecov.io/bash)
+- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
+  docker push sdcplatform/collectionexercisesvc;
+  fi
+- bash <(curl -s https://codecov.io/bash)
 
 notifications:
   slack:
@@ -30,5 +32,5 @@ cache:
   - $HOME/.m2
 
 branches:
-    only:
-        - master
+  only:
+  - master

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -608,7 +608,6 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
   @Override
   public CollectionExercise updateCollectionExercise(final CollectionExercise collex) {
     collex.setUpdated(new Timestamp(new Date().getTime()));
-    rabbitTemplate.convertAndSend(new CollectionTransitionEvent(collex.getId(), collex.getState()));
     return this.collectRepo.saveAndFlush(collex);
   }
 
@@ -660,6 +659,8 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
     if (oldState != newState) {
       collex.setState(newState);
       updateCollectionExercise(collex);
+      rabbitTemplate.convertAndSend(
+          new CollectionTransitionEvent(collex.getId(), collex.getState()));
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -656,12 +656,15 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
     CollectionExerciseDTO.CollectionExerciseState oldState = collex.getState();
     CollectionExerciseDTO.CollectionExerciseState newState =
         collectionExerciseTransitionState.transition(collex.getState(), event);
-    if (oldState != newState) {
-      collex.setState(newState);
-      updateCollectionExercise(collex);
-      rabbitTemplate.convertAndSend(
-          new CollectionTransitionEvent(collex.getId(), collex.getState()));
+
+    if (oldState == newState) {
+      return;
     }
+
+    collex.setState(newState);
+    updateCollectionExercise(collex);
+    rabbitTemplate.convertAndSend(
+        new CollectionTransitionEvent(collex.getId(), collex.getState()));
   }
 
   @Override

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -670,8 +670,7 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
 
     collex.setState(newState);
     updateCollectionExercise(collex);
-    rabbitTemplate.convertAndSend(
-        new CollectionTransitionEvent(collex.getId(), collex.getState()));
+    rabbitTemplate.convertAndSend(new CollectionTransitionEvent(collex.getId(), collex.getState()));
   }
 
   @Override

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.java
@@ -477,14 +477,14 @@ public class SampleUnitDistributorTest {
     sampleUnitDistributor.distributeSampleUnits(collectionExercise);
 
     ArgumentCaptor<CollectionExercise> collectionExerciseSave =
-            ArgumentCaptor.forClass(CollectionExercise.class);
+        ArgumentCaptor.forClass(CollectionExercise.class);
     verify(collectionExerciseRepo, times(1)).saveAndFlush(collectionExerciseSave.capture());
     List<CollectionExercise> savedCollectionExercise = collectionExerciseSave.getAllValues();
     assertTrue(savedCollectionExercise.size() == 1);
     savedCollectionExercise.forEach(
-            (exercise) -> {
-              assertEquals(COLLECTION_EXERCISE_ID, exercise.getId().toString());
-              assertEquals(CollectionExerciseState.LIVE, exercise.getState());
-            });
+        (exercise) -> {
+          assertEquals(COLLECTION_EXERCISE_ID, exercise.getId().toString());
+          assertEquals(CollectionExerciseState.LIVE, exercise.getState());
+        });
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -367,26 +368,35 @@ public class CollectionExerciseServiceImplTest {
   }
 
   @Test
-  public void testUpdateCollectionExerciseSendsCollectionTransitionEvent() throws Exception {
+  public void testTransitionEventSentWhenTransition() throws Exception {
     // Given
     CollectionExercise existing =
         FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
-    SurveyDTO survey = FixtureHelper.loadClassFixtures(SurveyDTO[].class).get(0);
-    UUID surveyId = UUID.fromString(survey.getId());
-    existing.setSurveyId(surveyId);
-    when(collexRepo.findOneById(existing.getId())).thenReturn(existing);
-    when(surveyService.findSurvey(surveyId)).thenReturn(survey);
-    CollectionExerciseDTO toUpdate =
-        FixtureHelper.loadClassFixtures(CollectionExerciseDTO[].class).get(0);
 
     // When
-    this.collectionExerciseServiceImpl.updateCollectionExercise(existing.getId(), toUpdate);
+    this.collectionExerciseServiceImpl.transitionCollectionExercise(
+        existing, CollectionExerciseDTO.CollectionExerciseEvent.VALIDATE);
 
     // Then
     CollectionTransitionEvent collectionTransitionEvent =
         new CollectionTransitionEvent(
-            existing.getId(), CollectionExerciseDTO.CollectionExerciseState.EXECUTED);
+            existing.getId(), CollectionExerciseDTO.CollectionExerciseState.VALIDATED);
     verify(rabbitTemplate).convertAndSend(collectionTransitionEvent);
+  }
+
+  @Test
+  public void testTransitionEventNotSentWhenNoTransition() throws Exception {
+    // Given
+    CollectionExercise existing =
+        FixtureHelper.loadClassFixtures(CollectionExercise[].class).get(0);
+    existing.setState(CollectionExerciseDTO.CollectionExerciseState.EXECUTION_STARTED);
+
+    // When
+    this.collectionExerciseServiceImpl.transitionCollectionExercise(
+        existing, CollectionExerciseDTO.CollectionExerciseEvent.EXECUTE);
+
+    // Then
+    verify(rabbitTemplate, never()).convertAndSend(any());
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
Only publish a message when the collection exercise has been
transitioned not whenever the collection exercise is updated.

This was introduced https://github.com/ONSdigital/rm-collection-exercise-service/pull/80/files

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
1. Run `mvn install -Ddocker.keepRunning`
2. Go to http://localhost:46672/#/queues/%2F/Collex.Transition
3. There should only be 7 events and no duplicate states for the same collection exercise id

# Links
https://github.com/ONSdigital/rm-collection-exercise-service/pull/80/files