### PR TITLE
Fix social survey event dates

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImpl.java
@@ -29,6 +29,7 @@ import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseSer
 import uk.gov.ons.ctp.response.collection.exercise.service.EventChangeHandler;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
 
 @Service
 @Slf4j
@@ -98,6 +99,11 @@ public class EventServiceImpl implements EventService {
     }
 
     final SurveyDTO survey = surveySvcClient.findSurvey(collectionExercise.getSurveyId());
+
+    if (survey.getSurveyType() != SurveyType.Business) {
+      return;
+    }
+
     final CaseTypeOverride businessCaseType = getCaseTypeOverride(collectionExercise, "B");
     final CaseTypeOverride businessIndividualCaseType =
         getCaseTypeOverride(collectionExercise, "BI");


### PR DESCRIPTION
Motivation and Context
======================

Currently when you create a social survey's collection exercise event
dates there is an exception. This is caused by assuming all
surveys are business surveys when creating action rules.

What has changed
================

This adds a check for if the survey is a business survey, removing the
automatic creation of action rules for non-business survey types.

How to test?
============

* Run Maven Test
* Create an event on a social survey