### PR TITLE
Remove references of survey name from across the service

### DIFF
--- a/API.md
+++ b/API.md
@@ -25,7 +25,6 @@ This page documents the Collection Exercise service API endpoints. Apart from th
   {
     "id": "c6467711-21eb-4e78-804c-1db8392f93fb",
     "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
-    "name": "Monthly Survey of Building Materials Bricks",
     "actualExecutionDateTime": null,
     "scheduledExecutionDateTime": null,
     "scheduledStartDateTime": null,
@@ -47,7 +46,6 @@ This page documents the Collection Exercise service API endpoints. Apart from th
   {
     "id": "b447e134-5e5d-46fb-b4fc-15efdcbe5ca7",
     "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
-    "name": "Monthly Survey of Building materials Bricks",
     "actualExecutionDateTime": null,
     "scheduledExecutionDateTime": null,
     "scheduledStartDateTime": null,
@@ -80,7 +78,6 @@ This page documents the Collection Exercise service API endpoints. Apart from th
   {
     "id": "b447e134-5e5d-46fb-b4fc-15efdcbe5ca7",
     "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
-    "name": "Monthly Survey of Building materials Bricks",
     "actualExecutionDateTime": null,
     "scheduledExecutionDateTime": null,
     "scheduledStartDateTime": null,
@@ -146,7 +143,6 @@ An `HTTP 404 Not Found` status code is returned if the survey with the specified
     {
         "id": "88e18a80-bc77-48bf-8eff-db351024be2b",
         "surveyId": "75b19ea0-69a4-4c58-8d7f-4458c8f43f5c",
-        "name": "Monthly Business Sur",
         "actualExecutionDateTime": null,
         "scheduledExecutionDateTime": null,
         "scheduledStartDateTime": null,
@@ -168,7 +164,6 @@ An `HTTP 404 Not Found` status code is returned if the survey with the specified
     {
         "id": "6af19036-f69b-4d2e-abf1-ce442debb51c",
         "surveyId": "75b19ea0-69a4-4c58-8d7f-4458c8f43f5c",
-        "name": "Monthly Business Sur",
         "actualExecutionDateTime": null,
         "scheduledExecutionDateTime": null,
         "scheduledStartDateTime": null,
@@ -297,7 +292,6 @@ In the event that errors have occurred validating the collection exercise, there
 ```json
 {
     "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef77",
-    "name": "SurveyName",
     "exerciseRef": "201715",
     "userDescription": "August 2017"
 }
@@ -313,7 +307,6 @@ In the event that errors have occurred validating the collection exercise, there
 
 ```json
 {
-    "name": "UpdatedSurveyName",
     "exerciseRef": "201715",
     "userDescription": "Updated August 2017",
     "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef77"
@@ -341,12 +334,6 @@ In the event that errors have occurred validating the collection exercise, there
 ```text/plain
 August 2018
 ```
-
-## Update Collection Exercise exerciseRef (name)
-* `PUT /collectionexercises/{collection_exercise_id}/name` will update the name of collection exercise with given id.
-* Returns 200 OK if the resource is updated
-* Returns 400 Bad Request, resource not updated
-* Returns 409 Conflict, resource not updated
 
 ### Example Request Body
 ```text\plain
@@ -481,7 +468,6 @@ json
     "collectionExercise": {
         "id": "14fb3e68-4dca-46db-bf49-04b84e07e97c",
         "exercisePK": 3,
-        "name": "SOCIAL",
         "actualExecutionDateTime": null,
         "scheduledExecutionDateTime": null,
         "scheduledStartDateTime": "2001-12-31T12:00:00.000+0000",

--- a/scripts/collectionexercise_report.sql
+++ b/scripts/collectionexercise_report.sql
@@ -1,5 +1,4 @@
-SELECT  c.name
-      , c.scheduledstartdatetime
+SELECT  c.scheduledstartdatetime
       , c.scheduledexecutiondatetime
       , c.scheduledreturndatetime
       , c.scheduledenddatetime

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CollectionExercise.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/domain/CollectionExercise.java
@@ -39,8 +39,6 @@ public class CollectionExercise {
   @Column(name = "exercisepk")
   private Integer exercisePK;
 
-  private String name;
-
   @Column(name = "actualexecutiondatetime")
   private Timestamp actualExecutionDateTime;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -246,7 +246,6 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
    */
   private void setCollectionExerciseFromDto(
       CollectionExerciseDTO collex, CollectionExercise collectionExercise) {
-    collectionExercise.setName(collex.getName());
     collectionExercise.setUserDescription(collex.getUserDescription());
     collectionExercise.setExerciseRef(collex.getExerciseRef());
     collectionExercise.setSurveyId(UUID.fromString(collex.getSurveyId()));
@@ -536,9 +535,6 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
 
       if (!StringUtils.isBlank(patchData.getExerciseRef())) {
         collex.setExerciseRef(patchData.getExerciseRef());
-      }
-      if (!StringUtils.isBlank(patchData.getName())) {
-        collex.setName(patchData.getName());
       }
       if (!StringUtils.isBlank(patchData.getUserDescription())) {
         collex.setUserDescription(patchData.getUserDescription());

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -36,6 +36,9 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-10.49.16/changelog.yml
+
+  - include:
+      file: database/changes/release-11/changelog.yml
       
 # When adding new groups of migrations to this file the numbers are arbitrary, please follow the following format for
 # all migrations after this point, using the the format "release-$NEXT_NUMBER". Incrementing $NEXT_NUMBER each

--- a/src/main/resources/database/changes/release-11/changelog.yml
+++ b/src/main/resources/database/changes/release-11/changelog.yml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 11.1
+      author: Samiul Islam
+      changes:
+        - sqlFile:
+            comment: Remove survey names
+            path: remove_survey_name.sql
+            relativeToChangelogFile: true
+            splitStatements: false
+
+  - changeSet:
+        id: 11.2
+        author: Samiul Islam
+        changes:
+          - sqlFile:
+              comment: Collection Exercise Survey Name Removal
+              path: recreate_collectionexercise_report.sql
+              relativeToChangelogFile: true
+              splitStatements: false

--- a/src/main/resources/database/changes/release-11/recreate_collectionexercise_report.sql
+++ b/src/main/resources/database/changes/release-11/recreate_collectionexercise_report.sql
@@ -1,0 +1,81 @@
+CREATE OR REPLACE FUNCTION collectionexercise.generate_collectionexercise_mi()
+  RETURNS boolean AS
+$BODY$
+DECLARE
+
+v_contents      text;
+r_dataline      record;
+v_rows          integer;
+
+BEGIN
+
+    PERFORM collectionexercise.logmessage(p_messagetext := 'GENERATING COLLECTION EXERCISE MI REPORT'
+                              ,p_jobid := 0
+                              ,p_messagelevel := 'INFO'
+                              ,p_functionname := 'collectionexercise.generate_collectionexercise_mi');
+
+       v_rows     := 0;
+       v_contents := '';
+       v_contents := 'CE Name,Scheduled Start DateTime,Scheduled Execution DateTime,Scheduled Return DateTime,Scheduled End DateTime,Period Start DateTime,Period End DateTime,Actual Execution DateTime,Actual Publish DateTime,Executed By,State,Sample Size';
+
+-- collectionexercise Report
+
+       FOR r_dataline IN (SELECT  c.scheduledstartdatetime
+                                , c.scheduledexecutiondatetime
+                                , c.scheduledreturndatetime
+                                , c.scheduledenddatetime
+                                , c.periodstartdatetime
+                                , c.periodenddatetime
+                                , c.actualexecutiondatetime
+                                , c.actualpublishdatetime
+                                , c.executedby
+                                , c.stateFK
+                                , c.samplesize
+                          FROM collectionexercise.collectionexercise c) LOOP
+
+                                v_contents := v_contents                                    || chr(10)
+                                || r_dataline.name                                          || ','
+                                || COALESCE(r_dataline.scheduledstartdatetime::text,'')     || ','
+                                || COALESCE(r_dataline.scheduledexecutiondatetime::text,'') || ','
+                                || COALESCE(r_dataline.scheduledreturndatetime::text,'')    || ','
+                                || COALESCE(r_dataline.scheduledenddatetime::text,'')       || ','
+                                || COALESCE(r_dataline.periodstartdatetime::text,'')        || ','
+                                || COALESCE(r_dataline.periodenddatetime::text,'')          || ','
+                                || COALESCE(r_dataline.actualexecutiondatetime::text,'')    || ','
+                                || COALESCE(r_dataline.actualpublishdatetime ::text,'')     || ','
+                                || COALESCE(r_dataline.executedby::text,'')                 || ','
+                                || COALESCE(r_dataline.stateFK::text,'')                    || ','
+                                || COALESCE(r_dataline.samplesize::text,'');
+
+             v_rows := v_rows+1;
+       END LOOP;
+
+       -- Insert the data into the report table
+       INSERT INTO collectionexercise.report (id, reportPK,reporttypeFK,contents, createddatetime) VALUES(gen_random_uuid(), nextval('collectionexercise.reportPKseq'), 'COLLECTIONEXERCISE', v_contents, CURRENT_TIMESTAMP);
+
+
+       PERFORM collectionexercise.logmessage(p_messagetext := 'GENERATING COLLECTION EXERCISE MI REPORT COMPLETED ROWS WRIITEN = ' || v_rows
+                                        ,p_jobid := 0
+                                        ,p_messagelevel := 'INFO'
+                                        ,p_functionname := 'collectionexercise.generate_collectionexercise_mi');
+
+
+       PERFORM collectionexercise.logmessage(p_messagetext := 'COLLECTION EXERCISE MI REPORT GENERATED'
+                                        ,p_jobid := 0
+                                        ,p_messagelevel := 'INFO'
+                                        ,p_functionname := 'collectionexercise.generate_collectionexercise_mi');
+
+  RETURN TRUE;
+
+  EXCEPTION
+  WHEN OTHERS THEN
+     PERFORM collectionexercise.logmessage(p_messagetext := 'GENERATE REPORTS EXCEPTION TRIGGERED SQLERRM: ' || SQLERRM || ' SQLSTATE : ' || SQLSTATE
+                               ,p_jobid := 0
+                               ,p_messagelevel := 'FATAL'
+                               ,p_functionname := 'collectionexercise.generate_collectionexercise_mi');
+
+  RETURN FALSE;
+END;
+$BODY$
+  LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+  COST 100;

--- a/src/main/resources/database/changes/release-11/remove_survey_name.sql
+++ b/src/main/resources/database/changes/release-11/remove_survey_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE collectionexercise.collectionexercise
+DROP COLUMN "name";

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -75,7 +75,6 @@ public class CollectionExerciseEndpointUnitTests {
       UUID.fromString("3ec82e0e-18ff-4886-8703-5b83442041ba");
   private static final UUID COLLECTIONEXERCISE_ID2 =
       UUID.fromString("e653d1ce-551b-4b41-b05c-eec02f71891e");
-  private static final String COLLECTIONEXERCISE_NAME = ("BRES_2016");
   private static final String COLLECTIONEXERCISE_DATE_OUTPUT = "2017-05-15T12:00:00.000+01:00";
 
   private static final String COLLECTIONEXERCISE_STATE = ("EXECUTED");
@@ -178,9 +177,6 @@ public class CollectionExerciseEndpointUnitTests {
                     COLLECTIONEXERCISE_ID1.toString(), COLLECTIONEXERCISE_ID2.toString())))
         .andExpect(
             jsonPath(
-                "$[*].name", containsInAnyOrder(COLLECTIONEXERCISE_NAME, COLLECTIONEXERCISE_NAME)))
-        .andExpect(
-            jsonPath(
                 "$[*].scheduledExecutionDateTime",
                 containsInAnyOrder(
                     new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT),
@@ -234,7 +230,6 @@ public class CollectionExerciseEndpointUnitTests {
         .andExpect(handler().methodName("getCollectionExercise"))
         .andExpect(jsonPath("$.id", is(COLLECTIONEXERCISE_ID1.toString())))
         .andExpect(jsonPath("$.surveyId", is(SURVEY_ID_1.toString())))
-        .andExpect(jsonPath("$.name", is(COLLECTIONEXERCISE_NAME)))
         .andExpect(jsonPath("$.state", is(COLLECTIONEXERCISE_STATE)))
         .andExpect(jsonPath("$.caseTypes[*]", hasSize(1)))
         .andExpect(jsonPath("$.caseTypes[*].*", hasSize(2)))
@@ -287,7 +282,6 @@ public class CollectionExerciseEndpointUnitTests {
         .andExpect(handler().methodName("getCollectionExercise"))
         .andExpect(jsonPath("$.id", is(COLLECTIONEXERCISE_ID1.toString())))
         .andExpect(jsonPath("$.surveyId", is(SURVEY_ID_1.toString())))
-        .andExpect(jsonPath("$.name", is(COLLECTIONEXERCISE_NAME)))
         .andExpect(jsonPath("$.state", is(COLLECTIONEXERCISE_STATE)))
         .andExpect(jsonPath("$.caseTypes[*]", hasSize(1)))
         .andExpect(jsonPath("$.caseTypes[*].*", hasSize(2)))
@@ -320,12 +314,10 @@ public class CollectionExerciseEndpointUnitTests {
         .andExpect(handler().methodName("getAllCollectionExercises"))
         .andExpect(jsonPath("$[0].id", is(COLLECTIONEXERCISE_ID1.toString())))
         .andExpect(jsonPath("$[0].surveyId", is(SURVEY_ID_1.toString())))
-        .andExpect(jsonPath("$[0].name", is(COLLECTIONEXERCISE_NAME)))
         .andExpect(jsonPath("$[0].state", is(COLLECTIONEXERCISE_STATE)))
         .andExpect(jsonPath("$[0].exerciseRef", is("2017")))
         .andExpect(jsonPath("$[1].id", is(COLLECTIONEXERCISE_ID2.toString())))
         .andExpect(jsonPath("$[1].surveyId", is(SURVEY_ID_2.toString())))
-        .andExpect(jsonPath("$[1].name", is(COLLECTIONEXERCISE_NAME)))
         .andExpect(jsonPath("$[1].state", is(COLLECTIONEXERCISE_STATE)))
         .andExpect(jsonPath("$[1].exerciseRef", is("2017")));
   }
@@ -538,7 +530,6 @@ public class CollectionExerciseEndpointUnitTests {
     assertEquals(uuid, uuidCaptor.getValue());
     CollectionExerciseDTO dtoArg = dtoCaptor.getValue();
     assertEquals("31ec898e-f370-429a-bca4-eab1045aff4e", dtoArg.getSurveyId());
-    assertEquals("Survey Name", dtoArg.getName());
     assertEquals("202103", dtoArg.getExerciseRef());
     assertEquals("March 2021", dtoArg.getUserDescription());
   }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.java
@@ -249,7 +249,6 @@ public class CollectionExerciseServiceImplTest {
     ArgumentCaptor<CollectionExercise> captor = ArgumentCaptor.forClass(CollectionExercise.class);
     verify(this.collexRepo).saveAndFlush(captor.capture());
     CollectionExercise collex = captor.getValue();
-    assertEquals(toCreate.getName(), collex.getName());
     assertEquals(toCreate.getUserDescription(), collex.getUserDescription());
     assertEquals(toCreate.getExerciseRef(), collex.getExerciseRef());
     assertEquals(toCreate.getSurveyId(), collex.getSurveyId().toString());
@@ -389,7 +388,6 @@ public class CollectionExerciseServiceImplTest {
     CollectionExercise collex = captor.getValue();
     assertEquals(UUID.fromString(toUpdate.getSurveyId()), collex.getSurveyId());
     assertEquals(toUpdate.getExerciseRef(), collex.getExerciseRef());
-    assertEquals(toUpdate.getName(), collex.getName());
     assertEquals(toUpdate.getUserDescription(), collex.getUserDescription());
     assertNotNull(collex.getUpdated());
   }
@@ -565,7 +563,6 @@ public class CollectionExerciseServiceImplTest {
     CollectionExercise existing = setupCollectionExercise();
     CollectionExerciseDTO collex = new CollectionExerciseDTO();
     String name = "Not BRES";
-    collex.setName(name);
 
     this.collectionExerciseServiceImpl.patchCollectionExercise(existing.getId(), collex);
 
@@ -573,7 +570,6 @@ public class CollectionExerciseServiceImplTest {
     verify(this.collexRepo).saveAndFlush(captor.capture());
 
     CollectionExercise ce = captor.getValue();
-    assertEquals(name, ce.getName());
     assertNotNull(ce.getUpdated());
   }
 

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.Event.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.Event.json
@@ -6,7 +6,6 @@
   "collectionExercise": {
     "exercisePK": 1,
     "id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
-    "name": "BRES_2016",
     "scheduledExecutionDateTime": 1494846000002,
     "state": "VALIDATED",
     "surveyId":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.ExerciseSampleUnitGroup.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.ExerciseSampleUnitGroup.json
@@ -5,7 +5,6 @@
 	{
 		"exercisePK": 1,
 		"id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
-		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000001,
 		"state": "VALIDATED",
 		"surveyId":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
@@ -20,7 +19,6 @@
       {
 		"exercisePK": 1,
 		"id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
-		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000002,
 		"state": "VALIDATED",
 		"surveyId":  "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExercise.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExercise.json
@@ -2,7 +2,6 @@
 	{
 		"exercisePK": 1,
 		"id": "3ec82e0e-18ff-4886-8703-5b83442041ba",
-		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000000,
 		"state": "EXECUTED",
 		"exerciseRef": "2017",
@@ -11,7 +10,6 @@
 	{
 		"exercisePK": 2,
 		"id": "e653d1ce-551b-4b41-b05c-eec02f71891e",
-		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000000,
 		"state": "EXECUTED",
 		"exerciseRef": "2017",

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExercise.post.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExercise.post.json
@@ -1,6 +1,5 @@
 [
 	{
-		"name": "Survey Name",
 		"exerciseRef": "202103",
 		"userDescription": "March 2021",
 		"exercisePK": 1,

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post-missing-survey.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post-missing-survey.json
@@ -1,5 +1,4 @@
   {
-    "name": "Survey Name",
     "exerciseRef": "202103",
     "userDescription": "March 2021"
   }

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post-survey-ref.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post-survey-ref.json
@@ -1,6 +1,5 @@
   {
     "surveyRef": "221",
-    "name": "Survey Name",
     "exerciseRef": "202103",
     "userDescription": "March 2021"
   }

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.CollectionExerciseDTO.post.json
@@ -1,6 +1,5 @@
   {
     "surveyId": "31ec898e-f370-429a-bca4-eab1045aff4e",
-    "name": "Survey Name",
     "exerciseRef": "202103",
     "userDescription": "March 2021"
   }

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.SurveyDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.SurveyDTO.json
@@ -1,14 +1,10 @@
 [
 	{
 		"id": "31ec898e-f370-429a-bca4-eab1045aff4e",
-		"surveyRef": "221",
-		"longName": "Business Register and Employment Survey",
-		"shortName": "BRES"
+		"surveyRef": "221"
 	},
 	{
 		"id": "32ec898e-f370-429a-bca4-eab1045aff4e",
-		"surveyRef": "222",
-		"longName": "Personal Register and Employment Survey",
-		"shortName": "PRES"
+		"surveyRef": "222"
 	}
 ]

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.CollectionExercise.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.CollectionExercise.json
@@ -2,7 +2,6 @@
 	{
 		"exercisePK": 1,
 		"id": "3ec82e0e-18ff-4886-8703-5b83442041ba",
-		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000000,
 		"state": "EXECUTED",
 		"surveyId": "31ec898e-f370-429a-bca4-eab1045aff4e",
@@ -11,7 +10,6 @@
 	{
 		"exercisePK": 2,
 		"id": "e653d1ce-551b-4b41-b05c-eec02f71891e",
-		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000000,
 		"state": "EXECUTED",
 		"surveyId": "31ec898e-f370-429a-bca4-eab1045aff4e",

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.CollectionExerciseDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImplTest.CollectionExerciseDTO.json
@@ -1,6 +1,5 @@
 {
   "surveyId": "31ec898e-f370-429a-bca4-eab1045aff4e",
-  "name": "Survey Name",
   "exerciseRef": "202103",
   "userDescription": "March 2021"
 }

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.CollectionExercise.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.CollectionExercise.json
@@ -2,7 +2,6 @@
   {
     "exercisePK": 1,
     "id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
-    "name": "BRES_2016",
     "scheduledExecutionDateTime": 1494846000001,
     "state": "EXECUTED",
     "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
@@ -11,7 +10,6 @@
   {
     "exercisePK": 2,
     "id": "14fb3e68-4dca-46db-bf49-04b84e07e77d",
-    "name": "BRES_2016",
     "scheduledExecutionDateTime": 1494846000002,
     "state": "EXECUTED",
     "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.ExerciseSampleUnit.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.ExerciseSampleUnit.json
@@ -14,7 +14,6 @@
            {
              "exercisePK": 1,
              "id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
-             "name": "BRES_2016",
              "scheduledExecutionDateTime": 1494846000001,   
              "state": "EXECUTED",
              "sampleSize": 2,

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.ExerciseSampleUnitGroup.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.ExerciseSampleUnitGroup.json
@@ -5,7 +5,6 @@
 	{
 		"exercisePK": 1,
 		"id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
-		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000001,
 		"state": "EXECUTED",
         "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
@@ -20,7 +19,6 @@
       {
 		"exercisePK": 2,
 		"id": "14fb3e68-4dca-46db-bf49-04b84e07e77d",
-		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000002,
 		"state": "EXECUTED",
         "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
@@ -35,7 +33,6 @@
 	{
 		"exercisePK": 1,
 		"id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
-		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000001,
 		"state": "EXECUTED",
         "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
@@ -50,7 +47,6 @@
       {
 		"exercisePK": 2,
 		"id": "14fb3e68-4dca-46db-bf49-04b84e07e77d",
-		"name": "BRES_2016",
 		"scheduledExecutionDateTime": 1494846000002,
 		"state": "EXECUTED",
         "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",

--- a/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.SurveyDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.SurveyDTO.json
@@ -1,7 +1,5 @@
 [{
   "id": "2615bba1-8a04-4cca-b5a0-5a0823e1c38d",
-  "shortName": "TEST",
-  "longName": "Test Survey",
   "surveyRef": "999",
   "legalBasis": "Statistics of Trade Act",
   "legalBasisRef": "STA",


### PR DESCRIPTION
### What is the Context of this PR?

Need this PR to be merged first for this to pass: https://github.com/ONSdigital/rm-collectionexercisesvc-api/pull/18

In context this PR is similar to: https://github.com/ONSdigital/ras-party/pull/152

Since the service name can be edited now, the one held in this service is not even the correct one i.e. out of date and the actual up to date survey details are stored in another service i.e. survey service

Card: https://trello.com/c/LP687BIU/331-remove-repeated-survey-name-from-services-other-than-survey-service-s

This PR aims to remove any ref of the survey name and drop the column entirely from the DB as well

### How to Review
- Run `mvn clean install` on collection-service-api then on rm-collection-exercise-service then do a `make up` on your `ras-rm-docker` then run `ras-party` locally to test all three PRs together.
- Verify all instances of survey name are removed and any code referencing it.
- Check all tests pass and that the script in the database change is correct/works. 
- Ensure all functionality works as per norm