### PR TITLE
Add client to get action plans by their selectors

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
@@ -4,6 +4,7 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
 import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
@@ -23,8 +24,16 @@ public interface ActionSvcClient {
   ActionPlanDTO createActionPlan(String name, String description, HashMap<String, String> selectors)
       throws RestClientException;
 
+  /**
+   * Request list of action plans with given selectors
+   *
+   * @param collectionExerciseId collectionExerciseId to find action plans for
+   * @param activeEnrolment boolean for if sample unit has an active enrolment associated with it
+   * @return List<ActionPlanDTO> representation of the created action plan
+   * @throws HttpClientErrorException for failure to retrieve action plans
+   */
   List<ActionPlanDTO> getActionPlansBySelectors(
-      String collectionExerciseId, Boolean activeEnrolment) throws RestClientException;
+      String collectionExerciseId, Boolean activeEnrolment) throws HttpClientErrorException;
 
   /**
    * Request action rule is created.

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
@@ -24,7 +24,7 @@ public interface ActionSvcClient {
       throws RestClientException;
 
   List<ActionPlanDTO> getActionPlansBySelectors(
-      String surveyRef, String exerciseRef, Boolean activeEnrolment) throws RestClientException;
+      String collectionExerciseId, Boolean activeEnrolment) throws RestClientException;
 
   /**
    * Request action rule is created.

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
@@ -4,7 +4,6 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
 import uk.gov.ons.ctp.response.action.representation.ActionRuleDTO;
@@ -30,10 +29,9 @@ public interface ActionSvcClient {
    * @param collectionExerciseId collectionExerciseId to find action plans for
    * @param activeEnrolment boolean for if sample unit has an active enrolment associated with it
    * @return List<ActionPlanDTO> representation of the created action plan
-   * @throws HttpClientErrorException for failure to retrieve action plans
    */
   List<ActionPlanDTO> getActionPlansBySelectors(
-      String collectionExerciseId, Boolean activeEnrolment) throws HttpClientErrorException;
+      String collectionExerciseId, Boolean activeEnrolment);
 
   /**
    * Request action rule is created.

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/ActionSvcClient.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.response.collection.exercise.client;
 
 import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.web.client.RestClientException;
 import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
@@ -21,6 +22,9 @@ public interface ActionSvcClient {
    */
   ActionPlanDTO createActionPlan(String name, String description, HashMap<String, String> selectors)
       throws RestClientException;
