### PR TITLE
Add authentication header & remove unnecessary survey calls

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -225,13 +225,14 @@ public class ActionSvcRestClientImpl implements ActionSvcClient {
             appConfig.getActionSvc().getActionRulesForActionPlanPath(), null, actionPlanId);
 
     ResponseEntity<List<ActionRuleDTO>> response;
+    HttpEntity httpEntity = restUtility.createHttpEntity(null);
 
     try {
       response =
           restTemplate.exchange(
               uriComponents.toUri(),
               HttpMethod.GET,
-              null,
+              httpEntity,
               new ParameterizedTypeReference<List<ActionRuleDTO>>() {});
     } catch (HttpClientErrorException e) {
       if (e.getStatusCode() == HttpStatus.NOT_FOUND) {

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleCreator.java
@@ -28,21 +28,21 @@ public final class GoLiveActionRuleCreator implements ActionRuleCreator {
 
   @Override
   public void execute(final Event collectionExerciseEvent) throws CTPException {
-    final SurveyDTO survey =
-        surveyService.getSurveyForCollectionExercise(
-            collectionExerciseEvent.getCollectionExercise());
-
-    if (survey.getSurveyType() != SurveyDTO.SurveyType.Business) {
-      return;
-    }
 
     if (!isGoLive(collectionExerciseEvent)) {
       return;
     }
 
+    final CollectionExercise collectionExercise = collectionExerciseEvent.getCollectionExercise();
+
+    final SurveyDTO survey = surveyService.getSurveyForCollectionExercise(collectionExercise);
+
+    if (survey.getSurveyType() != SurveyDTO.SurveyType.Business) {
+      return;
+    }
+
     final Instant instant = Instant.ofEpochMilli(collectionExerciseEvent.getTimestamp().getTime());
     final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(instant, ZoneId.systemDefault());
-    final CollectionExercise collectionExercise = collectionExerciseEvent.getCollectionExercise();
 
     final ActionPlanDTO actionPlan =
         actionSvcClient.getActionPlanBySelectors(collectionExercise.getId().toString(), true);

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleUpdater.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleUpdater.java
@@ -35,15 +35,15 @@ public final class GoLiveActionRuleUpdater implements ActionRuleUpdater {
   @Override
   public void execute(final Event event) throws CTPException {
 
+    if (!Tag.go_live.hasName(event.getTag())) {
+      return;
+    }
+
     final CollectionExercise collectionExercise = event.getCollectionExercise();
 
     final SurveyDTO survey = surveyService.getSurveyForCollectionExercise(collectionExercise);
 
     if (survey.getSurveyType() != SurveyType.Business) {
-      return;
-    }
-
-    if (!Tag.go_live.hasName(event.getTag())) {
       return;
     }
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreator.java
@@ -30,21 +30,20 @@ public final class MpsActionRuleCreator implements ActionRuleCreator {
   @Override
   public void execute(final Event collectionExerciseEvent) throws CTPException {
 
-    final SurveyDTO survey =
-        surveyService.getSurveyForCollectionExercise(
-            collectionExerciseEvent.getCollectionExercise());
+    if (!isMps(collectionExerciseEvent)) {
+      return;
+    }
+
+    final CollectionExercise collectionExercise = collectionExerciseEvent.getCollectionExercise();
+
+    final SurveyDTO survey = surveyService.getSurveyForCollectionExercise(collectionExercise);
 
     if (survey.getSurveyType() != SurveyDTO.SurveyType.Business) {
       return;
     }
 
-    if (!isMps(collectionExerciseEvent)) {
-      return;
-    }
-
     final Instant instant = Instant.ofEpochMilli(collectionExerciseEvent.getTimestamp().getTime());
     final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(instant, ZoneId.systemDefault());
-    final CollectionExercise collectionExercise = collectionExerciseEvent.getCollectionExercise();
 
     final ActionPlanDTO actionPlan =
         actionSvcClient.getActionPlanBySelectors(collectionExercise.getId().toString(), false);

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleUpdater.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleUpdater.java
@@ -36,13 +36,15 @@ public class MpsActionRuleUpdater implements ActionRuleUpdater {
   @Override
   public void execute(final Event event) throws CTPException {
 
-    CollectionExercise collectionExercise = event.getCollectionExercise();
-    final SurveyDTO survey = surveyService.getSurveyForCollectionExercise(collectionExercise);
-    if (survey.getSurveyType() != SurveyType.Business) {
+    if (!Tag.mps.hasName(event.getTag())) {
       return;
     }
 
-    if (!Tag.mps.hasName(event.getTag())) {
+    final CollectionExercise collectionExercise = event.getCollectionExercise();
+
+    final SurveyDTO survey = surveyService.getSurveyForCollectionExercise(collectionExercise);
+
+    if (survey.getSurveyType() != SurveyType.Business) {
       return;
     }
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreator.java
@@ -33,15 +33,16 @@ public final class ReminderActionRuleCreator implements ActionRuleCreator {
 
   @Override
   public void execute(final Event collectionExerciseEvent) throws CTPException {
+
+    if (!Tag.valueOf(collectionExerciseEvent.getTag()).isReminder()) {
+      return;
+    }
+
     final CollectionExercise collectionExercise = collectionExerciseEvent.getCollectionExercise();
 
     final SurveyDTO survey = surveyService.getSurveyForCollectionExercise(collectionExercise);
 
     if (survey.getSurveyType() != SurveyType.Business) {
-      return;
-    }
-
-    if (!Tag.valueOf(collectionExerciseEvent.getTag()).isReminder()) {
       return;
     }
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleUpdater.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleUpdater.java
@@ -42,15 +42,15 @@ public class ReminderActionRuleUpdater implements ActionRuleUpdater {
   @Override
   public void execute(final Event event) throws CTPException {
 
+    if (!Tag.valueOf(event.getTag()).isReminder()) {
+      return;
+    }
+
     final CollectionExercise collectionExercise = event.getCollectionExercise();
 
     final SurveyDTO survey = surveyService.getSurveyForCollectionExercise(collectionExercise);
 
     if (survey.getSurveyType() != SurveyType.Business) {
-      return;
-    }
-
-    if (!Tag.valueOf(event.getTag()).isReminder()) {
       return;
     }
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ActionSvcClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ActionSvcClientImplTest.java
@@ -329,11 +329,14 @@ public class ActionSvcClientImplTest {
             endsWith(ACTION_RULES_FOR_PLAN_PATH), eq(null), eq(actionPlanId)))
         .thenReturn(uriComponents);
 
+    final HttpEntity httpEntity = new HttpEntity(null, null);
+    when(restUtility.createHttpEntity(any())).thenReturn(httpEntity);
+
     final List<ActionRuleDTO> actionRuleDTOs = new ArrayList<>();
     when(restTemplate.exchange(
             eq(uriComponents.toUri()),
             eq(HttpMethod.GET),
-            eq(null),
+            eq(httpEntity),
             eq(new ParameterizedTypeReference<List<ActionRuleDTO>>() {})))
         .thenReturn(new ResponseEntity<>(actionRuleDTOs, HttpStatus.OK));
 
@@ -362,10 +365,14 @@ public class ActionSvcClientImplTest {
     final UUID actionPlanId = UUID.randomUUID();
     when(restUtility.createUriComponents(any(String.class), eq(null), eq(actionPlanId)))
         .thenReturn(uriComponents);
+
+    final HttpEntity httpEntity = new HttpEntity(null, null);
+    when(restUtility.createHttpEntity(any())).thenReturn(httpEntity);
+
     when(restTemplate.exchange(
             eq(uriComponents.toUri()),
             eq(HttpMethod.GET),
-            eq(null),
+            eq(httpEntity),
             eq(new ParameterizedTypeReference<List<ActionRuleDTO>>() {})))
         .thenThrow(new RestClientException("Error"));
 
@@ -390,10 +397,14 @@ public class ActionSvcClientImplTest {
     final UUID actionPlanId = UUID.randomUUID();
     when(restUtility.createUriComponents(any(String.class), eq(null), eq(actionPlanId)))
         .thenReturn(uriComponents);
+
+    final HttpEntity httpEntity = new HttpEntity(null, null);
+    when(restUtility.createHttpEntity(any())).thenReturn(httpEntity);
+
     when(restTemplate.exchange(
             eq(uriComponents.toUri()),
             eq(HttpMethod.GET),
-            eq(null),
+            eq(httpEntity),
             eq(new ParameterizedTypeReference<List<ActionRuleDTO>>() {})))
         .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleUpdaterTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/GoLiveActionRuleUpdaterTest.java
@@ -5,7 +5,10 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -59,6 +62,18 @@ public class GoLiveActionRuleUpdaterTest {
   }
 
   @Test
+  public void doNothingIfNotGoLiveEvent() throws CTPException {
+    final Event event = new Event();
+    event.setTag(Tag.mps.name());
+
+    updater.execute(event);
+
+    verify(actionSvcClient, never())
+        .updateActionRule(
+            any(UUID.class), anyString(), anyString(), any(OffsetDateTime.class), anyInt());
+  }
+
+  @Test
   public void doNothingIfNotBusinessSurveyEvent() throws CTPException {
     final SurveyDTO survey = new SurveyDTO();
     survey.setSurveyType(SurveyType.Social);
@@ -67,30 +82,12 @@ public class GoLiveActionRuleUpdaterTest {
     collex.setId(EXERCISE_ID);
     final Event event = new Event();
     event.setCollectionExercise(collex);
+    event.setTag(Tag.go_live.name());
     when(surveyService.getSurveyForCollectionExercise(collex)).thenReturn(survey);
 
     updater.execute(event);
-    verify(actionSvcClient, times(0))
-        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
-  }
-
-  @Test
-  public void doNothingIfNotGoLiveEvent() throws CTPException {
-    final CollectionExercise collex = new CollectionExercise();
-    collex.setId(EXERCISE_ID);
-    final Event event = new Event();
-    event.setCollectionExercise(collex);
-    event.setTag(Tag.mps.name());
-
-    final SurveyDTO survey = new SurveyDTO();
-    survey.setSurveyType(SurveyType.Business);
-    when(surveyService.getSurveyForCollectionExercise(collex)).thenReturn(survey);
-
-    updater.execute(event);
-
     verify(actionSvcClient, never())
-        .updateActionRule(
-            any(UUID.class), anyString(), anyString(), any(OffsetDateTime.class), anyInt());
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
   }
 
   public void raiseCTPExceptionIfNoBSNEActionRulesFound() throws CTPException {

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleCreatorTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,32 +52,26 @@ public class MpsActionRuleCreatorTest {
   }
 
   @Test
+  public void doNothingIfNotMpsEvent() throws CTPException {
+    final Event collectionExerciseEvent =
+        createCollectionExerciseEvent(Tag.go_live.name(), null, null);
+
+    mpsActionRuleCreator.execute(collectionExerciseEvent);
+    verify(actionSvcClient, never())
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
+  }
+
+  @Test
   public void doNothingIfNotBusinessSurveyEvent() throws CTPException {
     final SurveyDTO survey = new SurveyDTO();
     survey.setSurveyType(SurveyType.Social);
 
     final CollectionExercise collectionExercise = createCollectionExercise();
-    final Event event = createCollectionExerciseEvent(null, null, collectionExercise);
+    final Event event = createCollectionExerciseEvent(Tag.mps.name(), null, collectionExercise);
     when(surveyService.getSurveyForCollectionExercise(collectionExercise)).thenReturn(survey);
 
     mpsActionRuleCreator.execute(event);
-    verify(actionSvcClient, times(0))
-        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
-  }
-
-  @Test
-  public void doNothingIfNotMpsEvent() throws CTPException {
-    SurveyDTO survey = new SurveyDTO();
-    survey.setSurveyType(SurveyType.Business);
-
-    final CollectionExercise collex = createCollectionExercise();
-    final Event collectionExerciseEvent =
-        createCollectionExerciseEvent(Tag.go_live.name(), null, collex);
-
-    when(surveyService.getSurveyForCollectionExercise(collex)).thenReturn(survey);
-
-    mpsActionRuleCreator.execute(collectionExerciseEvent);
-    verify(actionSvcClient, times(0))
+    verify(actionSvcClient, never())
         .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleUpdaterTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/MpsActionRuleUpdaterTest.java
@@ -5,7 +5,10 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -59,6 +62,18 @@ public class MpsActionRuleUpdaterTest {
   }
 
   @Test
+  public void doNothingIfNotMps() throws CTPException {
+    final Event event = new Event();
+    event.setTag(Tag.go_live.name());
+
+    updater.execute(event);
+
+    verify(actionSvcClient, never())
+        .updateActionRule(
+            any(UUID.class), anyString(), anyString(), any(OffsetDateTime.class), anyInt());
+  }
+
+  @Test
   public void doNothingIfNotBusinessSurveyEvent() throws CTPException {
     final SurveyDTO survey = new SurveyDTO();
     survey.setSurveyType(SurveyType.Social);
@@ -66,29 +81,12 @@ public class MpsActionRuleUpdaterTest {
     final CollectionExercise collex = new CollectionExercise();
     final Event event = new Event();
     event.setCollectionExercise(collex);
+    event.setTag(Tag.mps.name());
     when(surveyService.getSurveyForCollectionExercise(collex)).thenReturn(survey);
 
     updater.execute(event);
-    verify(actionSvcClient, times(0))
-        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
-  }
-
-  @Test
-  public void doNothingIfNotMps() throws CTPException {
-    final CollectionExercise collex = new CollectionExercise();
-    final Event event = new Event();
-    event.setTag(Tag.go_live.name());
-    event.setCollectionExercise(collex);
-
-    final SurveyDTO survey = new SurveyDTO();
-    survey.setSurveyType(SurveyType.Business);
-    when(surveyService.getSurveyForCollectionExercise(collex)).thenReturn(survey);
-
-    updater.execute(event);
-
     verify(actionSvcClient, never())
-        .updateActionRule(
-            any(UUID.class), anyString(), anyString(), any(OffsetDateTime.class), anyInt());
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleCreatorTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,34 +55,27 @@ public class ReminderActionRuleCreatorTest {
   }
 
   @Test
+  public void doNothingIfNotReminderEvent() throws CTPException {
+    final String tag = Tag.go_live.name();
+    final Event collectionExerciseEvent = new Event();
+    collectionExerciseEvent.setTag(tag);
+
+    reminderActionRuleCreator.execute(collectionExerciseEvent);
+    verify(actionSvcClient, never())
+        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
+  }
+
+  @Test
   public void doNothingIfNotBusinessSurveyEvent() throws CTPException {
     final SurveyDTO survey = new SurveyDTO();
     survey.setSurveyType(SurveyType.Social);
 
     final CollectionExercise collex = new CollectionExercise();
-    final Event event = createCollectionExerciseEvent(null, null, collex);
+    final Event event = createCollectionExerciseEvent(Tag.reminder.name(), null, collex);
     when(surveyService.getSurveyForCollectionExercise(collex)).thenReturn(survey);
 
     reminderActionRuleCreator.execute(event);
-    verify(actionSvcClient, times(0))
-        .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
-  }
-
-  @Test
-  public void doNothingIfNotReminderEvent() throws CTPException {
-    String tag = Tag.go_live.name();
-    Event collectionExerciseEvent = new Event();
-    CollectionExercise collex = new CollectionExercise();
-
-    collectionExerciseEvent.setTag(tag);
-    collectionExerciseEvent.setCollectionExercise(collex);
-
-    final SurveyDTO survey = new SurveyDTO();
-    survey.setSurveyType(SurveyType.Business);
-
-    when(surveyService.getSurveyForCollectionExercise(collex)).thenReturn(survey);
-    reminderActionRuleCreator.execute(collectionExerciseEvent);
-    verify(actionSvcClient, times(0))
+    verify(actionSvcClient, never())
         .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleUpdaterTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/actionrule/ReminderActionRuleUpdaterTest.java
@@ -60,6 +60,18 @@ public class ReminderActionRuleUpdaterTest {
   }
 
   @Test
+  public void doNothingIfNotReminder() throws CTPException {
+    final Event event = new Event();
+    event.setTag(Tag.employment.name());
+
+    updater.execute(event);
+
+    verify(actionSvcClient, never())
+        .updateActionRule(
+            any(UUID.class), anyString(), anyString(), any(OffsetDateTime.class), anyInt());
+  }
+
+  @Test
   public void doNothingIfNotBusinessSurveyEvent() throws CTPException {
     final SurveyDTO survey = new SurveyDTO();
     survey.setSurveyType(SurveyType.Social);
@@ -67,29 +79,12 @@ public class ReminderActionRuleUpdaterTest {
     final CollectionExercise collex = new CollectionExercise();
     final Event event = new Event();
     event.setCollectionExercise(collex);
+    event.setTag(Tag.reminder.name());
     when(surveyService.getSurveyForCollectionExercise(collex)).thenReturn(survey);
 
     updater.execute(event);
     verify(actionSvcClient, times(0))
         .createActionRule(anyString(), anyString(), any(), any(), anyInt(), any());
-  }
-
-  @Test
-  public void doNothingIfNotReminder() throws CTPException {
-    final CollectionExercise collex = new CollectionExercise();
-    final Event event = new Event();
-    event.setCollectionExercise(collex);
-    event.setTag(Tag.employment.name());
-
-    final SurveyDTO survey = new SurveyDTO();
-    survey.setSurveyType(SurveyType.Business);
-    when(surveyService.getSurveyForCollectionExercise(collex)).thenReturn(survey);
-
-    updater.execute(event);
-
-    verify(actionSvcClient, never())
-        .updateActionRule(
-            any(UUID.class), anyString(), anyString(), any(OffsetDateTime.class), anyInt());
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Call to action service was being done without an authentication header
resulting in 401s on event update. This pr adds the header into the
request. Also a number of unnecessary calls are being made to survey
service, changed the logic order so the calls are not being made
unless it is needed.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Added authentication header to action service call
Changed order for calling survey service to after the event tag check.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
mvn test
ATs

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
