### PR TITLE
Fix flakey integration tests

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.thoughtworks.xstream.XStream;
 import java.io.ByteArrayInputStream;
@@ -113,7 +113,9 @@ public class CollectionExerciseEndpointIT {
 
   @Rule public final SpringMethodRule springMethodRule = new SpringMethodRule();
 
-  @Rule public WireMockRule wireMockRule = new WireMockRule(options().port(18002));
+  @ClassRule
+  public static WireMockClassRule wireMockRule =
+      new WireMockClassRule(options().port(18002).bindAddress("localhost"));
 
   private CollectionExerciseClient client;
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently http requests to stubs hang intermittently.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Changing to WireMockClassRule instead of WireMockRule.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run ITs a couple of times?

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
