### PR TITLE
Adding actionsvc connection config

### DIFF
--- a/manifest-template.yml
+++ b/manifest-template.yml
@@ -33,3 +33,8 @@ applications:
     endpoints_enabled: ENDPOINT_ENABLED
     security_user_name: REPLACE_BA_USERNAME
     security_user_password: REPLACE_BA_PASSWORD
+    actionSvc_connectionConfig_host: actionsvc-SPACE.DOMAIN
+    actionSvc_connectionConfig_port: "REPLACE_PORT"
+    actionSvc_connectionConfig_scheme: REPLACE_PROTOCOL
+    actionSvc_connectionConfig_username: REPLACE_BA_USERNAME
+    actionSvc_connectionConfig_password: REPLACE_BA_PASSWORD

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>collectionexercisesvc</artifactId>
-    <version>10.49.17-SNAPSHOT</version>
+    <version>10.49.17</version>
     <packaging>jar</packaging>
 
     <name>CTP : CollectionExerciseService</name>
@@ -265,7 +265,7 @@
         <connection>scm:git:https://github.com/ONSdigital/rm-collection-exercise-service</connection>
         <developerConnection>scm:git:https://github.com/ONSdigital/rm-collection-exercise-service</developerConnection>
         <url>https://github.com/ONSdigital/rm-collection-exercise-service</url>
-        <tag>collectionexercisesvc-10.49.16</tag>
+        <tag>collectionexercisesvc-10.49.17</tag>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>collectionexercisesvc</artifactId>
-    <version>10.49.16</version>
+    <version>10.49.17-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>CTP : CollectionExerciseService</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>collectionexercisesvc</artifactId>
-    <version>10.49.17</version>
+    <version>10.49.18-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>CTP : CollectionExerciseService</name>
@@ -265,7 +265,7 @@
         <connection>scm:git:https://github.com/ONSdigital/rm-collection-exercise-service</connection>
         <developerConnection>scm:git:https://github.com/ONSdigital/rm-collection-exercise-service</developerConnection>
         <url>https://github.com/ONSdigital/rm-collection-exercise-service</url>
-        <tag>collectionexercisesvc-10.49.17</tag>
+        <tag>collectionexercisesvc-10.49.16</tag>
     </scm>
 
     <build>


### PR DESCRIPTION
actionsvc connection config was missing from the manifest-template. These are required for PROD/PREPROD deployments to override localhost env variables.