### PR TITLE
Update action rules on update event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.product</groupId>
             <artifactId>actionsvc-api</artifactId>
-            <version>10.49.22</version>
+            <version>10.49.24</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
@@ -5,8 +5,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.web.client.RestClientException;
+import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
 import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
 
 /** HTTP RestClient implementation for calls to the Action service. */
 public interface ActionSvcClient {
@@ -48,9 +50,15 @@ public interface ActionSvcClient {
   ActionRuleDTO createActionRule(
       String name,
       String description,
-      String actionTypeName,
+      ActionType actionTypeName,
       OffsetDateTime triggerDateTime,
       int priority,
       UUID actionPlanId)
       throws RestClientException;
+
+  ActionRuleDTO updateActionRule(
+      UUID id, String name, String description, OffsetDateTime triggerDateTime, int priority)
+      throws RestClientException;
+
+  List<ActionRuleDTO> getActionRulesForActionPlan(UUID actionPlanId) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
@@ -20,9 +20,12 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.common.rest.RestUtility;
 import uk.gov.ons.ctp.response.collection.exercise.client.SurveySvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.response.survey.representation.SurveyClassifierDTO;
 import uk.gov.ons.response.survey.representation.SurveyClassifierTypeDTO;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
@@ -174,6 +177,18 @@ public class SurveySvcRestClientImpl implements SurveySvcClient {
       log.error("Client error with status code = {}", e.getStatusCode(), e);
       throw e;
     }
+    return survey;
+  }
+
+  public SurveyDTO getSurveyForCollectionExercise(final CollectionExercise collex)
+      throws CTPException {
+    final SurveyDTO survey = findSurvey(collex.getSurveyId());
+
+    if (survey == null) {
+      throw new CTPException(
+          Fault.SYSTEM_ERROR, String.format("Could not find survey id %s", collex.getId()));
+    }
+
     return survey;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/ActionSvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/ActionSvc.java
@@ -11,4 +11,6 @@ public class ActionSvc {
   private RestUtilityConfig connectionConfig;
   private String actionPlansPath;
   private String actionRulesPath;
+  private String actionRulePath;
+  private String actionRulesForActionPlanPath;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/ActionRuleUpdater.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/ActionRuleUpdater.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.response.collection.exercise.service;
+
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+
+public interface ActionRuleUpdater {
+  void execute(
+      Event event,
+      CaseTypeOverride businessCaseTypeOverride,
+      CaseTypeOverride businessIndividualCaseTypeOverride,
+      SurveyDTO survey)
+      throws CTPException;
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CaseTypeOverrideService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CaseTypeOverrideService.java
@@ -1,0 +1,10 @@
+package uk.gov.ons.ctp.response.collection.exercise.service;
+
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+
+public interface CaseTypeOverrideService {
+  CaseTypeOverride getCaseTypeOverride(CollectionExercise collectionExercise, String sampleUnitType)
+      throws CTPException;
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
@@ -41,6 +41,14 @@ public interface EventService {
 
       return actionableEvents.contains(this);
     }
+
+    public boolean hasName(final String eventName) {
+      return name().equals(eventName);
+    }
+
+    public boolean isReminder() {
+      return ORDERED_REMINDERS.contains(this);
+    }
   }
 
   Event createEvent(EventDTO eventDto) throws CTPException;

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SurveyService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SurveyService.java
@@ -1,6 +1,8 @@
 package uk.gov.ons.ctp.response.collection.exercise.service;
 
 import java.util.UUID;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /** Service responsible for dealing with samples */
@@ -21,4 +23,13 @@ public interface SurveyService {
    * @return the survey object
    */
   SurveyDTO findSurveyByRef(String surveyRef);
+
+  /**
+   * Get Survey linked to collection exercise.
+   *
+   * @param collex the collection exercise.
+   * @return the survey object
+   * @throws CTPException on not found
+   */
+  SurveyDTO getSurveyForCollectionExercise(final CollectionExercise collex) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CaseTypeOverrideServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CaseTypeOverrideServiceImpl.java
@@ -1,0 +1,44 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.repository.CaseTypeOverrideRepository;
+import uk.gov.ons.ctp.response.collection.exercise.service.CaseTypeOverrideService;
+
+@Slf4j
+@Service
+public class CaseTypeOverrideServiceImpl implements CaseTypeOverrideService {
+  private final CaseTypeOverrideRepository caseTypeOverrideRepository;
+
+  public CaseTypeOverrideServiceImpl(final CaseTypeOverrideRepository caseTypeOverrideRepository) {
+    this.caseTypeOverrideRepository = caseTypeOverrideRepository;
+  }
+
+  @Override
+  public CaseTypeOverride getCaseTypeOverride(
+      final CollectionExercise collectionExercise, final String sampleUnitType)
+      throws CTPException {
+    final CaseTypeOverride caseTypeOverride =
+        caseTypeOverrideRepository.findTopByExerciseFKAndSampleUnitTypeFK(
+            collectionExercise.getExercisePK(), sampleUnitType);
+
+    if (caseTypeOverride == null) {
+      log.warn(
+          "Business or business individual override action plans do not exist,"
+              + " CollectionExerciseId: {}",
+          collectionExercise.getId());
+
+      throw new CTPException(
+          Fault.RESOURCE_NOT_FOUND,
+          String.format(
+              "Override action plans do not exist for collection exercise %s",
+              collectionExercise.getId()));
+    }
+
+    return caseTypeOverride;
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImpl.java
@@ -15,16 +15,18 @@ import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.response.collection.exercise.client.SurveySvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEventPublisher.MessageType;
-import uk.gov.ons.ctp.response.collection.exercise.repository.CaseTypeOverrideRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.EventRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 import uk.gov.ons.ctp.response.collection.exercise.schedule.SchedulerConfiguration;
 import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleCreator;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleUpdater;
+import uk.gov.ons.ctp.response.collection.exercise.service.CaseTypeOverrideService;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventChangeHandler;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
@@ -35,9 +37,11 @@ import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
 @Slf4j
 public class EventServiceImpl implements EventService {
 
+  private static final String BUSINESS_INDIVIDUAL_SAMPLE_UNIT_TYPE = "BI";
+  private static final String BUSINESS_SAMPLE_UNIT_TYPE = "B";
   @Autowired private CollectionExerciseService collectionExerciseService;
 
-  @Autowired private CaseTypeOverrideRepository caseTypeOverrideRepo;
+  @Autowired private CaseTypeOverrideService caseTypeOverrideService;
 
   @Autowired private EventRepository eventRepository;
 
@@ -51,24 +55,18 @@ public class EventServiceImpl implements EventService {
 
   @Autowired private List<ActionRuleCreator> actionRuleCreators;
 
+  @Autowired private List<ActionRuleUpdater> actionRuleUpdaters;
+
   @Override
   public Event createEvent(EventDTO eventDto) throws CTPException {
     UUID collexId = eventDto.getCollectionExerciseId();
-    CollectionExercise collex = this.collectionExerciseService.findCollectionExercise(collexId);
-
-    if (collex == null) {
-      throw new CTPException(
-          CTPException.Fault.RESOURCE_NOT_FOUND,
-          String.format(
-              "Collection exercise %s does not exist", eventDto.getCollectionExerciseId()));
-    }
-
+    CollectionExercise collex = getCollectionExercise(collexId, Fault.RESOURCE_NOT_FOUND);
     Event existing =
         this.eventRepository.findOneByCollectionExerciseAndTag(collex, eventDto.getTag());
 
     if (existing != null) {
       throw new CTPException(
-          CTPException.Fault.RESOURCE_VERSION_CONFLICT,
+          Fault.RESOURCE_VERSION_CONFLICT,
           String.format(
               "Event %s already exists for collection exercise %s",
               eventDto.getTag(), collex.getId()));
@@ -98,46 +96,21 @@ public class EventServiceImpl implements EventService {
       return;
     }
 
-    final SurveyDTO survey = surveySvcClient.findSurvey(collectionExercise.getSurveyId());
+    final SurveyDTO survey = surveySvcClient.getSurveyForCollectionExercise(collectionExercise);
 
     if (survey.getSurveyType() != SurveyType.Business) {
       return;
     }
 
-    final CaseTypeOverride businessCaseType = getCaseTypeOverride(collectionExercise, "B");
+    final CaseTypeOverride businessCaseType =
+        caseTypeOverrideService.getCaseTypeOverride(collectionExercise, BUSINESS_SAMPLE_UNIT_TYPE);
     final CaseTypeOverride businessIndividualCaseType =
-        getCaseTypeOverride(collectionExercise, "BI");
+        caseTypeOverrideService.getCaseTypeOverride(
+            collectionExercise, BUSINESS_INDIVIDUAL_SAMPLE_UNIT_TYPE);
 
-    actionRuleCreators.forEach(
-        arc ->
-            arc.execute(
-                collectionExerciseEvent, businessCaseType, businessIndividualCaseType, survey));
-  }
-
-  private CaseTypeOverride getCaseTypeOverride(
-      final CollectionExercise collectionExercise, final String sampleUnitType)
-      throws CTPException {
-    final CaseTypeOverride businessIndividualCaseTypeOverride =
-        caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(
-            collectionExercise.getExercisePK(), sampleUnitType);
-
-    if (businessIndividualCaseTypeOverride == null) {
-      logAndThrow(collectionExercise);
-      return null;
+    for (ActionRuleCreator arc : actionRuleCreators) {
+      arc.execute(collectionExerciseEvent, businessCaseType, businessIndividualCaseType, survey);
     }
-    return businessIndividualCaseTypeOverride;
-  }
-
-  private void logAndThrow(final CollectionExercise collectionExercise) throws CTPException {
-    log.error(
-        "Business or business individual override action plans do not exist,"
-            + " CollectionExerciseId: {}}",
-        collectionExercise.getId());
-    throw new CTPException(
-        CTPException.Fault.RESOURCE_NOT_FOUND,
-        String.format(
-            "Override action plans do not exist for collection exercise %s",
-            collectionExercise.getId()));
   }
 
   @Override
@@ -146,37 +119,65 @@ public class EventServiceImpl implements EventService {
   }
 
   @Override
-  public Event updateEvent(UUID collexUuid, String tag, Date date) throws CTPException {
-    CollectionExercise collex = this.collectionExerciseService.findCollectionExercise(collexUuid);
-    if (collex != null) {
-      Event event = this.eventRepository.findOneByCollectionExerciseAndTag(collex, tag);
-      if (event != null) {
-        event.setTimestamp(new Timestamp(date.getTime()));
+  public Event updateEvent(final UUID collexUuid, final String tag, final Date date)
+      throws CTPException {
+    final CollectionExercise collex = getCollectionExercise(collexUuid, Fault.BAD_REQUEST);
+    final Event event = getEventByTagAndCollectionExerciseId(tag, collex);
 
-        List<Event> existingEvents = this.eventRepository.findByCollectionExercise(collex);
+    event.setTimestamp(new Timestamp(date.getTime()));
+    validateUpdatedEvents(collex, event);
+    updateActionRules(collex, event);
 
-        if (this.eventValidator.validate(existingEvents, event, collex.getState())) {
+    eventRepository.save(event);
 
-          this.eventRepository.save(event);
+    fireEventChangeHandlers(MessageType.EventUpdated, event);
 
-          fireEventChangeHandlers(MessageType.EventUpdated, event);
-        } else {
-          throw new CTPException(
-              CTPException.Fault.BAD_REQUEST, String.format("Invalid event update"));
-        }
+    return event;
+  }
 
-      } else {
-        throw new CTPException(
-            CTPException.Fault.RESOURCE_NOT_FOUND,
-            String.format("Event %s does not exist", event.getId()));
-      }
+  private void updateActionRules(final CollectionExercise collex, final Event event)
+      throws CTPException {
+    final CaseTypeOverride bCaseOverride =
+        caseTypeOverrideService.getCaseTypeOverride(collex, BUSINESS_SAMPLE_UNIT_TYPE);
+    final CaseTypeOverride biCaseOverride =
+        caseTypeOverrideService.getCaseTypeOverride(collex, BUSINESS_INDIVIDUAL_SAMPLE_UNIT_TYPE);
+    final SurveyDTO survey = surveySvcClient.getSurveyForCollectionExercise(collex);
 
-      return event;
-    } else {
-      throw new CTPException(
-          CTPException.Fault.BAD_REQUEST,
-          String.format("Collection exercise %s does not exist", collexUuid));
+    for (final ActionRuleUpdater aru : actionRuleUpdaters) {
+      aru.execute(event, bCaseOverride, biCaseOverride, survey);
     }
+  }
+
+  private void validateUpdatedEvents(final CollectionExercise collex, final Event event)
+      throws CTPException {
+    final List<Event> existingEvents = eventRepository.findByCollectionExercise(collex);
+
+    if (!eventValidator.validate(existingEvents, event, collex.getState())) {
+      throw new CTPException(Fault.BAD_REQUEST, "Invalid event update");
+    }
+  }
+
+  private Event getEventByTagAndCollectionExerciseId(
+      final String tag, final CollectionExercise collex) throws CTPException {
+    final Event event = eventRepository.findOneByCollectionExerciseAndTag(collex, tag);
+    if (event == null) {
+      throw new CTPException(
+          Fault.RESOURCE_NOT_FOUND,
+          String.format(
+              "Event with tag %s for Collection Exercise %s does not exist", tag, collex.getId()));
+    }
+    return event;
+  }
+
+  private CollectionExercise getCollectionExercise(final UUID collexUuid, final Fault fault)
+      throws CTPException {
+    final CollectionExercise collex = collectionExerciseService.findCollectionExercise(collexUuid);
+
+    if (collex == null) {
+      throw new CTPException(
+          fault, String.format("Collection exercise %s does not exist", collexUuid));
+    }
+    return collex;
   }
 
   @Override
@@ -188,13 +189,12 @@ public class EventServiceImpl implements EventService {
         return event;
       } else {
         throw new CTPException(
-            CTPException.Fault.RESOURCE_NOT_FOUND,
-            String.format("Event %s does not exist", event.getId()));
+            Fault.RESOURCE_NOT_FOUND, String.format("Event %s does not exist", event.getId()));
       }
 
     } else {
       throw new CTPException(
-          CTPException.Fault.BAD_REQUEST,
+          Fault.BAD_REQUEST,
           String.format("Collection exercise %s does not exist", collex.getId()));
     }
   }
@@ -205,7 +205,7 @@ public class EventServiceImpl implements EventService {
 
     if (event == null) {
       throw new CTPException(
-          CTPException.Fault.RESOURCE_NOT_FOUND, String.format("Event %s does not exist", event));
+          Fault.RESOURCE_NOT_FOUND, String.format("Event %s does not exist", event));
     } else {
       return event;
     }
@@ -224,12 +224,12 @@ public class EventServiceImpl implements EventService {
         return event;
       } else {
         throw new CTPException(
-            CTPException.Fault.RESOURCE_NOT_FOUND, String.format("Event %s does not exist", tag));
+            Fault.RESOURCE_NOT_FOUND, String.format("Event %s does not exist", tag));
       }
 
     } else {
       throw new CTPException(
-          CTPException.Fault.BAD_REQUEST,
+          Fault.BAD_REQUEST,
           String.format("Collection exercise %s does not exist", collex.getId()));
     }
   }
@@ -319,9 +319,7 @@ public class EventServiceImpl implements EventService {
       SchedulerConfiguration.unscheduleEvent(this.scheduler, event);
     } catch (SchedulerException e) {
       throw new CTPException(
-          CTPException.Fault.SYSTEM_ERROR,
-          String.format("Error unscheduling event %s", event.getId()),
-          e);
+          Fault.SYSTEM_ERROR, String.format("Error unscheduling event %s", event.getId()), e);
     }
   }
 
@@ -337,9 +335,7 @@ public class EventServiceImpl implements EventService {
       SchedulerConfiguration.scheduleEvent(this.scheduler, event);
     } catch (SchedulerException e) {
       throw new CTPException(
-          CTPException.Fault.SYSTEM_ERROR,
-          String.format("Error scheduling event %s", event.getId()),
-          e);
+          Fault.SYSTEM_ERROR, String.format("Error scheduling event %s", event.getId()), e);
     }
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventValidator.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
-import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
 
 public class EventValidator {
 
@@ -59,8 +59,8 @@ public class EventValidator {
    * @return
    */
   private boolean validateNonMandatoryEvents(final Map<String, Event> eventMap) {
-    Event referencePeriodStart = eventMap.get(EventService.Tag.ref_period_start.toString());
-    Event referencePeriodEnd = eventMap.get(EventService.Tag.ref_period_end.toString());
+    Event referencePeriodStart = eventMap.get(Tag.ref_period_start.toString());
+    Event referencePeriodEnd = eventMap.get(Tag.ref_period_end.toString());
 
     return referencePeriodInCorrectOrder(referencePeriodStart, referencePeriodEnd)
         && remindersDuringExercise(eventMap);
@@ -76,12 +76,12 @@ public class EventValidator {
   }
 
   private boolean remindersDuringExercise(final Map<String, Event> eventMap) {
-    Event goLive = eventMap.get(EventService.Tag.go_live.toString());
-    Event exerciseEnd = eventMap.get(EventService.Tag.exercise_end.toString());
+    Event goLive = eventMap.get(Tag.go_live.toString());
+    Event exerciseEnd = eventMap.get(Tag.exercise_end.toString());
 
-    Event reminder = eventMap.get(EventService.Tag.reminder.toString());
-    Event reminder2 = eventMap.get(EventService.Tag.reminder2.toString());
-    Event reminder3 = eventMap.get(EventService.Tag.reminder3.toString());
+    Event reminder = eventMap.get(Tag.reminder.toString());
+    Event reminder2 = eventMap.get(Tag.reminder2.toString());
+    Event reminder3 = eventMap.get(Tag.reminder3.toString());
     return eventDuringExercise(goLive, reminder, exerciseEnd)
         && eventDuringExercise(goLive, reminder2, exerciseEnd)
         && eventDuringExercise(goLive, reminder3, exerciseEnd);
@@ -101,10 +101,10 @@ public class EventValidator {
    * Validates the mandatory events are in the following order: MPS Go Live Return By Exercise End
    */
   private boolean validateMandatoryEvents(final Map<String, Event> eventMap) {
-    Event mpsEvent = eventMap.get(EventService.Tag.mps.toString());
-    Event goLiveEvent = eventMap.get(EventService.Tag.go_live.toString());
-    Event returnByEvent = eventMap.get(EventService.Tag.return_by.toString());
-    Event exerciseEndEvent = eventMap.get(EventService.Tag.exercise_end.toString());
+    Event mpsEvent = eventMap.get(Tag.mps.toString());
+    Event goLiveEvent = eventMap.get(Tag.go_live.toString());
+    Event returnByEvent = eventMap.get(Tag.return_by.toString());
+    Event exerciseEndEvent = eventMap.get(Tag.exercise_end.toString());
 
     return mpsEvent.getTimestamp().before(goLiveEvent.getTimestamp())
         && goLiveEvent.getTimestamp().before(returnByEvent.getTimestamp())
@@ -128,12 +128,10 @@ public class EventValidator {
   }
 
   private boolean isMandatory(final Event updatedEvent) {
-    return EventService.Tag.valueOf(updatedEvent.getTag()).isMandatory();
+    return Tag.valueOf(updatedEvent.getTag()).isMandatory();
   }
 
   private boolean isReminder(final Event updatedEvent) {
-    return EventService.Tag.valueOf(updatedEvent.getTag()).equals(EventService.Tag.reminder)
-        || EventService.Tag.valueOf(updatedEvent.getTag()).equals(EventService.Tag.reminder2)
-        || EventService.Tag.valueOf(updatedEvent.getTag()).equals(EventService.Tag.reminder3);
+    return Tag.valueOf(updatedEvent.getTag()).isReminder();
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/AbstractActionRuleUpdater.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/AbstractActionRuleUpdater.java
@@ -1,0 +1,62 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleUpdater;
+
+public abstract class AbstractActionRuleUpdater implements ActionRuleUpdater {
+  private static final String MULTIPLE_ACTION_RULES_FOUND_EXCEPTION =
+      "Multiple %s Action Rules Found for Action Plan %s, remove all but %d before continuing";
+  private static final String NO_ACTION_RULES_FOUND_EXCEPTION =
+      "No %s Action Rules Found for Action Plan %s, please create one instead";
+  private static final String ACTION_PLAN_NOT_FOUND_EXCEPTION = "Action Plan %s not found";
+  private static final int MAX_ACTION_RULES = 1;
+  protected ActionSvcClient actionSvcClient;
+
+  public AbstractActionRuleUpdater(final ActionSvcClient actionSvcClient) {
+    this.actionSvcClient = actionSvcClient;
+  }
+
+  protected List<ActionRuleDTO> getActionRulesForActionPlan(final UUID actionPlanId)
+      throws CTPException {
+    final List<ActionRuleDTO> actionRules =
+        actionSvcClient.getActionRulesForActionPlan(actionPlanId);
+
+    if (actionRules == null) {
+      throw new CTPException(
+          CTPException.Fault.SYSTEM_ERROR,
+          String.format(ACTION_PLAN_NOT_FOUND_EXCEPTION, actionPlanId));
+    }
+    return actionRules;
+  }
+
+  protected List<ActionRuleDTO> filterActionRulesByType(
+      final List<ActionRuleDTO> actionRules, final ActionType actionType, final UUID actionPlanId)
+      throws CTPException {
+    final List<ActionRuleDTO> filteredRules =
+        actionRules
+            .stream()
+            .filter(actionRuleDTO -> actionRuleDTO.getActionTypeName().equals(actionType))
+            .collect(Collectors.toList());
+
+    if (filteredRules.isEmpty()) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format(NO_ACTION_RULES_FOUND_EXCEPTION, actionType, actionPlanId));
+    }
+
+    if (filteredRules.size() > MAX_ACTION_RULES) {
+      throw new CTPException(
+          CTPException.Fault.SYSTEM_ERROR,
+          String.format(
+              MULTIPLE_ACTION_RULES_FOUND_EXCEPTION, actionType, actionPlanId, MAX_ACTION_RULES));
+    }
+
+    return filteredRules;
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleCreator.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
 import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
@@ -41,13 +42,13 @@ public final class GoLiveActionRuleCreator implements ActionRuleCreator {
     actionSvcClient.createActionRule(
         survey.getShortName() + "NOTE",
         survey.getShortName() + " Notification Email " + collectionExercise.getExerciseRef(),
-        "BSNE",
+        ActionType.BSNE,
         offsetDateTime,
         3,
         businessIndividualCaseTypeOverride.getActionPlanId());
   }
 
   private boolean isGoLive(final Event collectionExerciseEvent) {
-    return Tag.valueOf(collectionExerciseEvent.getTag()).equals(Tag.go_live);
+    return Tag.go_live.hasName(collectionExerciseEvent.getTag());
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleUpdater.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleUpdater.java
@@ -1,0 +1,52 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
+
+@Component
+public final class GoLiveActionRuleUpdater extends AbstractActionRuleUpdater {
+  private GoLiveActionRuleUpdater(final ActionSvcClient actionSvcClient) {
+    super(actionSvcClient);
+  }
+
+  @Override
+  public void execute(
+      final Event event,
+      final CaseTypeOverride businessCaseTypeOverride,
+      final CaseTypeOverride businessIndividualCaseTypeOverride,
+      final SurveyDTO survey)
+      throws CTPException {
+    if (survey.getSurveyType() != SurveyType.Business) {
+      return;
+    }
+
+    if (!Tag.go_live.hasName(event.getTag())) {
+      return;
+    }
+
+    final UUID actionPlanId = businessIndividualCaseTypeOverride.getActionPlanId();
+    final List<ActionRuleDTO> actionRules = getActionRulesForActionPlan(actionPlanId);
+    final List<ActionRuleDTO> bsneRules =
+        filterActionRulesByType(actionRules, ActionType.BSNE, actionPlanId);
+    final ActionRuleDTO bsneRule = bsneRules.get(0);
+
+    actionSvcClient.updateActionRule(
+        bsneRule.getId(),
+        bsneRule.getName(),
+        bsneRule.getDescription(),
+        OffsetDateTime.ofInstant(event.getTimestamp().toInstant(), ZoneId.systemDefault()),
+        bsneRule.getPriority());
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreator.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
 import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
@@ -42,13 +43,13 @@ public final class MpsActionRuleCreator implements ActionRuleCreator {
     actionSvcClient.createActionRule(
         survey.getShortName() + "NOTF",
         survey.getShortName() + " Notification File " + collectionExercise.getExerciseRef(),
-        "BSNL",
+        ActionType.BSNL,
         offsetDateTime,
         3,
         businessCaseTypeOverride.getActionPlanId());
   }
 
   private boolean isMps(final Event collectionExerciseEvent) {
-    return Tag.valueOf(collectionExerciseEvent.getTag()).equals(Tag.mps);
+    return Tag.mps.hasName(collectionExerciseEvent.getTag());
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleUpdater.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleUpdater.java
@@ -1,0 +1,53 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
+
+@Component
+public class MpsActionRuleUpdater extends AbstractActionRuleUpdater {
+
+  public MpsActionRuleUpdater(final ActionSvcClient actionSvcClient) {
+    super(actionSvcClient);
+  }
+
+  @Override
+  public void execute(
+      final Event event,
+      final CaseTypeOverride businessCaseTypeOverride,
+      final CaseTypeOverride businessIndividualCaseTypeOverride,
+      final SurveyDTO survey)
+      throws CTPException {
+    if (survey.getSurveyType() != SurveyType.Business) {
+      return;
+    }
+
+    if (!Tag.mps.hasName(event.getTag())) {
+      return;
+    }
+
+    final UUID actionPlanId = businessCaseTypeOverride.getActionPlanId();
+    final List<ActionRuleDTO> actionRules = getActionRulesForActionPlan(actionPlanId);
+    final List<ActionRuleDTO> bsnlRules =
+        filterActionRulesByType(actionRules, ActionType.BSNL, actionPlanId);
+    final ActionRuleDTO bsnlRule = bsnlRules.get(0);
+
+    actionSvcClient.updateActionRule(
+        bsnlRule.getId(),
+        bsnlRule.getName(),
+        bsnlRule.getDescription(),
+        OffsetDateTime.ofInstant(event.getTimestamp().toInstant(), ZoneId.systemDefault()),
+        bsnlRule.getPriority());
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleUpdater.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleUpdater.java
@@ -1,0 +1,83 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
+
+@Component
+public class ReminderActionRuleUpdater extends AbstractActionRuleUpdater {
+
+  private final ReminderSuffixGenerator reminderSuffixGenerator;
+
+  public ReminderActionRuleUpdater(
+      final ActionSvcClient actionSvcClient,
+      final ReminderSuffixGenerator reminderSuffixGenerator) {
+    super(actionSvcClient);
+    this.reminderSuffixGenerator = reminderSuffixGenerator;
+  }
+
+  @Override
+  public void execute(
+      final Event event,
+      final CaseTypeOverride businessCaseTypeOverride,
+      final CaseTypeOverride businessIndividualCaseTypeOverride,
+      final SurveyDTO survey)
+      throws CTPException {
+    if (survey.getSurveyType() != SurveyType.Business) {
+      return;
+    }
+
+    if (!Tag.valueOf(event.getTag()).isReminder()) {
+      return;
+    }
+    final String reminderSuffix = reminderSuffixGenerator.getReminderSuffix(event.getTag());
+
+    final UUID biActionPlanId = businessIndividualCaseTypeOverride.getActionPlanId();
+    final List<ActionRuleDTO> biActionRules = getActionRulesForActionPlan(biActionPlanId);
+    final List<ActionRuleDTO> biActionRulesMatchingSuffix =
+        filterRulesMatchingSuffix(reminderSuffix, biActionRules);
+    final List<ActionRuleDTO> bsreRules =
+        filterActionRulesByType(biActionRulesMatchingSuffix, ActionType.BSRE, biActionPlanId);
+
+    final UUID bActionPlanId = businessCaseTypeOverride.getActionPlanId();
+    final List<ActionRuleDTO> bActionRules = getActionRulesForActionPlan(bActionPlanId);
+    final List<ActionRuleDTO> bActionRulesMatchingSuffix =
+        filterRulesMatchingSuffix(reminderSuffix, bActionRules);
+    final List<ActionRuleDTO> bsrlRules =
+        filterActionRulesByType(bActionRulesMatchingSuffix, ActionType.BSRL, bActionPlanId);
+
+    final ArrayList<ActionRuleDTO> bsrlAndBsre = new ArrayList<>();
+    bsrlAndBsre.addAll(bsreRules);
+    bsrlAndBsre.addAll(bsrlRules);
+
+    for (final ActionRuleDTO actionRule : bsrlAndBsre) {
+      actionSvcClient.updateActionRule(
+          actionRule.getId(),
+          actionRule.getName(),
+          actionRule.getDescription(),
+          OffsetDateTime.ofInstant(event.getTimestamp().toInstant(), ZoneId.systemDefault()),
+          actionRule.getPriority());
+    }
+  }
+
+  private List<ActionRuleDTO> filterRulesMatchingSuffix(
+      final String reminderSuffix, final List<ActionRuleDTO> actionRules) {
+    return actionRules
+        .stream()
+        .filter(actionRuleDTO -> actionRuleDTO.getName().endsWith(reminderSuffix))
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderSuffixGenerator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderSuffixGenerator.java
@@ -1,0 +1,19 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+
+@Component
+public class ReminderSuffixGenerator {
+
+  public String getReminderSuffix(final String tagName) {
+    Tag tag = Tag.valueOf(tagName);
+
+    if (!tag.isReminder()) {
+      throw new IllegalArgumentException(String.format("Tag %s is not a reminder", tagName));
+    }
+
+    final int reminderIndex = Tag.ORDERED_REMINDERS.indexOf(tag);
+    return String.format("+%d", reminderIndex + 1);
+  }
+}

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -90,6 +90,26 @@ sample-svc:
     # time to read response
     read-timeout-milli-seconds: 5000
 
+action-svc:
+  action-plans-path: /actionplans
+  action-rules-path: /actionrules
+  action-rule-path: /actionrules/{actionRuleId}
+  action-rules-for-action-plan-path: /actionrules/actionplan/{actionPlanId}
+  connection-config:
+    scheme: http
+    host: localhost
+    port: 8151
+    username: admin
+    password: secret
+    # how many times should we attempt connection on failure
+    retry-attempts: 10
+    # sleep between retries
+    retry-pause-milli-seconds: 5000
+    # time to estab connection
+    connect-timeout-milli-seconds: 5000
+    # time to read response
+    read-timeout-milli-seconds: 5000
+
 survey-svc:
   request-classifier-types-list-path: /surveys/{surveyId}/classifiertypeselectors
   request-classifier-types-path: /surveys/{surveyId}/classifiertypeselectors/{selectorId}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,6 +117,8 @@ survey-svc:
 action-svc:
   action-plans-path: /actionplans
   action-rules-path: /actionrules
+  action-rule-path: /actionrules/{actionRuleId}
+  action-rules-for-action-plan-path: /actionrules/actionplan/{actionPlanId}
   connection-config:
     scheme: http
     host: localhost

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImplTest.java
@@ -1,12 +1,17 @@
 package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.net.URI;
 import java.util.UUID;
 import org.junit.Before;
@@ -14,19 +19,21 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.rest.RestUtility;
 import uk.gov.ons.ctp.common.rest.RestUtilityConfig;
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 import uk.gov.ons.ctp.response.collection.exercise.config.SurveySvc;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -37,28 +44,24 @@ public class SurveySvcRestClientImplTest {
 
   @Mock private RestTemplate restTemplate;
 
-  @Spy private RestUtility restUtility = new RestUtility(RestUtilityConfig.builder().build());
+  @Spy private final RestUtility restUtility = new RestUtility(RestUtilityConfig.builder().build());
 
   @InjectMocks private SurveySvcRestClientImpl surveySvcClient;
+
+  @Mock private ObjectMapper objectMapper;
 
   @Mock private AppConfig appConfig;
 
   @Before
-  public void setup() {
-    MockitoAnnotations.initMocks(this);
-  }
-
-  private SurveySvc prepareSurvey() {
+  public void prepareSurveyService() {
     SurveySvc surveySvc = new SurveySvc();
     surveySvc.setSurveyRefPath(SURVEY_REF_PATH);
     given(appConfig.getSurveySvc()).willReturn(surveySvc);
-    return surveySvc;
   }
 
   @Test(expected = RestClientException.class)
   public void ensure4xxThrownSurveyFindByRef() {
     String surveyRef = "ABC123";
-    prepareSurvey();
 
     given(
             restTemplate.exchange(
@@ -74,7 +77,6 @@ public class SurveySvcRestClientImplTest {
   @Test
   public void ensureNullReturnedOnNullSurvey() {
     UUID surveyId = UUID.randomUUID();
-    prepareSurvey();
 
     given(
             restTemplate.exchange(
@@ -85,5 +87,60 @@ public class SurveySvcRestClientImplTest {
 
     // When a 404 error is thrown, the function will return a null survey
     assertNull("Survey was not null as expected", survey);
+  }
+
+  @Test
+  public void ensureSurveyReturnedOnGetSurvey() throws IOException {
+    final UUID surveyId = UUID.randomUUID();
+
+    final ResponseEntity<String> responseEntity = new ResponseEntity<>("json", HttpStatus.OK);
+    given(
+            restTemplate.exchange(
+                any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+        .willReturn(responseEntity);
+
+    final SurveyDTO surveyDto = new SurveyDTO();
+
+    when(objectMapper.readValue("json", SurveyDTO.class)).thenReturn(surveyDto);
+
+    final SurveyDTO returnedSurvey = surveySvcClient.findSurvey(surveyId);
+
+    assertThat(returnedSurvey, is(surveyDto));
+  }
+
+  @Test
+  public void ensureGetSurveyForCollectionExerciseReturnsSurvey() throws IOException, CTPException {
+    final UUID surveyId = UUID.randomUUID();
+    final SurveyDTO surveyDto = new SurveyDTO();
+    surveyDto.setId(surveyId.toString());
+
+    final CollectionExercise collex = new CollectionExercise();
+    collex.setSurveyId(surveyId);
+
+    final ResponseEntity<String> responseEntity = new ResponseEntity<>("json", HttpStatus.OK);
+    given(
+            restTemplate.exchange(
+                any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+        .willReturn(responseEntity);
+
+    when(objectMapper.readValue("json", SurveyDTO.class)).thenReturn(surveyDto);
+
+    final SurveyDTO returnedSurvey = surveySvcClient.getSurveyForCollectionExercise(collex);
+
+    assertThat(returnedSurvey, is(surveyDto));
+  }
+
+  @Test(expected = CTPException.class)
+  public void throwCTPExceptionIfSurveyNotFoundForCollectionExercise() throws CTPException {
+    final UUID surveyId = UUID.randomUUID();
+    final CollectionExercise collectionExercse = new CollectionExercise();
+    collectionExercse.setSurveyId(surveyId);
+
+    given(
+            restTemplate.exchange(
+                any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+        .willThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND, "Bad request"));
+
+    surveySvcClient.getSurveyForCollectionExercise(collectionExercse);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/EventServiceTest.java
@@ -36,4 +36,34 @@ public class EventServiceTest {
   public void testTagShouldHaveReminder3AsAnActionableTag() {
     assertThat(Tag.reminder3.isActionable(), is(true));
   }
+
+  @Test
+  public void testCompareTagToItsName() {
+    assertThat(Tag.mps.hasName("mps"), is(true));
+  }
+
+  @Test
+  public void testCompareTagToRandomString() {
+    assertThat(Tag.mps.hasName("asdadfgsfgth"), is(false));
+  }
+
+  @Test
+  public void testTagShouldHaveReminderAsIsReminder() {
+    assertThat(Tag.reminder.isReminder(), is(true));
+  }
+
+  @Test
+  public void testTagShouldHaveReminder2AsIsReminder() {
+    assertThat(Tag.reminder2.isReminder(), is(true));
+  }
+
+  @Test
+  public void testTagShouldHaveReminder3AsIsReminder() {
+    assertThat(Tag.reminder3.isReminder(), is(true));
+  }
+
+  @Test
+  public void testTagShouldHaveMPSAsIsNotReminder() {
+    assertThat(Tag.mps.isReminder(), is(false));
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ActionSvcClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ActionSvcClientImplTest.java
@@ -1,29 +1,36 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.ons.ctp.common.rest.RestUtility;
-import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
-import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
-import uk.gov.ons.ctp.response.action.representation.ActionRulePostRequestDTO;
+import uk.gov.ons.ctp.response.action.representation.*;
 import uk.gov.ons.ctp.response.collection.exercise.client.impl.ActionSvcRestClientImpl;
 import uk.gov.ons.ctp.response.collection.exercise.config.ActionSvc;
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
@@ -32,11 +39,21 @@ import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 public class ActionSvcClientImplTest {
 
   private static final String ACTION_PATH = "/actions";
-  private static final String ACTION_RULE_PATH = "/actionrules";
+  private static final String ACTION_RULES_PATH = "/actionrules";
+  private static final String ACTION_RULE_PATH = "/actionrules/{actionRuleId}";
   private static final String HTTP = "http";
   private static final String LOCALHOST = "localhost";
   private static final String ACTION_PLAN_NAME = "example";
   private static final String ACTION_PLAN_DESCRIPTION = "example description";
+  private static final String ACTION_RULES_FOR_PLAN_PATH = "/actionrules/actionplan/{actionPlanId}";
+  private static final String ACTION_RULE_NAME = "BSREM+45";
+  private static final String ACTION_RULE_DESCRIPTION = "Enrolment Reminder Letter(+45 days)";
+  private static final UUID ACTION_RULE_ID =
+      UUID.fromString("714356ba-7236-4179-8007-f09190eed323");
+  private static final int ACTION_RULE_PRIORITY = 3;
+  private static final OffsetDateTime ACTION_RULE_TRIGGER_DATE_TIME = OffsetDateTime.now();
+  private static final UUID ACTION_PLAN_ID =
+      UUID.fromString("003e587a-843f-11e8-adc0-fa7ae01bbebc");
 
   @Mock private AppConfig appConfig;
 
@@ -135,7 +152,7 @@ public class ActionSvcClientImplTest {
   public void testCreateActionRule() {
     // Given
     ActionSvc actionSvcConfig = new ActionSvc();
-    actionSvcConfig.setActionRulesPath(ACTION_RULE_PATH);
+    actionSvcConfig.setActionRulesPath(ACTION_RULES_PATH);
     when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
 
     UriComponents uriComponents =
@@ -149,7 +166,6 @@ public class ActionSvcClientImplTest {
         .thenReturn(uriComponents);
 
     ActionRulePostRequestDTO actionRulePostRequestDTO = getActionRulePostRequestDTO();
-
     ActionRuleDTO actionRuleDTO = getActionRuleDTO();
 
     HttpEntity httpEntity = new HttpEntity<>(actionRulePostRequestDTO, null);
@@ -186,7 +202,7 @@ public class ActionSvcClientImplTest {
   public void testCreateActionRuleRestClientException() {
     // Given
     ActionSvc actionSvcConfig = new ActionSvc();
-    actionSvcConfig.setActionRulesPath(ACTION_RULE_PATH);
+    actionSvcConfig.setActionRulesPath(ACTION_RULES_PATH);
     when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
 
     when(restUtility.createUriComponents(any(String.class), any(MultiValueMap.class)))
@@ -196,36 +212,217 @@ public class ActionSvcClientImplTest {
 
     // When
     actionSvcClient.createActionRule(
-        "BSREM+45",
-        "Enrolment Reminder Letter(+45 days)",
-        "BSREM",
+        ACTION_RULE_NAME,
+        ACTION_RULE_DESCRIPTION,
+        ActionType.BSREM,
         OffsetDateTime.now().plusDays(45),
-        3,
-        UUID.fromString("003e587a-843f-11e8-adc0-fa7ae01bbebc"));
+        ACTION_RULE_PRIORITY,
+        ACTION_RULE_ID);
 
     // Then RestClientException is thrown
   }
 
+  /** Test that the action service is called with the correct details when creating action rules. */
+  @Test
+  public void testUpdateActionRule() {
+    // Given
+    final ActionSvc actionSvcConfig = new ActionSvc();
+    actionSvcConfig.setActionRulePath(ACTION_RULE_PATH);
+    when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
+
+    final UriComponents uriComponents =
+        UriComponentsBuilder.newInstance()
+            .scheme(HTTP)
+            .host(LOCALHOST)
+            .port(80)
+            .path(ACTION_RULE_PATH)
+            .build();
+    when(restUtility.createUriComponents(eq(ACTION_RULE_PATH), eq(null), eq(ACTION_RULE_ID)))
+        .thenReturn(uriComponents);
+
+    final ActionRulePutRequestDTO actionRulePutRequestDTO = getActionRulePutRequestDTO();
+    final ActionRuleDTO actionRuleDTO = getActionRuleDTO();
+
+    final HttpEntity httpEntity = new HttpEntity<>(actionRulePutRequestDTO, null);
+    when(restUtility.createHttpEntity(any(ActionRulePutRequestDTO.class))).thenReturn(httpEntity);
+    when(restTemplate.exchange(
+            eq(uriComponents.toUri()), eq(HttpMethod.PUT), eq(httpEntity), eq(ActionRuleDTO.class)))
+        .thenReturn(new ResponseEntity<>(actionRuleDTO, HttpStatus.OK));
+
+    // When
+    final ActionRuleDTO updateActionRule =
+        actionSvcClient.updateActionRule(
+            ACTION_RULE_ID,
+            ACTION_RULE_NAME,
+            ACTION_RULE_DESCRIPTION,
+            ACTION_RULE_TRIGGER_DATE_TIME,
+            ACTION_RULE_PRIORITY);
+
+    // Then
+    assertThat(actionRuleDTO.getName(), is(updateActionRule.getName()));
+    assertThat(actionRuleDTO.getDescription(), is(updateActionRule.getDescription()));
+    assertThat(actionRuleDTO.getActionTypeName(), is(updateActionRule.getActionTypeName()));
+    assertThat(actionRuleDTO.getId(), is(updateActionRule.getId()));
+  }
+
+  /**
+   * Test that a rest client exception is thrown when issues contacting the action service to create
+   * an action rule.
+   */
+  @Test(expected = RestClientException.class)
+  public void testUpdateActionRuleRestClientException() {
+    // Given
+    final ActionSvc actionSvcConfig = new ActionSvc();
+    actionSvcConfig.setActionRulePath(ACTION_RULE_PATH);
+    when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
+
+    final UriComponents uriComponents =
+        UriComponentsBuilder.newInstance()
+            .scheme(HTTP)
+            .host(LOCALHOST)
+            .port(80)
+            .path(ACTION_RULE_PATH)
+            .build();
+    when(restUtility.createUriComponents(eq(ACTION_RULE_PATH), eq(null), eq(ACTION_RULE_ID)))
+        .thenReturn(uriComponents);
+
+    final ActionRulePutRequestDTO actionRulePutRequestDTO = getActionRulePutRequestDTO();
+
+    final HttpEntity httpEntity = new HttpEntity<>(actionRulePutRequestDTO, null);
+    when(restUtility.createHttpEntity(any(ActionRulePutRequestDTO.class))).thenReturn(httpEntity);
+    when(restTemplate.exchange(
+            eq(uriComponents.toUri()), eq(HttpMethod.PUT), eq(httpEntity), eq(ActionRuleDTO.class)))
+        .thenThrow(new RestClientException("Err"));
+
+    // When
+    actionSvcClient.updateActionRule(
+        ACTION_RULE_ID,
+        ACTION_RULE_NAME,
+        ACTION_RULE_DESCRIPTION,
+        ACTION_RULE_TRIGGER_DATE_TIME,
+        ACTION_RULE_PRIORITY);
+    // Then RestClientException is thrown
+  }
+
+  @Test
+  public void testGetActionRulesForActionPlan() {
+    // Given
+    final ActionSvc actionSvcConfig = new ActionSvc();
+    actionSvcConfig.setActionRulesForActionPlanPath(ACTION_RULES_FOR_PLAN_PATH);
+    when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
+
+    final UriComponents uriComponents =
+        UriComponentsBuilder.newInstance()
+            .scheme(HTTP)
+            .host(LOCALHOST)
+            .port(80)
+            .path(ACTION_RULES_FOR_PLAN_PATH)
+            .build();
+    final UUID actionPlanId = UUID.randomUUID();
+    when(restUtility.createUriComponents(
+            endsWith(ACTION_RULES_FOR_PLAN_PATH), eq(null), eq(actionPlanId)))
+        .thenReturn(uriComponents);
+
+    final List<ActionRuleDTO> actionRuleDTOs = new ArrayList<>();
+    when(restTemplate.exchange(
+            eq(uriComponents.toUri()),
+            eq(HttpMethod.GET),
+            eq(null),
+            eq(new ParameterizedTypeReference<List<ActionRuleDTO>>() {})))
+        .thenReturn(new ResponseEntity<>(actionRuleDTOs, HttpStatus.OK));
+
+    // When
+    final List<ActionRuleDTO> returnedActionRuleDTOs =
+        actionSvcClient.getActionRulesForActionPlan(actionPlanId);
+
+    // Then
+    assertThat(returnedActionRuleDTOs, is(actionRuleDTOs));
+  }
+
+  @Test(expected = RestClientException.class)
+  public void testGetActionRulesForActionPlanRestClientException() {
+    // Given
+    final ActionSvc actionSvcConfig = new ActionSvc();
+    actionSvcConfig.setActionRulesForActionPlanPath(ACTION_RULES_FOR_PLAN_PATH);
+    when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
+
+    final UriComponents uriComponents =
+        UriComponentsBuilder.newInstance()
+            .scheme(HTTP)
+            .host(LOCALHOST)
+            .port(80)
+            .path(ACTION_RULES_FOR_PLAN_PATH)
+            .build();
+    final UUID actionPlanId = UUID.randomUUID();
+    when(restUtility.createUriComponents(any(String.class), eq(null), eq(actionPlanId)))
+        .thenReturn(uriComponents);
+    when(restTemplate.exchange(
+            eq(uriComponents.toUri()),
+            eq(HttpMethod.GET),
+            eq(null),
+            eq(new ParameterizedTypeReference<List<ActionRuleDTO>>() {})))
+        .thenThrow(new RestClientException("Error"));
+
+    // When
+    actionSvcClient.getActionRulesForActionPlan(actionPlanId);
+  }
+
+  @Test
+  public void testGetActionRulesForActionPlanReturnsNullOn404() {
+    // Given
+    final ActionSvc actionSvcConfig = new ActionSvc();
+    actionSvcConfig.setActionRulesForActionPlanPath(ACTION_RULES_FOR_PLAN_PATH);
+    when(appConfig.getActionSvc()).thenReturn(actionSvcConfig);
+
+    final UriComponents uriComponents =
+        UriComponentsBuilder.newInstance()
+            .scheme(HTTP)
+            .host(LOCALHOST)
+            .port(80)
+            .path(ACTION_RULES_FOR_PLAN_PATH)
+            .build();
+    final UUID actionPlanId = UUID.randomUUID();
+    when(restUtility.createUriComponents(any(String.class), eq(null), eq(actionPlanId)))
+        .thenReturn(uriComponents);
+    when(restTemplate.exchange(
+            eq(uriComponents.toUri()),
+            eq(HttpMethod.GET),
+            eq(null),
+            eq(new ParameterizedTypeReference<List<ActionRuleDTO>>() {})))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+
+    // When
+    assertThat(actionSvcClient.getActionRulesForActionPlan(actionPlanId), nullValue());
+  }
+
+  private ActionRulePutRequestDTO getActionRulePutRequestDTO() {
+    final ActionRulePutRequestDTO actionRulePutRequestDTO = new ActionRulePutRequestDTO();
+    actionRulePutRequestDTO.setName(ACTION_RULE_NAME);
+    actionRulePutRequestDTO.setDescription(ACTION_RULE_DESCRIPTION);
+    actionRulePutRequestDTO.setTriggerDateTime(ACTION_RULE_TRIGGER_DATE_TIME);
+    actionRulePutRequestDTO.setPriority(ACTION_RULE_PRIORITY);
+    return actionRulePutRequestDTO;
+  }
+
   private ActionRulePostRequestDTO getActionRulePostRequestDTO() {
-    ActionRulePostRequestDTO actionRulePostRequestDTO = new ActionRulePostRequestDTO();
-    actionRulePostRequestDTO.setName("BSREM+45");
-    actionRulePostRequestDTO.setActionTypeName("BSREM");
-    actionRulePostRequestDTO.setDescription("Enrolment Reminder Letter(+45 days)");
-    actionRulePostRequestDTO.setActionPlanId(
-        UUID.fromString("003e587a-843f-11e8-adc0-fa7ae01bbebc"));
-    actionRulePostRequestDTO.setTriggerDateTime(OffsetDateTime.now());
-    actionRulePostRequestDTO.setPriority(3);
+    final ActionRulePostRequestDTO actionRulePostRequestDTO = new ActionRulePostRequestDTO();
+    actionRulePostRequestDTO.setName(ACTION_RULE_NAME);
+    actionRulePostRequestDTO.setActionTypeName(ActionType.BSREM);
+    actionRulePostRequestDTO.setDescription(ACTION_RULE_DESCRIPTION);
+    actionRulePostRequestDTO.setActionPlanId(ACTION_PLAN_ID);
+    actionRulePostRequestDTO.setTriggerDateTime(ACTION_RULE_TRIGGER_DATE_TIME);
+    actionRulePostRequestDTO.setPriority(ACTION_RULE_PRIORITY);
     return actionRulePostRequestDTO;
   }
 
   private ActionRuleDTO getActionRuleDTO() {
-    ActionRuleDTO actionRuleDTO = new ActionRuleDTO();
-    actionRuleDTO.setName("BSREM+45");
-    actionRuleDTO.setActionTypeName("BSREM");
-    actionRuleDTO.setDescription("Enrolment Reminder Letter(+45 days)");
-    actionRuleDTO.setId(UUID.fromString("714356ba-7236-4179-8007-f09190eed323"));
-    actionRuleDTO.setTriggerDateTime(OffsetDateTime.now());
-    actionRuleDTO.setPriority(3);
+    final ActionRuleDTO actionRuleDTO = new ActionRuleDTO();
+    actionRuleDTO.setName(ACTION_RULE_NAME);
+    actionRuleDTO.setActionTypeName(ActionType.BSREM);
+    actionRuleDTO.setDescription(ACTION_RULE_DESCRIPTION);
+    actionRuleDTO.setId(ACTION_PLAN_ID);
+    actionRuleDTO.setTriggerDateTime(ACTION_RULE_TRIGGER_DATE_TIME);
+    actionRuleDTO.setPriority(ACTION_RULE_PRIORITY);
     return actionRuleDTO;
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CaseTypeOverrideServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CaseTypeOverrideServiceImplTest.java
@@ -1,0 +1,70 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.repository.CaseTypeOverrideRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CaseTypeOverrideServiceImplTest {
+
+  private static final String BUSINESS_SAMPLE_UNIT_TYPE = "B";
+  private static final int COLLECTION_EXERCISE_PK = 10;
+  private static final UUID COLLECTION_EXERCISE_ID =
+      UUID.fromString("65dec540-f562-4fbf-87e7-a6ef411101d4");
+
+  @Mock CaseTypeOverrideRepository caseTypeOverrideRepository;
+
+  @Mock Logger logger;
+
+  @InjectMocks CaseTypeOverrideServiceImpl caseTypeOverrideService;
+
+  @Test
+  public void testGetCaseTypeOverrideReturnsCaseTypeOverrideOnSuccess() throws CTPException {
+    final CaseTypeOverride caseTypeOverride = new CaseTypeOverride();
+    when(caseTypeOverrideRepository.findTopByExerciseFKAndSampleUnitTypeFK(
+            COLLECTION_EXERCISE_PK, BUSINESS_SAMPLE_UNIT_TYPE))
+        .thenReturn(caseTypeOverride);
+
+    final CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setExercisePK(COLLECTION_EXERCISE_PK);
+
+    assertThat(
+        caseTypeOverrideService.getCaseTypeOverride(collectionExercise, BUSINESS_SAMPLE_UNIT_TYPE),
+        is(caseTypeOverride));
+  }
+
+  @Test
+  public void testGetCaseTypeOverrideThrowsExceptionOnNotFound() {
+    when(caseTypeOverrideRepository.findTopByExerciseFKAndSampleUnitTypeFK(
+            COLLECTION_EXERCISE_PK, BUSINESS_SAMPLE_UNIT_TYPE))
+        .thenReturn(null);
+
+    final CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setId(COLLECTION_EXERCISE_ID);
+    collectionExercise.setExercisePK(COLLECTION_EXERCISE_PK);
+
+    try {
+      caseTypeOverrideService.getCaseTypeOverride(collectionExercise, BUSINESS_SAMPLE_UNIT_TYPE);
+    } catch (final CTPException e) {
+      assertThat(e.getFault(), is(Fault.RESOURCE_NOT_FOUND));
+      assertThat(
+          e.getMessage(),
+          is(
+              "Override action plans do not exist for collection exercise "
+                  + COLLECTION_EXERCISE_ID));
+    }
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImplTest.java
@@ -1,10 +1,12 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -18,6 +20,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -25,14 +28,17 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.response.collection.exercise.client.SurveySvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
-import uk.gov.ons.ctp.response.collection.exercise.repository.CaseTypeOverrideRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.EventRepository;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleCreator;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleUpdater;
+import uk.gov.ons.ctp.response.collection.exercise.service.CaseTypeOverrideService;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
@@ -41,22 +47,43 @@ import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
 /** Class containing tests for EventServiceImpl */
 @RunWith(MockitoJUnitRunner.class)
 public class EventServiceImplTest {
-  public static final UUID SURVEY_ID = UUID.fromString("4ca97b1b-de9c-4fed-9898-fac594d1565f");
+  private static final UUID SURVEY_ID = UUID.fromString("4ca97b1b-de9c-4fed-9898-fac594d1565f");
+  private static final UUID BUSINESS_INDIVIDUAL_ACTION_PLAN_ID =
+      UUID.fromString("84a3afcd-bb2c-4a89-b8c6-3f117420f047");
+  private static final UUID BUSINESS_ACTION_PLAN_ID =
+      UUID.fromString("459304df-e4f9-450f-947b-ec7c2c85a1aa");
+  private static final UUID COLLECTION_EXERCISE_EVENT_ID =
+      UUID.fromString("ba6a92c1-9869-41ca-b0d8-12c27fc30e23");
+  private static final UUID COLLEX_UUID = UUID.fromString("f03206ee-137d-41e3-af5c-2dea393bb360");
+  private static final String BUSINESS_SAMPLE_TYPE = "B";
+  private static final String BUSINESS_INDIVIDUAL_SAMPLE_TYPE = "BI";
+  private static final int EXERCISE_PK = 6433;
+
   @Mock private SurveySvcClient surveySvcClient;
 
-  @Mock private EventRepository eventRepository;
-
-  @Mock private CaseTypeOverrideRepository caseTypeOverrideRepo;
+  @Mock private CaseTypeOverrideService caseTypeOverrideService;
 
   @Mock private CollectionExerciseService collectionExerciseService;
+
+  @Mock private EventValidator eventValidator;
 
   @Mock private ActionRuleCreator actionRuleCreator;
 
   @Mock private ActionRuleCreator actionRuleCreator2;
 
-  @Spy private List<ActionRuleCreator> actionRuleCreators = new ArrayList<ActionRuleCreator>();
+  @Mock private ActionRuleUpdater actionRuleUpdater;
+
+  @Mock private ActionRuleUpdater actionRuleUpdater2;
+
+  @Mock private EventRepository eventRepository;
+
+  @Spy private List<ActionRuleCreator> actionRuleCreators = new ArrayList<>();
+
+  @Spy private List<ActionRuleUpdater> actionRuleUpdaters = new ArrayList<>();
 
   @InjectMocks private EventServiceImpl eventService;
+
+  /* Given collection excercise does not exist When event is created Then exception is thrown */
 
   private static Event createEvent(Tag tag) {
     Timestamp eventTime = new Timestamp(new Date().getTime());
@@ -66,8 +93,8 @@ public class EventServiceImplTest {
 
     return event;
   }
+  /* Given event already exists When event is created Then exception is thrown */
 
-  /* Given collection excercise does not exist When event is created Then exception is thrown */
   @Test
   public void givenCollectionExcerciseDoesNotExistWhenEventIsCreatedThenExceptionIsThrown() {
     EventDTO eventDto = new EventDTO();
@@ -80,11 +107,10 @@ public class EventServiceImplTest {
       fail("Created event with non-existent collection exercise");
     } catch (CTPException e) {
       // Expected 404
-      assertEquals(CTPException.Fault.RESOURCE_NOT_FOUND, e.getFault());
+      assertThat(e.getFault(), is(Fault.RESOURCE_NOT_FOUND));
     }
   }
 
-  /* Given event already exists When event is created Then exception is thrown */
   @Test
   public void givenEventAlreadyExistsWhenEventIsCreatedThenExceptionIsThrown() throws CTPException {
     String tag = Tag.mps.name();
@@ -104,90 +130,28 @@ public class EventServiceImplTest {
       fail("Created event with non-existent collection exercise");
     } catch (CTPException e) {
       // Expected 409
-      assertEquals(CTPException.Fault.RESOURCE_VERSION_CONFLICT, e.getFault());
-    }
-  }
-
-  /**
-   * Test CTP exception thrown if no business case type override found, so no action plans have been
-   * associated to CE
-   */
-  @Test
-  public void testCreateActionRulesRaisesCTPExceptionIfNoBCaseOverRide() {
-    Event event = new Event();
-    CollectionExercise collex = new CollectionExercise();
-    CaseTypeOverride biCaseTypeOverride = new CaseTypeOverride();
-    collex.setExercisePK(1);
-    collex.setSurveyId(SURVEY_ID);
-    event.setTag(Tag.mps.name());
-
-    final SurveyDTO surveyDto = new SurveyDTO();
-    surveyDto.setSurveyType(SurveyType.Business);
-    when(surveySvcClient.findSurvey(SURVEY_ID)).thenReturn(surveyDto);
-
-    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(1, "B")).thenReturn(null);
-    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(1, "BI"))
-        .thenReturn(biCaseTypeOverride);
-    try {
-      eventService.createActionRulesForEvent(event, collex);
-      fail("Trying to create action rules when no action plans associated");
-    } catch (CTPException e) {
-      assertEquals(CTPException.Fault.RESOURCE_NOT_FOUND, e.getFault());
-    }
-  }
-
-  /**
-   * Test CTP exception thrown if no business individual case type override found, so no action
-   * plans have been associated to CE
-   */
-  @Test
-  public void testCreateActionRulesRaisesCTPExceptionIfNoBICaseOverRide() {
-    String tag = Tag.mps.name();
-    Event event = new Event();
-    CollectionExercise collex = new CollectionExercise();
-    CaseTypeOverride bCaseTypeOverride = new CaseTypeOverride();
-    collex.setExercisePK(1);
-    collex.setSurveyId(SURVEY_ID);
-    event.setTag(tag);
-
-    final SurveyDTO surveyDto = new SurveyDTO();
-    surveyDto.setSurveyType(SurveyType.Business);
-    when(surveySvcClient.findSurvey(SURVEY_ID)).thenReturn(surveyDto);
-
-    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(1, "B"))
-        .thenReturn(bCaseTypeOverride);
-    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(1, "BI")).thenReturn(null);
-    try {
-      eventService.createActionRulesForEvent(event, collex);
-      fail("Trying to create action rules when no action plans associated");
-    } catch (CTPException e) {
-      assertEquals(CTPException.Fault.RESOURCE_NOT_FOUND, e.getFault());
+      assertThat(e.getFault(), is(Fault.RESOURCE_VERSION_CONFLICT));
     }
   }
 
   @Test
   public void testCreateCorrectActionRulesForAnyEvent() throws CTPException {
     // Given
-    String businessSampleType = "B";
-    String businessIndividualSampleType = "BI";
     Event collectionExerciseEvent = new Event();
 
     CollectionExercise collex = new CollectionExercise();
-    int exercisePk = 6433;
-    collex.setExercisePK(exercisePk);
+    collex.setExercisePK(EXERCISE_PK);
     collex.setSurveyId(SURVEY_ID);
 
     final SurveyDTO surveyDto = new SurveyDTO();
     surveyDto.setSurveyType(SurveyType.Business);
-    when(surveySvcClient.findSurvey(SURVEY_ID)).thenReturn(surveyDto);
+    when(surveySvcClient.getSurveyForCollectionExercise(collex)).thenReturn(surveyDto);
 
     CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
-    UUID businessActionPlanId = UUID.randomUUID();
-    businessCaseTypeOverride.setActionPlanId(businessActionPlanId);
+    businessCaseTypeOverride.setActionPlanId(BUSINESS_ACTION_PLAN_ID);
 
     CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
-    UUID businessIndividualActionPlanId = UUID.randomUUID();
-    businessIndividualCaseTypeOverride.setActionPlanId(businessIndividualActionPlanId);
+    businessIndividualCaseTypeOverride.setActionPlanId(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID);
 
     Instant eventTriggerInstant = Instant.now();
     Timestamp eventTriggerDate = new Timestamp(eventTriggerInstant.toEpochMilli());
@@ -195,14 +159,11 @@ public class EventServiceImplTest {
     collectionExerciseEvent.setCollectionExercise(collex);
     collectionExerciseEvent.setTag(Tag.mps.name());
     collectionExerciseEvent.setTimestamp(eventTriggerDate);
-    UUID collectionExerciseEventId = UUID.fromString("ba6a92c1-9869-41ca-b0d8-12c27fc30e23");
-    collectionExerciseEvent.setId(collectionExerciseEventId);
+    collectionExerciseEvent.setId(COLLECTION_EXERCISE_EVENT_ID);
 
-    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(
-            exercisePk, businessSampleType))
+    when(caseTypeOverrideService.getCaseTypeOverride(collex, BUSINESS_SAMPLE_TYPE))
         .thenReturn(businessCaseTypeOverride);
-    when(caseTypeOverrideRepo.findTopByExerciseFKAndSampleUnitTypeFK(
-            exercisePk, businessIndividualSampleType))
+    when(caseTypeOverrideService.getCaseTypeOverride(collex, BUSINESS_INDIVIDUAL_SAMPLE_TYPE))
         .thenReturn(businessIndividualCaseTypeOverride);
 
     actionRuleCreators.add(actionRuleCreator);
@@ -251,7 +212,7 @@ public class EventServiceImplTest {
 
     SurveyDTO surveyDto = new SurveyDTO();
     surveyDto.setSurveyType(SurveyType.Social);
-    when(surveySvcClient.findSurvey(SURVEY_ID)).thenReturn(surveyDto);
+    when(surveySvcClient.getSurveyForCollectionExercise(collex)).thenReturn(surveyDto);
 
     collectionExerciseEvent.setCollectionExercise(collex);
     collectionExerciseEvent.setTag(Tag.mps.name());
@@ -263,10 +224,6 @@ public class EventServiceImplTest {
     verify(actionRuleCreator, never()).execute(any(), any(), any(), any());
   }
 
-  private List<Event> createEventList(Tag... tags) {
-    return Arrays.stream(tags).map(EventServiceImplTest::createEvent).collect(Collectors.toList());
-  }
-
   @Test
   public void givenNoEventsWhenScheduledIsCheckedThenFalse() throws CTPException {
     UUID collexUuid = UUID.randomUUID();
@@ -275,6 +232,119 @@ public class EventServiceImplTest {
     boolean scheduled = this.eventService.isScheduled(collexUuid);
 
     assertFalse(scheduled);
+  }
+
+  @Test
+  public void givenCollectionExcerciseDoesNotExistWhenEventIsUpdatedThenExceptionIsThrown() {
+    final UUID collexUuid = UUID.randomUUID();
+
+    when(collectionExerciseService.findCollectionExercise(collexUuid)).thenReturn(null);
+
+    try {
+      eventService.updateEvent(collexUuid, Tag.mps.name(), new Date());
+
+      Assert.fail("Updated event with non-existent collection exercise");
+    } catch (final CTPException e) {
+      assertThat(e.getFault(), is(Fault.BAD_REQUEST));
+    }
+  }
+
+  @Test
+  public void givenEventDoesNotExistWhenEventIsUpdatedThenExceptionIsThrown() {
+    final UUID collexUuid = UUID.randomUUID();
+
+    final CollectionExercise collex = new CollectionExercise();
+    collex.setId(collexUuid);
+
+    when(collectionExerciseService.findCollectionExercise(collexUuid)).thenReturn(collex);
+    when(eventRepository.findOneByCollectionExerciseAndTag(collex, Tag.mps.name()))
+        .thenReturn(null);
+
+    try {
+      eventService.updateEvent(collexUuid, Tag.mps.name(), new Date());
+
+      Assert.fail("Updated non-existent event");
+    } catch (final CTPException e) {
+      assertThat(e.getFault(), is(Fault.RESOURCE_NOT_FOUND));
+    }
+  }
+
+  @Test
+  public void
+      givenEventsForCollectionExerciseDoNotValidateWhenEventIsUpdatedThenExceptionIsThrown() {
+    final UUID collexUuid = UUID.randomUUID();
+
+    final CollectionExercise collex = new CollectionExercise();
+    collex.setId(collexUuid);
+    final CollectionExerciseState collectionExerciseState = CollectionExerciseState.SCHEDULED;
+    collex.setState(collectionExerciseState);
+
+    when(collectionExerciseService.findCollectionExercise(collexUuid)).thenReturn(collex);
+    final Event existingEvent = new Event();
+    when(eventRepository.findOneByCollectionExerciseAndTag(collex, Tag.mps.name()))
+        .thenReturn(existingEvent);
+
+    final List<Event> existingEvents = new ArrayList<>();
+    when(eventRepository.findByCollectionExercise(collex)).thenReturn(existingEvents);
+    when(eventValidator.validate(existingEvents, existingEvent, collectionExerciseState))
+        .thenReturn(false);
+
+    try {
+      eventService.updateEvent(collexUuid, Tag.mps.name(), new Date());
+
+      Assert.fail("Validation failed and request was not rejected");
+    } catch (final CTPException e) {
+      Assert.assertEquals(Fault.BAD_REQUEST, e.getFault());
+    }
+  }
+
+  @Test
+  public void givenEventsForCollectionExerciseValidateWhenEventIsUpdatedItIsSaved()
+      throws CTPException {
+
+    final CollectionExercise collex = new CollectionExercise();
+    collex.setId(COLLEX_UUID);
+    collex.setExercisePK(EXERCISE_PK);
+    final CollectionExerciseState collectionExerciseState = CollectionExerciseState.SCHEDULED;
+    collex.setState(collectionExerciseState);
+
+    final SurveyDTO survey = new SurveyDTO();
+    when(surveySvcClient.getSurveyForCollectionExercise(collex)).thenReturn(survey);
+
+    when(collectionExerciseService.findCollectionExercise(COLLEX_UUID)).thenReturn(collex);
+    final Event existingEvent = new Event();
+    when(eventRepository.findOneByCollectionExerciseAndTag(collex, Tag.mps.name()))
+        .thenReturn(existingEvent);
+
+    final List<Event> existingEvents = new ArrayList<>();
+
+    final CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    businessCaseTypeOverride.setActionPlanId(BUSINESS_ACTION_PLAN_ID);
+
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID);
+
+    when(caseTypeOverrideService.getCaseTypeOverride(collex, BUSINESS_SAMPLE_TYPE))
+        .thenReturn(businessCaseTypeOverride);
+    when(caseTypeOverrideService.getCaseTypeOverride(collex, BUSINESS_INDIVIDUAL_SAMPLE_TYPE))
+        .thenReturn(businessIndividualCaseTypeOverride);
+
+    when(eventRepository.findByCollectionExercise(collex)).thenReturn(existingEvents);
+    when(eventValidator.validate(existingEvents, existingEvent, collectionExerciseState))
+        .thenReturn(true);
+
+    actionRuleUpdaters.add(actionRuleUpdater);
+    actionRuleUpdaters.add(actionRuleUpdater2);
+
+    eventService.updateEvent(COLLEX_UUID, Tag.mps.name(), new Date());
+
+    verify(eventRepository, atLeastOnce()).save(eq(existingEvent));
+    verify(actionRuleUpdater, atLeastOnce())
+        .execute(
+            existingEvent, businessCaseTypeOverride, businessIndividualCaseTypeOverride, survey);
+    verify(actionRuleUpdater2, atLeastOnce())
+        .execute(
+            existingEvent, businessCaseTypeOverride, businessIndividualCaseTypeOverride, survey);
   }
 
   @Test
@@ -297,5 +367,9 @@ public class EventServiceImplTest {
     boolean scheduled = this.eventService.isScheduled(collexUuid);
 
     assertTrue(scheduled);
+  }
+
+  private List<Event> createEventList(Tag... tags) {
+    return Arrays.stream(tags).map(EventServiceImplTest::createEvent).collect(Collectors.toList());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleCreatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleCreatorTest.java
@@ -19,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
 import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
@@ -55,7 +56,7 @@ public class GoLiveActionRuleCreatorTest {
     goLiveActionRuleCreator.execute(
         new Event(), new CaseTypeOverride(), new CaseTypeOverride(), survey);
     verify(actionSvcClient, times(0))
-        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
   }
 
   @Test
@@ -72,7 +73,7 @@ public class GoLiveActionRuleCreatorTest {
     CaseTypeOverride bCaseTypeOverride = new CaseTypeOverride();
     goLiveActionRuleCreator.execute(collectionExerciseEvent, bCaseTypeOverride, null, survey);
     verify(actionSvcClient, times(0))
-        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
   }
 
   @Test
@@ -100,7 +101,7 @@ public class GoLiveActionRuleCreatorTest {
     when(actionSvcClient.createActionRule(
             anyString(),
             anyString(),
-            eq("BSNE"),
+            eq(ActionType.BSNE),
             eq(eventTriggerOffsetDateTime),
             eq(3),
             eq(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID)))
@@ -115,7 +116,7 @@ public class GoLiveActionRuleCreatorTest {
         .createActionRule(
             eq(SURVEY_SHORT_NAME + "NOTE"),
             eq(SURVEY_SHORT_NAME + " Notification Email " + EXERCISE_REF),
-            eq("BSNE"),
+            eq(ActionType.BSNE),
             eq(eventTriggerOffsetDateTime),
             eq(3),
             eq(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID));

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleUpdaterTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleUpdaterTest.java
@@ -1,0 +1,184 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleUpdater;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoLiveActionRuleUpdaterTest {
+  private static final String MULTIPLE_ACTION_RULES_FOUND_EXCEPTION =
+      "Multiple BSNE Action Rules Found for Action Plan %s, remove all but 1 before continuing";
+  private static final String NO_BSNE_ACTION_RULES_FOUND_EXCEPTION =
+      "No BSNE Action Rules Found for Action Plan %s, please create one instead";
+  private static final String ACTION_PLAN_NOT_FOUND_EXCEPTION = "Action Plan %s not found";
+  private static final UUID ACTION_PLAN_ID = UUID.randomUUID();
+  private static final UUID ACTION_RULE_ID = UUID.randomUUID();
+  @Rule public ExpectedException thrown = ExpectedException.none();
+  @Mock private ActionSvcClient actionSvcClient;
+
+  @InjectMocks private GoLiveActionRuleUpdater updater;
+
+  public void isAnActionRuleUpdater() {
+    assertThat(updater, instanceOf(ActionRuleUpdater.class));
+  }
+
+  @Test
+  public void doNothingIfNotBusinessSurveyEvent() throws CTPException {
+    final Event event = new Event();
+    event.setTag(Tag.go_live.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Social);
+
+    updater.execute(event, new CaseTypeOverride(), new CaseTypeOverride(), survey);
+    verify(actionSvcClient, times(0))
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void doNothingIfNotGoLiveEvent() throws CTPException {
+    final Event event = new Event();
+    event.setTag(Tag.mps.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    updater.execute(event, null, new CaseTypeOverride(), survey);
+
+    verify(actionSvcClient, never())
+        .updateActionRule(
+            any(UUID.class), anyString(), anyString(), any(OffsetDateTime.class), anyInt());
+  }
+
+  @Test
+  public void raiseCTPExceptionIfActionPlanNotFound() throws CTPException {
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(String.format(ACTION_PLAN_NOT_FOUND_EXCEPTION, ACTION_PLAN_ID.toString()));
+
+    final Event event = new Event();
+    event.setTag(Tag.go_live.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(ACTION_PLAN_ID);
+
+    when(actionSvcClient.getActionRulesForActionPlan(ACTION_PLAN_ID)).thenReturn(null);
+
+    updater.execute(event, null, businessIndividualCaseTypeOverride, survey);
+  }
+
+  @Test
+  public void raiseCTPExceptionIfNoBSNEActionRulesFound() throws CTPException {
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(
+        String.format(NO_BSNE_ACTION_RULES_FOUND_EXCEPTION, ACTION_PLAN_ID.toString()));
+
+    final Event event = new Event();
+    event.setTag(Tag.go_live.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(ACTION_PLAN_ID);
+
+    final ActionRuleDTO actionRuleDTO = new ActionRuleDTO();
+    actionRuleDTO.setActionTypeName(ActionType.BSNL);
+    final List<ActionRuleDTO> actionRuleDTOs = Collections.singletonList(actionRuleDTO);
+
+    when(actionSvcClient.getActionRulesForActionPlan(ACTION_PLAN_ID)).thenReturn(actionRuleDTOs);
+
+    updater.execute(event, null, businessIndividualCaseTypeOverride, survey);
+  }
+
+  @Test
+  public void raiseCTPExceptionIfMultipleBSNEActionRulesFound() throws CTPException {
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(
+        String.format(MULTIPLE_ACTION_RULES_FOUND_EXCEPTION, ACTION_PLAN_ID.toString()));
+
+    final Event event = new Event();
+    event.setTag(Tag.go_live.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(ACTION_PLAN_ID);
+
+    final ActionRuleDTO actionRuleDTO1 = new ActionRuleDTO();
+    actionRuleDTO1.setActionTypeName(ActionType.BSNE);
+    final ActionRuleDTO actionRuleDTO2 = new ActionRuleDTO();
+    actionRuleDTO2.setActionTypeName(ActionType.BSNE);
+    final List<ActionRuleDTO> actionRuleDTOs = Arrays.asList(actionRuleDTO1, actionRuleDTO2);
+
+    when(actionSvcClient.getActionRulesForActionPlan(ACTION_PLAN_ID)).thenReturn(actionRuleDTOs);
+
+    updater.execute(event, null, businessIndividualCaseTypeOverride, survey);
+  }
+
+  @Test
+  public void testSuccessfullyChangeActionRule() throws CTPException {
+    final Instant eventTriggerInstant = Instant.now();
+    final Timestamp eventTriggerDate = new Timestamp(eventTriggerInstant.toEpochMilli());
+
+    final Event event = new Event();
+    event.setTag(Tag.go_live.name());
+    event.setTimestamp(eventTriggerDate);
+
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(ACTION_PLAN_ID);
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final ActionRuleDTO actionRuleDTO = new ActionRuleDTO();
+    actionRuleDTO.setId(ACTION_RULE_ID);
+    actionRuleDTO.setActionTypeName(ActionType.BSNE);
+    actionRuleDTO.setPriority(3);
+    final List<ActionRuleDTO> actionRuleDTOs = Collections.singletonList(actionRuleDTO);
+
+    when(actionSvcClient.getActionRulesForActionPlan(ACTION_PLAN_ID)).thenReturn(actionRuleDTOs);
+
+    updater.execute(event, null, businessIndividualCaseTypeOverride, survey);
+
+    verify(actionSvcClient, atLeastOnce())
+        .updateActionRule(
+            ACTION_RULE_ID,
+            actionRuleDTO.getName(),
+            actionRuleDTO.getDescription(),
+            OffsetDateTime.ofInstant(eventTriggerInstant, ZoneId.systemDefault()),
+            actionRuleDTO.getPriority());
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreatorTest.java
@@ -19,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
 import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
@@ -55,7 +56,7 @@ public class MpsActionRuleCreatorTest {
     mpsActionRuleCreator.execute(
         new Event(), new CaseTypeOverride(), new CaseTypeOverride(), survey);
     verify(actionSvcClient, times(0))
-        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
   }
 
   @Test
@@ -74,7 +75,7 @@ public class MpsActionRuleCreatorTest {
     final CaseTypeOverride bCaseTypeOverride = new CaseTypeOverride();
     mpsActionRuleCreator.execute(collectionExerciseEvent, bCaseTypeOverride, null, survey);
     verify(actionSvcClient, times(0))
-        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
   }
 
   @Test
@@ -105,7 +106,7 @@ public class MpsActionRuleCreatorTest {
     when(actionSvcClient.createActionRule(
             anyString(),
             anyString(),
-            eq("BSNL"),
+            eq(ActionType.BSNL),
             eq(eventTriggerOffsetDateTime),
             eq(3),
             eq(BUSINESS_ACTION_PLAN_ID)))
@@ -119,7 +120,7 @@ public class MpsActionRuleCreatorTest {
         .createActionRule(
             eq(SURVEY_SHORT_NAME + "NOTF"),
             eq(SURVEY_SHORT_NAME + " Notification File " + EXERCISE_REF),
-            eq("BSNL"),
+            eq(ActionType.BSNL),
             eq(eventTriggerOffsetDateTime),
             eq(3),
             eq(BUSINESS_ACTION_PLAN_ID));

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleUpdaterTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleUpdaterTest.java
@@ -1,0 +1,182 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleUpdater;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MpsActionRuleUpdaterTest {
+  private static final String MULTIPLE_ACTION_RULES_FOUND_EXCEPTION =
+      "Multiple BSNL Action Rules Found for Action Plan %s, remove all but 1 before continuing";
+  private static final String NO_BSNL_ACTION_RULES_FOUND_EXCEPTION =
+      "No BSNL Action Rules Found for Action Plan %s, please create one instead";
+  private static final String ACTION_PLAN_NOT_FOUND_EXCEPTION = "Action Plan %s not found";
+  private static final UUID ACTION_PLAN_ID = UUID.randomUUID();
+  private static final UUID ACTION_RULE_ID = UUID.randomUUID();
+  @Rule public ExpectedException thrown = ExpectedException.none();
+  @Mock private ActionSvcClient actionSvcClient;
+
+  @InjectMocks private MpsActionRuleUpdater updater;
+
+  @Test
+  public void isAnActionRuleUpdater() {
+    assertThat(updater, instanceOf(ActionRuleUpdater.class));
+  }
+
+  @Test
+  public void doNothingIfNotBusinessSurveyEvent() throws CTPException {
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Social);
+
+    updater.execute(new Event(), new CaseTypeOverride(), new CaseTypeOverride(), survey);
+    verify(actionSvcClient, never())
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void doNothingIfNotMps() throws CTPException {
+    final Event event = new Event();
+    event.setTag(Tag.go_live.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    updater.execute(event, new CaseTypeOverride(), null, survey);
+
+    verify(actionSvcClient, never())
+        .updateActionRule(
+            any(UUID.class), anyString(), anyString(), any(OffsetDateTime.class), anyInt());
+  }
+
+  @Test
+  public void raiseCTPExceptionIfActionPlanNotFound() throws CTPException {
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(String.format(ACTION_PLAN_NOT_FOUND_EXCEPTION, ACTION_PLAN_ID.toString()));
+
+    final Event event = new Event();
+    event.setTag(Tag.mps.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    businessCaseTypeOverride.setActionPlanId(ACTION_PLAN_ID);
+
+    when(actionSvcClient.getActionRulesForActionPlan(ACTION_PLAN_ID)).thenReturn(null);
+
+    updater.execute(event, businessCaseTypeOverride, null, survey);
+  }
+
+  @Test
+  public void raiseCTPExceptionIfNoBSNLActionRulesFound() throws CTPException {
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(
+        String.format(NO_BSNL_ACTION_RULES_FOUND_EXCEPTION, ACTION_PLAN_ID.toString()));
+
+    final Event event = new Event();
+    event.setTag(Tag.mps.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    businessCaseTypeOverride.setActionPlanId(ACTION_PLAN_ID);
+
+    final ActionRuleDTO actionRuleDTO = new ActionRuleDTO();
+    actionRuleDTO.setActionTypeName(ActionType.BSNE);
+    final List<ActionRuleDTO> actionRuleDTOs = Collections.singletonList(actionRuleDTO);
+
+    when(actionSvcClient.getActionRulesForActionPlan(ACTION_PLAN_ID)).thenReturn(actionRuleDTOs);
+
+    updater.execute(event, businessCaseTypeOverride, null, survey);
+  }
+
+  @Test
+  public void raiseCTPExceptionIfMultipleBSNLActionRulesFound() throws CTPException {
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(
+        String.format(MULTIPLE_ACTION_RULES_FOUND_EXCEPTION, ACTION_PLAN_ID.toString()));
+
+    final Event event = new Event();
+    event.setTag(Tag.mps.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    businessCaseTypeOverride.setActionPlanId(ACTION_PLAN_ID);
+
+    final ActionRuleDTO actionRuleDTO1 = new ActionRuleDTO();
+    actionRuleDTO1.setActionTypeName(ActionType.BSNL);
+    final ActionRuleDTO actionRuleDTO2 = new ActionRuleDTO();
+    actionRuleDTO2.setActionTypeName(ActionType.BSNL);
+    final List<ActionRuleDTO> actionRuleDTOs = Arrays.asList(actionRuleDTO1, actionRuleDTO2);
+
+    when(actionSvcClient.getActionRulesForActionPlan(ACTION_PLAN_ID)).thenReturn(actionRuleDTOs);
+
+    updater.execute(event, businessCaseTypeOverride, null, survey);
+  }
+
+  @Test
+  public void testSuccessfullyChangeActionRule() throws CTPException {
+    final Instant eventTriggerInstant = Instant.now();
+    final Timestamp eventTriggerDate = new Timestamp(eventTriggerInstant.toEpochMilli());
+
+    final Event event = new Event();
+    event.setTag(Tag.mps.name());
+    event.setTimestamp(eventTriggerDate);
+
+    final CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    businessCaseTypeOverride.setActionPlanId(ACTION_PLAN_ID);
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final ActionRuleDTO actionRuleDTO = new ActionRuleDTO();
+    actionRuleDTO.setId(ACTION_RULE_ID);
+    actionRuleDTO.setActionTypeName(ActionType.BSNL);
+    actionRuleDTO.setPriority(3);
+    final List<ActionRuleDTO> actionRuleDTOs = Collections.singletonList(actionRuleDTO);
+
+    when(actionSvcClient.getActionRulesForActionPlan(ACTION_PLAN_ID)).thenReturn(actionRuleDTOs);
+
+    updater.execute(event, businessCaseTypeOverride, null, survey);
+
+    verify(actionSvcClient, atLeastOnce())
+        .updateActionRule(
+            ACTION_RULE_ID,
+            actionRuleDTO.getName(),
+            actionRuleDTO.getDescription(),
+            OffsetDateTime.ofInstant(eventTriggerInstant, ZoneId.systemDefault()),
+            actionRuleDTO.getPriority());
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreatorTest.java
@@ -6,9 +6,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -19,8 +17,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
 import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
@@ -41,6 +41,7 @@ public class ReminderActionRuleCreatorTest {
   private static final int EXERCISE_PK = 6433;
   @Mock private ActionSvcClient actionSvcClient;
   @Mock private CaseTypeOverrideRepository caseTypeOverrideRepo;
+  @Spy private ReminderSuffixGenerator reminderSuffix;
   @InjectMocks private ReminderActionRuleCreator reminderActionRuleCreator;
 
   @Test
@@ -56,7 +57,7 @@ public class ReminderActionRuleCreatorTest {
     reminderActionRuleCreator.execute(
         new Event(), new CaseTypeOverride(), new CaseTypeOverride(), survey);
     verify(actionSvcClient, times(0))
-        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
   }
 
   @Test
@@ -74,7 +75,7 @@ public class ReminderActionRuleCreatorTest {
     reminderActionRuleCreator.execute(
         collectionExerciseEvent, new CaseTypeOverride(), new CaseTypeOverride(), survey);
     verify(actionSvcClient, times(0))
-        .createActionRule(anyString(), anyString(), anyString(), any(), anyInt(), any());
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
   }
 
   @Test
@@ -146,7 +147,7 @@ public class ReminderActionRuleCreatorTest {
     when(actionSvcClient.createActionRule(
             anyString(),
             anyString(),
-            eq("BSRE"),
+            eq(ActionType.BSRE),
             eq(eventTriggerOffsetDateTime),
             eq(3),
             eq(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID)))
@@ -154,7 +155,7 @@ public class ReminderActionRuleCreatorTest {
     when(actionSvcClient.createActionRule(
             anyString(),
             anyString(),
-            eq("BSRL"),
+            eq(ActionType.BSRL),
             eq(eventTriggerOffsetDateTime),
             eq(3),
             eq(BUSINESS_ACTION_PLAN_ID)))
@@ -172,7 +173,7 @@ public class ReminderActionRuleCreatorTest {
         .createActionRule(
             eq(SURVEY_SHORT_NAME + "REME" + suffixNumber),
             eq(SURVEY_SHORT_NAME + " Reminder Email " + EXERCISE_REF),
-            eq("BSRE"),
+            eq(ActionType.BSRE),
             eq(eventTriggerOffsetDateTime),
             eq(3),
             eq(BUSINESS_INDIVIDUAL_ACTION_PLAN_ID));
@@ -180,7 +181,7 @@ public class ReminderActionRuleCreatorTest {
         .createActionRule(
             eq(SURVEY_SHORT_NAME + "REMF" + suffixNumber),
             eq(SURVEY_SHORT_NAME + " Reminder File " + EXERCISE_REF),
-            eq("BSRL"),
+            eq(ActionType.BSRL),
             eq(eventTriggerOffsetDateTime),
             eq(3),
             eq(BUSINESS_ACTION_PLAN_ID));

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleUpdaterTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleUpdaterTest.java
@@ -1,0 +1,388 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
+import uk.gov.ons.ctp.response.action.representation.ActionType;
+import uk.gov.ons.ctp.response.collection.exercise.client.ActionSvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeOverride;
+import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
+import uk.gov.ons.ctp.response.collection.exercise.service.ActionRuleUpdater;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+import uk.gov.ons.response.survey.representation.SurveyDTO;
+import uk.gov.ons.response.survey.representation.SurveyDTO.SurveyType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReminderActionRuleUpdaterTest {
+  private static final String MULTIPLE_BSRE_ACTION_RULES_FOUND_EXCEPTION =
+      "Multiple BSRE Action Rules Found for Action Plan %s, remove all but 1 before continuing";
+  private static final String MULTIPLE_BSRL_ACTION_RULES_FOUND_EXCEPTION =
+      "Multiple BSRL Action Rules Found for Action Plan %s, remove all but 1 before continuing";
+  private static final String ACTION_PLAN_NOT_FOUND_EXCEPTION = "Action Plan %s not found";
+  private static final UUID ACTION_PLAN_ID =
+      UUID.fromString("31cbf9ee-4c56-4a81-958b-4b952fc5cc2d");
+  private static final String NO_BSRE_ACTION_RULES_FOUND_EXCEPTION =
+      "No BSRE Action Rules Found for Action Plan %s, please create one instead";
+  private static final String NO_BSRL_ACTION_RULES_FOUND_EXCEPTION =
+      "No BSRL Action Rules Found for Action Plan %s, please create one instead";
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+  @Mock private ActionSvcClient actionSvcClient;
+
+  @Spy private ReminderSuffixGenerator reminderSuffixGenerator;
+
+  @InjectMocks private ReminderActionRuleUpdater updater;
+
+  @Test
+  public void isAnActionRuleUpdater() {
+    assertThat(updater, instanceOf(ActionRuleUpdater.class));
+  }
+
+  @Test
+  public void doNothingIfNotBusinessSurveyEvent() throws CTPException {
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Social);
+
+    updater.execute(new Event(), new CaseTypeOverride(), new CaseTypeOverride(), survey);
+    verify(actionSvcClient, times(0))
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void doNothingIfNotReminder() throws CTPException {
+    final Event event = new Event();
+    event.setTag(Tag.employment.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    updater.execute(event, null, new CaseTypeOverride(), survey);
+
+    verify(actionSvcClient, never())
+        .updateActionRule(
+            any(UUID.class), anyString(), anyString(), any(OffsetDateTime.class), anyInt());
+  }
+
+  @Test
+  public void raiseCTPExceptionIfNoActionPlanFound() throws CTPException {
+    final Event event = new Event();
+    event.setTag(Tag.reminder.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(ACTION_PLAN_ID);
+
+    when(actionSvcClient.getActionRulesForActionPlan(ACTION_PLAN_ID)).thenReturn(null);
+
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(String.format(ACTION_PLAN_NOT_FOUND_EXCEPTION, ACTION_PLAN_ID.toString()));
+
+    updater.execute(event, null, businessIndividualCaseTypeOverride, survey);
+  }
+
+  @Test
+  public void raiseCTPExceptionNoBSREActionRulesFound() throws CTPException {
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(
+        String.format(NO_BSRE_ACTION_RULES_FOUND_EXCEPTION, ACTION_PLAN_ID.toString()));
+
+    final Event event = new Event();
+    event.setTag(Tag.reminder.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(ACTION_PLAN_ID);
+
+    final ActionRuleDTO actionRuleDTO = createActionRuleDTO(null, ActionType.BSRL, "+1");
+    final List<ActionRuleDTO> actionRuleDTOs = Collections.singletonList(actionRuleDTO);
+
+    when(actionSvcClient.getActionRulesForActionPlan(ACTION_PLAN_ID)).thenReturn(actionRuleDTOs);
+
+    updater.execute(event, null, businessIndividualCaseTypeOverride, survey);
+  }
+
+  @Test
+  public void raiseCTPExceptionNoBSRLActionRulesFound() throws CTPException {
+
+    final Event event = new Event();
+    event.setTag(Tag.reminder.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride bCaseTypeOverride = new CaseTypeOverride();
+    final UUID bActionPlanId = UUID.fromString("2346ddba-db99-4265-8d11-edbaa462e6a6");
+    bCaseTypeOverride.setActionPlanId(bActionPlanId);
+    final List<ActionRuleDTO> bActionRuleDTOs = new ArrayList<>();
+    when(actionSvcClient.getActionRulesForActionPlan(bActionPlanId)).thenReturn(bActionRuleDTOs);
+
+    final CaseTypeOverride biCaseTypeOverride = new CaseTypeOverride();
+    final UUID biActionPlanId = ACTION_PLAN_ID;
+    biCaseTypeOverride.setActionPlanId(biActionPlanId);
+
+    final ActionRuleDTO actionRuleDTO = createActionRuleDTO(null, ActionType.BSRE, "+1");
+    final List<ActionRuleDTO> biActionRuleDTOs = Collections.singletonList(actionRuleDTO);
+    when(actionSvcClient.getActionRulesForActionPlan(biActionPlanId)).thenReturn(biActionRuleDTOs);
+
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(
+        String.format(NO_BSRL_ACTION_RULES_FOUND_EXCEPTION, bActionPlanId.toString()));
+
+    updater.execute(event, bCaseTypeOverride, biCaseTypeOverride, survey);
+  }
+
+  @Test
+  public void raiseCTPExceptionNoBSRLOrBSREActionRulesFound() throws CTPException {
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(
+        String.format(NO_BSRE_ACTION_RULES_FOUND_EXCEPTION, ACTION_PLAN_ID.toString()));
+
+    final Event event = new Event();
+    event.setTag(Tag.reminder.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(ACTION_PLAN_ID);
+
+    final ActionRuleDTO actionRuleDTO = createActionRuleDTO(null, ActionType.SOCIALNOT, "+44");
+    final List<ActionRuleDTO> actionRuleDTOs = Collections.singletonList(actionRuleDTO);
+
+    when(actionSvcClient.getActionRulesForActionPlan(ACTION_PLAN_ID)).thenReturn(actionRuleDTOs);
+
+    updater.execute(event, null, businessIndividualCaseTypeOverride, survey);
+  }
+
+  @Test
+  public void raiseCTPExceptionWhenMoreThanOneBSREActionRuleFound() throws CTPException {
+    final UUID bsrlActionPlanId = UUID.fromString("a1dbb1c9-1ae0-45ec-9e09-3ef70be7d3d9");
+    final UUID bsreActionPlanId = UUID.fromString("3e1bc645-d37f-4055-8d27-4a4f02a7602a");
+
+    final Event event = new Event();
+    event.setTag(Tag.reminder.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(bsreActionPlanId);
+
+    final ActionRuleDTO bsreActionRule1 = createActionRuleDTO(null, ActionType.BSRE, "+1");
+    final ActionRuleDTO bsreActionRule2 = createActionRuleDTO(null, ActionType.BSRE, "+1");
+
+    final List<ActionRuleDTO> bsreDtos = Arrays.asList(bsreActionRule1, bsreActionRule2);
+    when(actionSvcClient.getActionRulesForActionPlan(bsreActionPlanId)).thenReturn(bsreDtos);
+
+    final CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    businessCaseTypeOverride.setActionPlanId(bsrlActionPlanId);
+
+    final ActionRuleDTO bsrlActionRule1 = new ActionRuleDTO();
+    bsrlActionRule1.setActionTypeName(ActionType.BSRL);
+    bsrlActionRule1.setName("+1");
+    final List<ActionRuleDTO> bsrlDtos = Arrays.asList(bsrlActionRule1);
+    when(actionSvcClient.getActionRulesForActionPlan(bsrlActionPlanId)).thenReturn(bsrlDtos);
+
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(
+        String.format(MULTIPLE_BSRE_ACTION_RULES_FOUND_EXCEPTION, bsreActionPlanId));
+
+    updater.execute(event, businessCaseTypeOverride, businessIndividualCaseTypeOverride, survey);
+  }
+
+  @Test
+  public void raiseCTPExceptionWhenMoreThanOneBSRLActionRuleFound() throws CTPException {
+    final UUID bsrlActionPlanId = UUID.fromString("5df76355-f167-4fa8-8e11-e07d67bde5ad");
+    final UUID bsreActionPlanId = UUID.fromString("a7c10382-d069-42cb-b3d4-63a3392dab04");
+
+    thrown.expect(CTPException.class);
+    thrown.expectMessage(
+        String.format(String.format(MULTIPLE_BSRL_ACTION_RULES_FOUND_EXCEPTION, bsrlActionPlanId)));
+
+    final Event event = new Event();
+    event.setTag(Tag.reminder.name());
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(bsreActionPlanId);
+
+    final CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    businessCaseTypeOverride.setActionPlanId(bsrlActionPlanId);
+
+    final ActionRuleDTO bsreActionRule = createActionRuleDTO(null, ActionType.BSRE, "+1");
+    final List<ActionRuleDTO> bsreDtos = Collections.singletonList(bsreActionRule);
+    when(actionSvcClient.getActionRulesForActionPlan(bsreActionPlanId)).thenReturn(bsreDtos);
+
+    final ActionRuleDTO bsrlActionRule1 = createActionRuleDTO(null, ActionType.BSRL, "+1");
+    final ActionRuleDTO bsrlActionRule2 = createActionRuleDTO(null, ActionType.BSRL, "+1");
+    final List<ActionRuleDTO> bsrlDtos = Arrays.asList(bsrlActionRule1, bsrlActionRule2);
+    when(actionSvcClient.getActionRulesForActionPlan(bsrlActionPlanId)).thenReturn(bsrlDtos);
+
+    updater.execute(event, businessCaseTypeOverride, businessIndividualCaseTypeOverride, survey);
+  }
+
+  @Test
+  public void testActionRulesUpdatedForReminder() throws CTPException {
+    testReminderTagUpdatesActionRules(Tag.reminder);
+  }
+
+  @Test
+  public void testActionRulesUpdatedForReminder2() throws CTPException {
+    testReminderTagUpdatesActionRules(Tag.reminder2);
+  }
+
+  @Test
+  public void testActionRulesUpdatedForReminder3() throws CTPException {
+    testReminderTagUpdatesActionRules(Tag.reminder3);
+  }
+
+  private void testReminderTagUpdatesActionRules(final Tag tag) throws CTPException {
+    final Instant eventTriggerInstant = Instant.now();
+    final Timestamp eventTriggerDate = new Timestamp(eventTriggerInstant.toEpochMilli());
+
+    final Event event = new Event();
+    event.setTag(tag.name());
+    event.setTimestamp(eventTriggerDate);
+
+    final UUID bActionPlanId = UUID.fromString("29f312e4-fe2e-4042-97c6-98e7d48cacfa");
+    final CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    businessCaseTypeOverride.setActionPlanId(bActionPlanId);
+
+    final UUID biActionPlanId = UUID.fromString("1795efdf-9961-40eb-b22a-db4b3612c1f3");
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(biActionPlanId);
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+
+    final String actionRuleSuffix = reminderSuffixGenerator.getReminderSuffix(tag.name());
+    final UUID actionRuleId1 = UUID.fromString("7186077b-809f-46c7-a0ba-43139d3efa23");
+    final ActionRuleDTO actionRuleDTO1 =
+        createActionRuleDTO(actionRuleId1, ActionType.BSRE, actionRuleSuffix);
+    final List<ActionRuleDTO> biActionRules = Arrays.asList(actionRuleDTO1);
+    when(actionSvcClient.getActionRulesForActionPlan(biActionPlanId)).thenReturn(biActionRules);
+
+    final UUID actionRuleId2 = UUID.fromString("012cda1e-916a-4182-8d9a-cc66e32f8860");
+    final ActionRuleDTO actionRuleDTO2 =
+        createActionRuleDTO(actionRuleId2, ActionType.BSRL, actionRuleSuffix);
+    final List<ActionRuleDTO> bActionRuleDTOs = Arrays.asList(actionRuleDTO2);
+    when(actionSvcClient.getActionRulesForActionPlan(bActionPlanId)).thenReturn(bActionRuleDTOs);
+
+    updater.execute(event, businessCaseTypeOverride, businessIndividualCaseTypeOverride, survey);
+
+    verify(actionSvcClient, atLeastOnce())
+        .updateActionRule(
+            actionRuleId1,
+            actionRuleDTO1.getName(),
+            actionRuleDTO1.getDescription(),
+            OffsetDateTime.ofInstant(eventTriggerInstant, ZoneId.systemDefault()),
+            actionRuleDTO1.getPriority());
+    verify(actionSvcClient, atLeastOnce())
+        .updateActionRule(
+            actionRuleId2,
+            actionRuleDTO2.getName(),
+            actionRuleDTO2.getDescription(),
+            OffsetDateTime.ofInstant(eventTriggerInstant, ZoneId.systemDefault()),
+            actionRuleDTO2.getPriority());
+  }
+
+  @Test
+  public void rulesForOtherRemindersOtherThanTheCurrentTagShouldNotBeUpdated() throws CTPException {
+    final Instant eventTriggerInstant = Instant.now();
+    final Timestamp eventTriggerDate = new Timestamp(eventTriggerInstant.toEpochMilli());
+
+    final Event event = new Event();
+    event.setTag(Tag.reminder.name());
+    event.setTimestamp(eventTriggerDate);
+
+    final UUID bActionPlanId = UUID.fromString("29f312e4-fe2e-4042-97c6-98e7d48cacfa");
+    final CaseTypeOverride businessCaseTypeOverride = new CaseTypeOverride();
+    businessCaseTypeOverride.setActionPlanId(bActionPlanId);
+
+    final UUID biActionPlanId = UUID.fromString("1795efdf-9961-40eb-b22a-db4b3612c1f3");
+    final CaseTypeOverride businessIndividualCaseTypeOverride = new CaseTypeOverride();
+    businessIndividualCaseTypeOverride.setActionPlanId(biActionPlanId);
+
+    final SurveyDTO survey = new SurveyDTO();
+    survey.setSurveyType(SurveyType.Business);
+    survey.setShortName("QBS");
+
+    final UUID actionRuleId1 = UUID.fromString("7186077b-809f-46c7-a0ba-43139d3efa23");
+    final ActionRuleDTO actionRuleDTO1 =
+        createActionRuleDTO(actionRuleId1, ActionType.BSRE, "QBSREME+1");
+    final UUID actionRuleId2 = UUID.fromString("14639bd2-b569-4611-b42e-f20448d40272");
+    final ActionRuleDTO actionRuleDTO2 =
+        createActionRuleDTO(actionRuleId2, ActionType.BSRE, "QBSREME+3");
+    final List<ActionRuleDTO> biActionRules = Arrays.asList(actionRuleDTO1, actionRuleDTO2);
+    when(actionSvcClient.getActionRulesForActionPlan(biActionPlanId)).thenReturn(biActionRules);
+
+    final UUID actionRuleId3 = UUID.fromString("50acbf7c-ffbd-4428-b200-5cf62b4de99a");
+    final ActionRuleDTO actionRuleDTO3 =
+        createActionRuleDTO(actionRuleId3, ActionType.BSRL, "QBSREMF+1");
+    final UUID actionRuleId4 = UUID.fromString("ef3bf58b-18f7-4697-afe5-46a236256dc7");
+    final ActionRuleDTO actionRuleDTO4 =
+        createActionRuleDTO(actionRuleId4, ActionType.BSRL, "QBSREMF+2");
+    final List<ActionRuleDTO> bActionRuleDTOs = Arrays.asList(actionRuleDTO3, actionRuleDTO4);
+    when(actionSvcClient.getActionRulesForActionPlan(bActionPlanId)).thenReturn(bActionRuleDTOs);
+
+    updater.execute(event, businessCaseTypeOverride, businessIndividualCaseTypeOverride, survey);
+
+    verify(actionSvcClient, atLeastOnce())
+        .updateActionRule(
+            actionRuleId1,
+            actionRuleDTO1.getName(),
+            actionRuleDTO1.getDescription(),
+            OffsetDateTime.ofInstant(eventTriggerInstant, ZoneId.systemDefault()),
+            actionRuleDTO1.getPriority());
+
+    verify(actionSvcClient, times(0))
+        .updateActionRule(eq(actionRuleId2), anyString(), anyString(), any(), anyInt());
+
+    verify(actionSvcClient, atLeastOnce())
+        .updateActionRule(
+            actionRuleId3,
+            actionRuleDTO3.getName(),
+            actionRuleDTO3.getDescription(),
+            OffsetDateTime.ofInstant(eventTriggerInstant, ZoneId.systemDefault()),
+            actionRuleDTO3.getPriority());
+
+    verify(actionSvcClient, never())
+        .updateActionRule(eq(actionRuleId4), anyString(), anyString(), any(), anyInt());
+  }
+
+  private ActionRuleDTO createActionRuleDTO(
+      final UUID actionRuleId, final ActionType actionRuleType, final String actionRuleName) {
+    final ActionRuleDTO actionRuleDTO = new ActionRuleDTO();
+    actionRuleDTO.setId(actionRuleId);
+    actionRuleDTO.setActionTypeName(actionRuleType);
+    actionRuleDTO.setName(actionRuleName);
+    actionRuleDTO.setPriority(3);
+    return actionRuleDTO;
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderSuffixGeneratorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderSuffixGeneratorTest.java
@@ -1,0 +1,36 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.impl.actionrule;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReminderSuffixGeneratorTest {
+
+  @InjectMocks private ReminderSuffixGenerator reminderSuffix;
+
+  @Test
+  public void testReminders1ReturnsPlusOne() {
+    assertThat(reminderSuffix.getReminderSuffix(Tag.reminder.name()), is("+1"));
+  }
+
+  @Test
+  public void testReminders2ReturnsPlusTwo() {
+    assertThat(reminderSuffix.getReminderSuffix(Tag.reminder2.name()), is("+2"));
+  }
+
+  @Test
+  public void testReminders3ReturnsPlusThree() {
+    assertThat(reminderSuffix.getReminderSuffix(Tag.reminder3.name()), is("+3"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void onlyRemindersAreSupported() {
+    reminderSuffix.getReminderSuffix(Tag.go_live.name());
+  }
+}


### PR DESCRIPTION
# Motivation and Context
Currently the action rules for the matching events do not get updated
when event dates get updated.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
This PR adds the logic to update action rules for all business survey events.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Use UI to update mps or go_live events datetime and see the matching action rule trigger datetime get updated as well in the actionrule table.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/r79j0Xlg/125-tbl123-link-action-rules-to-action-plans-at-create-time-update