### PR TITLE
Add missing headers in get action plans call

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -113,6 +113,8 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
     queryParams.add(SELECTOR_COLLECTION_EXERCISE_ID, collectionExerciseId);
     queryParams.add(SELECTOR_ACTIVE_ENROLMENT, Boolean.toString(activeEnrolment));
 
+    HttpEntity httpEntity = restUtility.createHttpEntity(null);
+
     final UriComponents uriComponents =
         restUtility.createUriComponents(appConfig.getActionSvc().getActionPlansPath(), queryParams);
 
@@ -120,7 +122,7 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
         restTemplate.exchange(
             uriComponents.toString(),
             HttpMethod.GET,
-            null,
+            httpEntity,
             new ParameterizedTypeReference<List<ActionPlanDTO>>() {});
 
     log.debug(

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImplTest.java
@@ -23,6 +23,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -73,11 +74,13 @@ public class ActionSvcRestClientImplTest {
     // Given
     ActionSvc actionSvc = new ActionSvc();
     actionSvc.setActionPlansPath("test:path");
+    HttpEntity httpEntity = new HttpEntity(null, null);
+    when(restUtility.createHttpEntity(any(ActionPlanDTO.class))).thenReturn(httpEntity);
     when(appConfig.getActionSvc()).thenReturn(actionSvc);
     when(restTemplate.exchange(
             any(String.class),
             eq(HttpMethod.GET),
-            eq(null),
+            eq(httpEntity),
             eq(new ParameterizedTypeReference<List<ActionPlanDTO>>() {})))
         .thenReturn(responseEntity);
 
@@ -90,7 +93,7 @@ public class ActionSvcRestClientImplTest {
             String.format(
                 "test:path?collectionExerciseId=%s&activeEnrolment=false", COLLECTION_EXERCISE_ID),
             HttpMethod.GET,
-            null,
+            httpEntity,
             new ParameterizedTypeReference<List<ActionPlanDTO>>() {});
   }
 
@@ -101,10 +104,12 @@ public class ActionSvcRestClientImplTest {
     ActionSvc actionSvc = new ActionSvc();
     actionSvc.setActionPlansPath("test:path");
     when(appConfig.getActionSvc()).thenReturn(actionSvc);
+    HttpEntity httpEntity = new HttpEntity(null, null);
+    when(restUtility.createHttpEntity(any())).thenReturn(httpEntity);
     when(restTemplate.exchange(
             any(String.class),
             eq(HttpMethod.GET),
-            eq(null),
+            eq(httpEntity),
             eq(new ParameterizedTypeReference<List<ActionPlanDTO>>() {})))
         .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
 
@@ -119,11 +124,13 @@ public class ActionSvcRestClientImplTest {
     // Given
     ActionSvc actionSvc = new ActionSvc();
     actionSvc.setActionPlansPath("test:path");
+    HttpEntity httpEntity = new HttpEntity(null, null);
+    when(restUtility.createHttpEntity(any())).thenReturn(httpEntity);
     when(appConfig.getActionSvc()).thenReturn(actionSvc);
     when(restTemplate.exchange(
             any(String.class),
             eq(HttpMethod.GET),
-            eq(null),
+            eq(httpEntity),
             eq(new ParameterizedTypeReference<List<ActionPlanDTO>>() {})))
         .thenReturn(new ResponseEntity<>(HttpStatus.NO_CONTENT));
 
@@ -145,11 +152,13 @@ public class ActionSvcRestClientImplTest {
     // Given
     ActionSvc actionSvc = new ActionSvc();
     actionSvc.setActionPlansPath("test:path");
+    HttpEntity httpEntity = new HttpEntity(null, null);
+    when(restUtility.createHttpEntity(any())).thenReturn(httpEntity);
     when(appConfig.getActionSvc()).thenReturn(actionSvc);
     when(restTemplate.exchange(
             any(String.class),
             eq(HttpMethod.GET),
-            eq(null),
+            eq(httpEntity),
             eq(new ParameterizedTypeReference<List<ActionPlanDTO>>() {})))
         .thenReturn(
             new ResponseEntity<>(
@@ -175,12 +184,15 @@ public class ActionSvcRestClientImplTest {
     actionSvc.setActionPlansPath("test:path");
     when(appConfig.getActionSvc()).thenReturn(actionSvc);
 
+    HttpEntity httpEntity = new HttpEntity(null, null);
+    when(restUtility.createHttpEntity(any())).thenReturn(httpEntity);
+
     ActionPlanDTO actionPlan = new ActionPlanDTO();
 
     when(restTemplate.exchange(
             any(String.class),
             eq(HttpMethod.GET),
-            eq(null),
+            eq(httpEntity),
             eq(new ParameterizedTypeReference<List<ActionPlanDTO>>() {})))
         .thenReturn(new ResponseEntity<>(Collections.singletonList(actionPlan), HttpStatus.OK));
 
@@ -196,7 +208,7 @@ public class ActionSvcRestClientImplTest {
             String.format(
                 "test:path?collectionExerciseId=%s&activeEnrolment=false", COLLECTION_EXERCISE_ID),
             HttpMethod.GET,
-            null,
+            httpEntity,
             new ParameterizedTypeReference<List<ActionPlanDTO>>() {});
   }
 }


### PR DESCRIPTION
Call to action service was missing the authentication header.
This adds it in.

Test using this docker dev change (as the services do not check basic auth using the master branch)>> https://github.com/ONSdigital/ras-rm-docker-dev/pull/76