### PR TITLE
Correct Reminder Naming Convention

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
@@ -24,6 +24,8 @@ public interface EventService {
     ref_period_end(false),
     employment(false);
 
+    public static final List<Tag> ORDERED_REMINDERS = Arrays.asList(reminder, reminder2, reminder3);
+
     Tag(final boolean mandatory) {
       this.mandatory = mandatory;
     }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreator.java
@@ -40,8 +40,10 @@ public final class ReminderActionRuleCreator implements ActionRuleCreator {
     final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(instant, ZoneId.systemDefault());
     final CollectionExercise collectionExercise = collectionExerciseEvent.getCollectionExercise();
 
+    final String reminderSuffix = getReminderSuffix(collectionExerciseEvent.getTag());
+
     actionSvcClient.createActionRule(
-        survey.getShortName() + "REME",
+        survey.getShortName() + "REME" + reminderSuffix,
         survey.getShortName() + " Reminder Email " + collectionExercise.getExerciseRef(),
         "BSRE",
         offsetDateTime,
@@ -49,12 +51,17 @@ public final class ReminderActionRuleCreator implements ActionRuleCreator {
         businessIndividualCaseTypeOverride.getActionPlanId());
 
     actionSvcClient.createActionRule(
-        survey.getShortName() + "REMF",
+        survey.getShortName() + "REMF" + reminderSuffix,
         survey.getShortName() + " Reminder File " + collectionExercise.getExerciseRef(),
         "BSRL",
         offsetDateTime,
         3,
         businessCaseTypeOverride.getActionPlanId());
+  }
+
+  private String getReminderSuffix(final String tag) {
+    final int reminderIndex = Tag.ORDERED_REMINDERS.indexOf(Tag.valueOf(tag));
+    return String.format("+%d", reminderIndex + 1);
   }
 
   private boolean isReminder(final Event collectionExerciseEvent) {

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreatorTest.java
@@ -6,7 +6,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -78,21 +80,21 @@ public class ReminderActionRuleCreatorTest {
   @Test
   public void testCreateCorrectActionRulesForReminderEvent() {
     // Given
-    testReminderTagCreatesActionRules(Tag.reminder.name());
+    testReminderTagCreatesActionRules(Tag.reminder.name(), "+1");
   }
 
   /** Test correct action rules are created for new mps event */
   @Test
   public void testCreateCorrectActionRulesForReminder2Event() {
     // Given
-    testReminderTagCreatesActionRules(Tag.reminder2.name());
+    testReminderTagCreatesActionRules(Tag.reminder2.name(), "+2");
   }
 
   /** Test correct action rules are created for new mps event */
   @Test
   public void testCreateCorrectActionRulesForReminder3Event() {
     // Given
-    testReminderTagCreatesActionRules(Tag.reminder3.name());
+    testReminderTagCreatesActionRules(Tag.reminder3.name(), "+3");
   }
 
   private Event createCollectionExerciseEvent(
@@ -114,7 +116,7 @@ public class ReminderActionRuleCreatorTest {
     return collex;
   }
 
-  private void testReminderTagCreatesActionRules(final String tag) {
+  private void testReminderTagCreatesActionRules(final String tag, final String suffixNumber) {
     Instant eventTriggerInstant = Instant.now();
     Timestamp eventTriggerDate = new Timestamp(eventTriggerInstant.toEpochMilli());
 
@@ -168,7 +170,7 @@ public class ReminderActionRuleCreatorTest {
     // Then
     verify(actionSvcClient)
         .createActionRule(
-            eq(SURVEY_SHORT_NAME + "REME"),
+            eq(SURVEY_SHORT_NAME + "REME" + suffixNumber),
             eq(SURVEY_SHORT_NAME + " Reminder Email " + EXERCISE_REF),
             eq("BSRE"),
             eq(eventTriggerOffsetDateTime),
@@ -176,7 +178,7 @@ public class ReminderActionRuleCreatorTest {
             eq(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID));
     verify(actionSvcClient)
         .createActionRule(
-            eq(SURVEY_SHORT_NAME + "REMF"),
+            eq(SURVEY_SHORT_NAME + "REMF" + suffixNumber),
             eq(SURVEY_SHORT_NAME + " Reminder File " + EXERCISE_REF),
             eq("BSRL"),
             eq(eventTriggerOffsetDateTime),


### PR DESCRIPTION
Currently we don't differentiate between the different reminder action
rules.


This will add a "+1", "+2", or "+3" to the action rules name for
the reminder, reminder2, and reminder3 event tags.


mvn test