### PR TITLE
Roll out Godaddy logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>uk.gov.ons.ctp.product</groupId>
         <artifactId>rm-common-config</artifactId>
-        <version>10.49.12</version>
+        <version>10.49.13</version>
     </parent>
 
     <dependencies>
@@ -229,6 +229,10 @@
             <version>2.9.6</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.godaddy</groupId>
+            <artifactId>logging</artifactId>
+        </dependency>
         <!-- Third party end -->
 
         <!-- Testing -->

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.collection.exercise;
 
+import com.godaddy.logging.LoggingConfigs;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
@@ -225,6 +226,8 @@ public class CollectionExerciseApplication {
    * @param args These are the optional command line arguments
    */
   public static void main(String[] args) {
+    LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
+
     SpringApplication.run(CollectionExerciseApplication.class, args);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/ActionSvcRestClientImpl.java
@@ -1,10 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
@@ -34,8 +35,8 @@ import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 
 /** HTTP RestClient implementation for calls to the Action service. */
 @Component
-@Slf4j
 public class ActionSvcRestClientImpl implements ActionSvcClient {
+  private static final Logger log = LoggerFactory.getLogger(ActionSvcRestClientImpl.class);
 
   public static final String FOUND_NO_ACTION_PLANS =
       "Expected one action plan for selectors,"

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/CollectionInstrumentSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/CollectionInstrumentSvcRestClientImpl.java
@@ -2,9 +2,10 @@ package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
@@ -25,8 +26,9 @@ import uk.gov.ons.ctp.response.collection.instrument.representation.CollectionIn
 
 /** HTTP RestClient implementation for calls to the Collection Instrument service. */
 @Component
-@Slf4j
 public class CollectionInstrumentSvcRestClientImpl implements CollectionInstrumentSvcClient {
+  private static final Logger log =
+      LoggerFactory.getLogger(CollectionInstrumentSvcRestClientImpl.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/PartySvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/PartySvcRestClientImpl.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
@@ -24,8 +25,8 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 
 /** HTTP RestClient implementation for calls to the Party service */
 @Component
-@Slf4j
 public class PartySvcRestClientImpl implements PartySvcClient {
+  private static final Logger log = LoggerFactory.getLogger(PartySvcRestClientImpl.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
@@ -32,8 +33,8 @@ import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /** HTTP RestClient implementation for calls to the Sample service */
 @Component
-@Slf4j
 public class SampleSvcRestClientImpl implements SampleSvcClient {
+  private static final Logger log = LoggerFactory.getLogger(SampleSvcRestClientImpl.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SurveySvcRestClientImpl.java
@@ -2,10 +2,11 @@ package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Primary;
@@ -32,10 +33,10 @@ import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /** HTTP RestClient implementation for calls to the Survey service */
 @Component
-@Slf4j
 @Qualifier("restClient")
 @Primary
 public class SurveySvcRestClientImpl implements SurveySvcClient {
+  private static final Logger log = LoggerFactory.getLogger(SurveySvcRestClientImpl.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributor.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.response.collection.exercise.distribution;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -41,8 +42,8 @@ import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
 /** Class responsible for business logic to distribute SampleUnits. */
 @Component
-@Slf4j
 public class SampleUnitDistributor {
+  private static final Logger log = LoggerFactory.getLogger(SampleUnitDistributor.class);
 
   private static final String DISTRIBUTION_LIST_ID = "group";
   // this is a bit of a kludge - jpa does not like having an IN clause with an

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -2,6 +2,8 @@ package uk.gov.ons.ctp.response.collection.exercise.endpoint;
 
 import static java.util.stream.Collectors.joining;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.net.URI;
 import java.text.ParseException;
 import java.time.LocalDateTime;
@@ -18,7 +20,6 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Valid;
 import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.apache.commons.lang3.StringUtils;
 import org.quartz.Scheduler;
@@ -59,8 +60,8 @@ import uk.gov.ons.response.survey.representation.SurveyDTO;
 /** The REST endpoint controller for Collection Exercises. */
 @RestController
 @RequestMapping(value = "/collectionexercises", produces = "application/json")
-@Slf4j
 public class CollectionExerciseEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(CollectionExerciseEndpoint.class);
 
   private static final String RETURN_COLLECTIONEXERCISENOTFOUND =
       "Collection Exercise not found for collection exercise Id";

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseExecutionEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseExecutionEndpoint.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.collection.exercise.endpoint;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,8 +16,9 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 /** The REST endpoint controller for Collection Exercises. */
 @RestController
 @RequestMapping(value = "/collectionexerciseexecution", produces = "application/json")
-@Slf4j
 public class CollectionExerciseExecutionEndpoint {
+  private static final Logger log =
+      LoggerFactory.getLogger(CollectionExerciseExecutionEndpoint.class);
 
   private static final String RETURN_SAMPLENOTFOUND = "Sample not found for collection exercise Id";
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventInboundReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventInboundReceiver.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -18,8 +19,9 @@ import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
  * messages
  */
 @MessageEndpoint
-@Slf4j
 public class CollectionExerciseEventInboundReceiver {
+  private static final Logger log =
+      LoggerFactory.getLogger(CollectionExerciseEventInboundReceiver.class);
 
   @Autowired private CollectionExerciseService collectionExerciseService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventPublisherImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionExerciseEventPublisherImpl.java
@@ -2,7 +2,8 @@ package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -14,8 +15,9 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
 @Component
-@Slf4j
 public class CollectionExerciseEventPublisherImpl implements CollectionExerciseEventPublisher {
+  private static final Logger log =
+      LoggerFactory.getLogger(CollectionExerciseEventPublisherImpl.class);
 
   @Autowired private EventService eventService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionInstrumentLoadedReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionInstrumentLoadedReceiver.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -10,8 +11,9 @@ import uk.gov.ons.ctp.response.collection.exercise.message.dto.CollectionInstrum
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 
 @MessageEndpoint
-@Slf4j
 public class CollectionInstrumentLoadedReceiver {
+  private static final Logger log =
+      LoggerFactory.getLogger(CollectionInstrumentLoadedReceiver.class);
 
   @Autowired private CollectionExerciseService collectionExerciseService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/ExceptionHandler.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.MessageHandlingException;
@@ -14,8 +15,8 @@ import uk.gov.ons.ctp.response.collection.exercise.message.dto.CollectionInstrum
  * a map that's more friendly to posting as messages
  */
 @MessageEndpoint
-@Slf4j
 public class ExceptionHandler {
+  private static final Logger log = LoggerFactory.getLogger(ExceptionHandler.class);
 
   /**
    * Service activator method that accepts a MessageHandlingException, pulls out the important bits

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUnitPublisherImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUnitPublisherImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,8 +13,8 @@ import uk.gov.ons.ctp.response.collection.exercise.message.SampleUnitPublisher;
 /** Service implementation responsible for publishing a sampleUnit message to the case service. */
 @CoverageIgnore
 @MessageEndpoint
-@Slf4j
 public class SampleUnitPublisherImpl implements SampleUnitPublisher {
+  private static final Logger log = LoggerFactory.getLogger(SampleUnitPublisherImpl.class);
 
   @Qualifier("caseRabbitTemplate")
   @Autowired

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUploadedInboundReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUploadedInboundReceiver.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -14,8 +15,8 @@ import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
 
 /** Class to hold service activator method to handle incoming sample uploaded messages */
 @MessageEndpoint
-@Slf4j
 public class SampleUploadedInboundReceiver {
+  private static final Logger log = LoggerFactory.getLogger(SampleUploadedInboundReceiver.class);
 
   @Autowired private CollectionExerciseService collectionExerciseService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/schedule/EventJob.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/schedule/EventJob.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.collection.exercise.schedule;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Date;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -15,8 +16,9 @@ import uk.gov.ons.ctp.response.collection.exercise.message.CollectionExerciseEve
 import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 
 @Component
-@Slf4j
 public class EventJob implements Job {
+  private static final Logger log = LoggerFactory.getLogger(EventJob.class);
+
   @Autowired private CollectionExerciseEventPublisher eventPublisher;
 
   @Override

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/schedule/SchedulerConfiguration.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/schedule/SchedulerConfiguration.java
@@ -3,6 +3,8 @@ package uk.gov.ons.ctp.response.collection.exercise.schedule;
 import static org.quartz.JobBuilder.newJob;
 import static org.quartz.TriggerBuilder.newTrigger;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
@@ -11,7 +13,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
@@ -33,8 +34,8 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.EventDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
 @Configuration
-@Slf4j
 public class SchedulerConfiguration {
+  private static final Logger log = LoggerFactory.getLogger(SchedulerConfiguration.class);
 
   @Autowired private EventService eventService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/BusinessEventValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/BusinessEventValidator.java
@@ -12,13 +12,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService.Tag;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventValidator;
 
-@Slf4j
 public class BusinessEventValidator implements EventValidator {
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -10,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import javax.transaction.Transactional;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -42,8 +43,8 @@ import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /** The implementation of the SampleService */
 @Service
-@Slf4j
 public class CollectionExerciseServiceImpl implements CollectionExerciseService {
+  private static final Logger log = LoggerFactory.getLogger(CollectionExerciseServiceImpl.class);
 
   private CaseTypeDefaultRepository caseTypeDefaultRepo;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/EventServiceImpl.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Date;
@@ -9,7 +11,6 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,8 @@ import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventValidator;
 
 @Service
-@Slf4j
 public class EventServiceImpl implements EventService {
+  private static final Logger log = LoggerFactory.getLogger(EventServiceImpl.class);
 
   @Autowired private CollectionExerciseService collectionExerciseService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ExerciseSampleUnitGroupServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/ExerciseSampleUnitGroupServiceImpl.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,8 +18,9 @@ import uk.gov.ons.ctp.response.collection.exercise.service.ExerciseSampleUnitGro
 
 /** Implementation to deal with sampleUnitGroups. */
 @Service
-@Slf4j
 public class ExerciseSampleUnitGroupServiceImpl implements ExerciseSampleUnitGroupService {
+  private static final Logger log =
+      LoggerFactory.getLogger(ExerciseSampleUnitGroupServiceImpl.class);
 
   private static final int TRANSACTION_TIMEOUT = 60;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -1,12 +1,13 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Predicate;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -38,8 +39,8 @@ import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
 /** The implementation of the SampleService */
 @Service
-@Slf4j
 public class SampleServiceImpl implements SampleService {
+  private static final Logger log = LoggerFactory.getLogger(SampleServiceImpl.class);
 
   private static final int TRANSACTION_TIMEOUT = 60;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/PublishEventToQueueHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/PublishEventToQueueHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl.change;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -11,8 +12,9 @@ import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 
 /** EventChangeHandler to publish a message to a rabbit queue when the event changes */
 @Component
-@Slf4j
 public final class PublishEventToQueueHandler implements EventChangeHandler {
+  private static final Logger log = LoggerFactory.getLogger(PublishEventToQueueHandler.class);
+
   @Autowired private CollectionExerciseEventPublisher eventPublisher;
 
   @Override

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStartDateHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStartDateHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl.change;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
@@ -15,8 +16,8 @@ import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
  * created or updated
  */
 @Component
-@Slf4j
 public final class ScheduledStartDateHandler implements EventChangeHandler {
+  private static final Logger log = LoggerFactory.getLogger(ScheduledStartDateHandler.class);
 
   @Autowired private CollectionExerciseService collectionExerciseService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStateTransitionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/change/ScheduledStateTransitionHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl.change;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -19,8 +20,8 @@ import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
  * READY_FOR_LIVE
  */
 @Component
-@Slf4j
 public class ScheduledStateTransitionHandler implements EventChangeHandler {
+  private static final Logger log = LoggerFactory.getLogger(ScheduledStateTransitionHandler.class);
 
   @Autowired private EventService eventService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.validation;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
@@ -9,7 +11,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,8 +48,8 @@ import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /** Class responsible for business logic to validate SampleUnits. */
 @Component
-@Slf4j
 public class ValidateSampleUnits {
+  private static final Logger log = LoggerFactory.getLogger(ValidateSampleUnits.class);
 
   private static final String CASE_TYPE_SELECTOR = "COLLECTION_INSTRUMENT";
   private static final String VALIDATION_LIST_ID = "group";

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,30 +9,49 @@
     value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p})  %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
   <property name="SYSLOG_PATTERN"
     value="${LOG_LEVEL_PATTERN:-%5level} %-40.40logger{39} : %message%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
+  <property name="ISO8601_DATE_FORMAT" value="yyyy-MM-dd'T'HH:mm:ss'Z'" />
 
   <appender name="CLOUD" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
       <providers>
-        <mdc/>
-        <pattern>
-          <pattern>
-            {
-            "created": "%date{ISO8601}",
-            "service": "collectionexercisesvc",
-            "level": "%level",
-            "event": "%message"
-            }
-          </pattern>
-        </pattern>
+        <timestamp>
+          <timeZone>UTC</timeZone>
+          <pattern>${ISO8601_DATE_FORMAT}</pattern>
+          <fieldName>created</fieldName>
+        </timestamp>
+        <globalCustomFields>
+          <customFields>{"service":"collectionexercisesvc"}</customFields>
+        </globalCustomFields>
+        <message>
+          <fieldName>event</fieldName>
+        </message>
+        <loggerName/>
+        <threadName/>
+        <logLevel>
+          <fieldName>level</fieldName>
+        </logLevel>
         <stackTrace>
           <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-            <maxDepthPerThrowable>30</maxDepthPerThrowable>
-            <shortenedClassNameLength>20</shortenedClassNameLength>
+            <maxDepthPerThrowable>20</maxDepthPerThrowable>
+            <maxLength>1000</maxLength>
+            <shortenedClassNameLength>30</shortenedClassNameLength>
+            <rootCauseFirst>true</rootCauseFirst>
             <exclude>^sun\.reflect\..*\.invoke</exclude>
             <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
-            <rootCauseFirst>true</rootCauseFirst>
           </throwableConverter>
         </stackTrace>
+        <context/>
+        <jsonMessage/>
+        <mdc>
+          <includeMdcKeyName>included</includeMdcKeyName>
+        </mdc>
+        <contextMap/>
+        <tags/>
+        <logstashMarkers/>
+        <arguments>
+          <includeNonStructuredArguments>true</includeNonStructuredArguments>
+          <nonStructuredArgumentsFieldPrefix>prefix</nonStructuredArgumentsFieldPrefix>
+        </arguments>
       </providers>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorHelperIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorHelperIT.java
@@ -2,8 +2,9 @@ package uk.gov.ons.ctp.response.collection.exercise.distribution;
 
 import static org.junit.Assert.assertEquals;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,11 +23,12 @@ import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExercise
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 
 /** Integration tests */
-@Slf4j
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class SampleUnitDistributorHelperIT {
+  private static final Logger log = LoggerFactory.getLogger(SampleUnitDistributorHelperIT.class);
+
   // Gubbins to make spring wire itself up
   @ClassRule public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
   @Rule public final SpringMethodRule springMethodRule = new SpringMethodRule();

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import com.thoughtworks.xstream.XStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -37,7 +39,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.stream.Collectors;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -78,11 +79,11 @@ import uk.gov.ons.tools.rabbit.SimpleMessageListener;
 import uk.gov.ons.tools.rabbit.SimpleMessageSender;
 
 /** A class to contain integration tests for the collection exercise service */
-@Slf4j
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class CollectionExerciseEndpointIT {
+  private static final Logger log = LoggerFactory.getLogger(CollectionExerciseEndpointIT.class);
 
   private static final UUID TEST_SURVEY_ID =
       UUID.fromString("c23bb1c1-5202-43bb-8357-7a07c844308f");

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -17,6 +17,8 @@ import static uk.gov.ons.ctp.common.MvcHelper.postJson;
 import static uk.gov.ons.ctp.common.MvcHelper.putJson;
 import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -25,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.hamcrest.core.Is;
 import org.junit.Before;
@@ -61,8 +62,10 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /** Collection Exercise Endpoint Unit tests */
-@Slf4j
 public class CollectionExerciseEndpointUnitTests {
+  private static final Logger log =
+      LoggerFactory.getLogger(CollectionExerciseEndpointUnitTests.class);
+
   private static final String LINK_SAMPLE_SUMMARY_JSON =
       "{\"sampleSummaryIds\": [\"87043936-4d38-4696-952a-fcd55a51be96\", \"cf23b621-c613-424c-9d0d-53a9cfa82f3a\"]}";
   private static final UUID SURVEY_ID_1 = UUID.fromString("31ec898e-f370-429a-bca4-eab1045aff4e");

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseExecutionEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseExecutionEndpointUnitTests.java
@@ -7,9 +7,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.ons.ctp.common.MvcHelper.*;
 import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -26,8 +27,10 @@ import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 
 /** Collection Exercise Endpoint Unit tests */
-@Slf4j
 public class CollectionExerciseExecutionEndpointUnitTests {
+  private static final Logger log =
+      LoggerFactory.getLogger(CollectionExerciseExecutionEndpointUnitTests.class);
+
   private static final UUID COLLECTIONEXERCISE_ID1 =
       UUID.fromString("3ec82e0e-18ff-4886-8703-5b83442041ba");
   private static final int SAMPLEUNITSTOTAL = 500;

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepositoryIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepositoryIT.java
@@ -2,11 +2,12 @@ package uk.gov.ons.ctp.response.collection.exercise.repository;
 
 import static org.junit.Assert.assertEquals;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,11 +25,11 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGrou
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitType;
 
 /** Integration tests */
-@Slf4j
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class SampleUnitRepositoryIT {
+  private static final Logger log = LoggerFactory.getLogger(SampleUnitRepositoryIT.class);
 
   // Gubbins to make spring wire itself up
   @ClassRule public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();


### PR DESCRIPTION
# Motivation and Context
We've agreed to use the Godaddy logger for structured JSON logging, which we are now rolling out to all the Java services.

# What has changed
Replaced all the `@Slf4j` annotations. Updated the logback.xml config.

# How to test?
Run with CLOUD profile and check that the logs are coming out in the correct JSON format.

# Links
Trello: https://trello.com/c/2cLIClJa/348-roll-out-godaddy-logger-to-all-the-other-java-services

Architecture decision: https://github.com/ONSdigital/sdc/blob/master/doc/architecture/decisions/godaddy-structured-json-logging-java.md