+
+  List<ActionPlanDTO> getActionPlansBySelectors(
+      String surveyRef, String exerciseRef, Boolean activeEnrolment) throws RestClientException;
 
   /**
    * Request action rule is created.

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -2,14 +2,20 @@ package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 
 import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
@@ -73,6 +79,44 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
         "Successfully posted to action service to create action plan, ActionPlanId: {}",
         createdActionPlan.getId());
     return createdActionPlan;
+  }
+
+  @Retryable(
+      value = {RestClientException.class},
+      maxAttemptsExpression = "#{${retries.maxAttempts}}",
+      backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
+  @Override
+  public List<ActionPlanDTO> getActionPlansBySelectors(
+      final String surveyRef, final String exerciseRef, final Boolean activeEnrolment)
+      throws RestClientException {
+    log.debug(
+        "Retrieving action plan for selectors, "
+            + "surveyRef: {}, exerciseRef: {}, activeEnrolment: {}",
+        surveyRef,
+        exerciseRef,
+        activeEnrolment);
+
+    MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+    queryParams.add("surveyRef", surveyRef);
+    queryParams.add("exerciseRef", exerciseRef);
+    queryParams.add("activeEnrolment", activeEnrolment.toString());
+    UriComponents uriComponents =
+        restUtility.createUriComponents(appConfig.getActionSvc().getActionPlansPath(), queryParams);
+
+    ResponseEntity<List<ActionPlanDTO>> responseEntity =
+        restTemplate.exchange(
+            uriComponents.toString(),
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<List<ActionPlanDTO>>() {});
+
+    log.debug(
+        "Successfully retrieved action plan for selectors, "
+            + "surveyRef: {}, exerciseRef: {}, activeEnrolment: {}",
+        surveyRef,
+        exerciseRef,
+        activeEnrolment);
+    return responseEntity.getBody();
   }
 
   @Override

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -87,18 +87,16 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
   public List<ActionPlanDTO> getActionPlansBySelectors(
-      final String surveyRef, final String exerciseRef, final Boolean activeEnrolment)
+      final String collectionExerciseId, final Boolean activeEnrolment)
       throws RestClientException {
     log.debug(
         "Retrieving action plan for selectors, "
-            + "surveyRef: {}, exerciseRef: {}, activeEnrolment: {}",
-        surveyRef,
-        exerciseRef,
+            + "collectionExerciseId: {}, activeEnrolment: {}",
+        collectionExerciseId,
         activeEnrolment);
 
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
-    queryParams.add("surveyRef", surveyRef);
-    queryParams.add("exerciseRef", exerciseRef);
+    queryParams.add("collectionExericseId", collectionExerciseId);
     queryParams.add("activeEnrolment", activeEnrolment.toString());
     UriComponents uriComponents =
         restUtility.createUriComponents(appConfig.getActionSvc().getActionPlansPath(), queryParams);
@@ -112,9 +110,8 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
 
     log.debug(
         "Successfully retrieved action plan for selectors, "
-            + "surveyRef: {}, exerciseRef: {}, activeEnrolment: {}",
-        surveyRef,
-        exerciseRef,
+            + "collectionExerciseId: {}, activeEnrolment: {}",
+        collectionExerciseId,
         activeEnrolment);
     return responseEntity.getBody();
   }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -10,12 +10,14 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
@@ -87,7 +89,8 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
   public List<ActionPlanDTO> getActionPlansBySelectors(
-      final String collectionExerciseId, final Boolean activeEnrolment) throws RestClientException {
+      final String collectionExerciseId, final Boolean activeEnrolment)
+    throws HttpClientErrorException {
     log.debug(
         "Retrieving action plan for selectors, " + "collectionExerciseId: {}, activeEnrolment: {}",
         collectionExerciseId,
@@ -99,12 +102,21 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
     UriComponents uriComponents =
         restUtility.createUriComponents(appConfig.getActionSvc().getActionPlansPath(), queryParams);
 
-    ResponseEntity<List<ActionPlanDTO>> responseEntity =
+    ResponseEntity<List<ActionPlanDTO>> responseEntity;
+    try {
+      responseEntity =
         restTemplate.exchange(
-            uriComponents.toString(),
-            HttpMethod.GET,
-            null,
-            new ParameterizedTypeReference<List<ActionPlanDTO>>() {});
+          uriComponents.toString(),
+          HttpMethod.GET,
+          null,
+          new ParameterizedTypeReference<List<ActionPlanDTO>>() {
+          });
+    } catch (HttpClientErrorException e) {
+      if (e.getStatusCode() ==  HttpStatus.NOT_FOUND) {
+        return null;
+      }
+      throw e;
+    }
 
     log.debug(
         "Successfully retrieved action plan for selectors, "

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -90,7 +90,7 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
   @Override
   public List<ActionPlanDTO> getActionPlansBySelectors(
       final String collectionExerciseId, final Boolean activeEnrolment)
-    throws HttpClientErrorException {
+      throws HttpClientErrorException {
     log.debug(
         "Retrieving action plan for selectors, " + "collectionExerciseId: {}, activeEnrolment: {}",
         collectionExerciseId,
@@ -105,14 +105,13 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
     ResponseEntity<List<ActionPlanDTO>> responseEntity;
     try {
       responseEntity =
-        restTemplate.exchange(
-          uriComponents.toString(),
-          HttpMethod.GET,
-          null,
-          new ParameterizedTypeReference<List<ActionPlanDTO>>() {
-          });
+          restTemplate.exchange(
+              uriComponents.toString(),
+              HttpMethod.GET,
+              null,
+              new ParameterizedTypeReference<List<ActionPlanDTO>>() {});
     } catch (HttpClientErrorException e) {
-      if (e.getStatusCode() ==  HttpStatus.NOT_FOUND) {
+      if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
         return null;
       }
       throw e;

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -94,7 +94,7 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
         activeEnrolment);
 
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
-    queryParams.add("collectionExericseId", collectionExerciseId);
+    queryParams.add("collectionExerciseId", collectionExerciseId);
     queryParams.add("activeEnrolment", activeEnrolment.toString());
     UriComponents uriComponents =
         restUtility.createUriComponents(appConfig.getActionSvc().getActionPlansPath(), queryParams);

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -89,8 +89,7 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
   public List<ActionPlanDTO> getActionPlansBySelectors(
-      final String collectionExerciseId, final Boolean activeEnrolment)
-      throws HttpClientErrorException {
+      final String collectionExerciseId, final Boolean activeEnrolment) {
     log.debug(
         "Retrieving action plan for selectors, " + "collectionExerciseId: {}, activeEnrolment: {}",
         collectionExerciseId,

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -87,11 +87,9 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
   @Override
   public List<ActionPlanDTO> getActionPlansBySelectors(
-      final String collectionExerciseId, final Boolean activeEnrolment)
-      throws RestClientException {
+      final String collectionExerciseId, final Boolean activeEnrolment) throws RestClientException {
     log.debug(
-        "Retrieving action plan for selectors, "
-            + "collectionExerciseId: {}, activeEnrolment: {}",
+        "Retrieving action plan for selectors, " + "collectionExerciseId: {}, activeEnrolment: {}",
         collectionExerciseId,
         activeEnrolment);
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImplTest.java
@@ -36,7 +36,7 @@ public class ActionSvcRestClientImplTest {
 
   private static final String COLLECTION_EXERCISE_ID = "14fb3e68-4dca-46db-bf49-04b84e07e77c";
 
-  @Spy RestUtility restUtility = new RestUtility(RestUtilityConfig.builder().build());
+  @Spy private RestUtility restUtility = new RestUtility(RestUtilityConfig.builder().build());
 
   @Mock private RestTemplate restTemplate;
 
@@ -45,11 +45,9 @@ public class ActionSvcRestClientImplTest {
   @InjectMocks private ActionSvcRestClientImpl actionSvcRestClient;
 
   private ResponseEntity<List<ActionPlanDTO>> responseEntity;
-  private ResponseEntity<List<ActionPlanDTO>> responseEntity404;
-  private ResponseEntity<List<ActionPlanDTO>> responseEntityFail;
 
   @Before
-  public void setup() {
+  public void setUp() {
     ActionPlanDTO actionPlan = new ActionPlanDTO();
     actionPlan.setName("Test");
     actionPlan.setId(UUID.fromString("14fb3e68-4dca-46db-bf49-04b84e07e77c"));
@@ -61,8 +59,6 @@ public class ActionSvcRestClientImplTest {
     actionPlans.add(actionPlan);
 
     responseEntity = new ResponseEntity(actionPlans, HttpStatus.OK);
-    responseEntity404 = new ResponseEntity(HttpStatus.NOT_FOUND);
-    responseEntityFail = new ResponseEntity(HttpStatus.BAD_REQUEST);
 
     MockitoAnnotations.initMocks(this);
   }
@@ -79,7 +75,7 @@ public class ActionSvcRestClientImplTest {
             eq(HttpMethod.GET),
             eq(null),
             eq(new ParameterizedTypeReference<List<ActionPlanDTO>>() {})))
-        .thenReturn(responseEntityFail);
+        .thenReturn(responseEntity);
 
     // When
     actionSvcRestClient.getActionPlansBySelectors(COLLECTION_EXERCISE_ID, false);
@@ -112,7 +108,7 @@ public class ActionSvcRestClientImplTest {
     List<ActionPlanDTO> actionPlanDTOs =
         actionSvcRestClient.getActionPlansBySelectors(COLLECTION_EXERCISE_ID, false);
 
-    // Then call is made to correct url
+    // Then Null is returned
     assertNull(actionPlanDTOs);
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImplTest.java
@@ -1,0 +1,90 @@
+package uk.gov.ons.ctp.response.collection.exercise.client.impl;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.ons.ctp.common.rest.RestUtility;
+import uk.gov.ons.ctp.common.rest.RestUtilityConfig;
+import uk.gov.ons.ctp.response.action.representation.ActionPlanDTO;
+import uk.gov.ons.ctp.response.collection.exercise.config.ActionSvc;
+import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ActionSvcRestClientImplTest {
+
+  private static final String COLLECTION_EXERCISE_ID = "14fb3e68-4dca-46db-bf49-04b84e07e77c";
+
+  @Spy RestUtility restUtility = new RestUtility(RestUtilityConfig.builder().build());
+
+  @Mock private RestTemplate restTemplate;
+
+  @Mock private AppConfig appConfig;
+
+  @InjectMocks private ActionSvcRestClientImpl actionSvcRestClient;
+
+  private ResponseEntity<List<ActionPlanDTO>> responseEntity;
+
+  @Before
+  public void setup() {
+    ActionPlanDTO actionPlan = new ActionPlanDTO();
+    actionPlan.setName("Test");
+    actionPlan.setId(UUID.fromString("14fb3e68-4dca-46db-bf49-04b84e07e77c"));
+    HashMap<String, String> selectors = new HashMap<>();
+    selectors.put("collectionExerciseId", COLLECTION_EXERCISE_ID);
+    actionPlan.setSelectors(selectors);
+
+    List<ActionPlanDTO> actionPlans = new ArrayList<>();
+    actionPlans.add(actionPlan);
+
+    responseEntity = new ResponseEntity(actionPlans, HttpStatus.OK);
+
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void getActionPlansBySelectors() {
+
+    // Given
+    ActionSvc actionSvc = new ActionSvc();
+    actionSvc.setActionPlansPath("test:path");
+    when(appConfig.getActionSvc()).thenReturn(actionSvc);
+    when(restTemplate.exchange(
+            any(String.class),
+            eq(HttpMethod.GET),
+            eq(null),
+            eq(new ParameterizedTypeReference<List<ActionPlanDTO>>() {})))
+        .thenReturn(responseEntity);
+
+    // When
+    actionSvcRestClient.getActionPlansBySelectors(COLLECTION_EXERCISE_ID, false);
+
+    // Then call is made to correct url
+    verify(restTemplate, times(1))
+        .exchange(
+            String.format(
+                "test:path?collectionExerciseId=%s&activeEnrolment=false", COLLECTION_EXERCISE_ID),
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<List<ActionPlanDTO>>() {});
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImplTest.java
@@ -102,15 +102,15 @@ public class ActionSvcRestClientImplTest {
     actionSvc.setActionPlansPath("test:path");
     when(appConfig.getActionSvc()).thenReturn(actionSvc);
     when(restTemplate.exchange(
-      any(String.class),
-      eq(HttpMethod.GET),
-      eq(null),
-      eq(new ParameterizedTypeReference<List<ActionPlanDTO>>() {})))
-      .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+            any(String.class),
+            eq(HttpMethod.GET),
+            eq(null),
+            eq(new ParameterizedTypeReference<List<ActionPlanDTO>>() {})))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 
     // When
     List<ActionPlanDTO> actionPlanDTOs =
-      actionSvcRestClient.getActionPlansBySelectors(COLLECTION_EXERCISE_ID, false);
+        actionSvcRestClient.getActionPlansBySelectors(COLLECTION_EXERCISE_ID, false);
 
     // Then call is made to correct url
     assertNull(actionPlanDTOs);
@@ -124,11 +124,11 @@ public class ActionSvcRestClientImplTest {
     actionSvc.setActionPlansPath("test:path");
     when(appConfig.getActionSvc()).thenReturn(actionSvc);
     when(restTemplate.exchange(
-      any(String.class),
-      eq(HttpMethod.GET),
-      eq(null),
-      eq(new ParameterizedTypeReference<List<ActionPlanDTO>>() {})))
-      .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+            any(String.class),
+            eq(HttpMethod.GET),
+            eq(null),
+            eq(new ParameterizedTypeReference<List<ActionPlanDTO>>() {})))
+        .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
 
     // When
     actionSvcRestClient.getActionPlansBySelectors(COLLECTION_EXERCISE_ID, false);


### PR DESCRIPTION
# Motivation and Context
A few people required this client function for what they are currently working on so this is being added independently so they have access to it

# What has changed
Added a client function for retrieving action plans from the action service using their selectors field

# How to test?
Tests should still pass
You could also exercise the function as part of a related piece of work