### PR TITLE
Use collectionExerciseId as selector for action plans

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -448,15 +448,14 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
     }
 
     // Create action plan with appropriate name and description
-    String exerciseRef = collectionExercise.getExerciseRef();
     HashMap<String, String> selectors = new HashMap<>();
-    selectors.put("exerciseRef", exerciseRef);
-    selectors.put("surveyRef", survey.getSurveyRef());
+    selectors.put("collectionExerciseId", collectionExercise.getId().toString());
     if (!"H".equals(sampleUnitType) && !"HI".equals(sampleUnitType)) {
       String activeEnrolment = Boolean.toString("BI".equals(sampleUnitType));
       selectors.put("activeEnrolment", activeEnrolment);
     }
     String shortName = survey.getShortName();
+    String exerciseRef = collectionExercise.getExerciseRef();
     String name = String.format("%s %s %s", shortName, sampleUnitType, exerciseRef);
     String description = String.format("%s %s Case %s", shortName, sampleUnitType, exerciseRef);
     ActionPlanDTO actionPlan = actionSvcClient.createActionPlan(name, description, selectors);

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
@@ -280,18 +280,15 @@ public class CollectionExerciseServiceImplTest {
     verify(actionService, times(1)).createActionPlan("BRES B", "BRES B Case", null);
     verify(actionService, times(1)).createActionPlan("BRES BI", "BRES BI Case", null);
 
-    String exerciseRef = collectionExercise.getExerciseRef();
-    String surveyRef = survey.getSurveyRef();
+    String exerciseId = collectionExercise.getId().toString();
     HashMap<String, String> overrideBSelectors = new HashMap<>();
-    overrideBSelectors.put("surveyRef", surveyRef);
-    overrideBSelectors.put("exerciseRef", exerciseRef);
+    overrideBSelectors.put("collectionExerciseId", exerciseId);
     overrideBSelectors.put("activeEnrolment", "false");
     verify(actionService, times(1))
         .createActionPlan("BRES B 202103", "BRES B Case 202103", overrideBSelectors);
 
     HashMap<String, String> overrideBISelectors = new HashMap<>();
-    overrideBISelectors.put("surveyRef", surveyRef);
-    overrideBISelectors.put("exerciseRef", exerciseRef);
+    overrideBISelectors.put("collectionExerciseId", exerciseId);
     overrideBISelectors.put("activeEnrolment", "true");
     verify(actionService, times(1))
         .createActionPlan("BRES BI 202103", "BRES BI Case 202103", overrideBISelectors);


### PR DESCRIPTION
# Motivation and Context
We were previously using `exerciseRef` and `surveyRef` as selectors for the actionplans. This made them more human readable but harder to work with in the code.

# What has changed
Selectors `exerciseRef` and `surveyRef` have been replaced with `collectionExerciseId`

# How to test?
Check that when creating a collection exericse that action plans are created with `collectionExerciseId` in the selectors field
Acceptance tests should pass