### PR TITLE
Init JSON logging in PostConstruct method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.common</groupId>
             <artifactId>framework</artifactId>
-            <version>10.49.16</version>
+            <version>10.49.17</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
@@ -1,13 +1,13 @@
 package uk.gov.ons.ctp.response.collection.exercise;
 
 import com.godaddy.logging.LoggingConfigs;
+import javax.annotation.PostConstruct;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -45,7 +45,7 @@ import uk.gov.ons.ctp.response.collection.exercise.state.CollectionExerciseState
 @EnableJpaRepositories(basePackages = {"uk.gov.ons.ctp.response"})
 @EntityScan("uk.gov.ons.ctp.response")
 @ImportResource("springintegration/main.xml")
-public class CollectionExerciseApplication implements CommandLineRunner {
+public class CollectionExerciseApplication {
 
   private static final String VALIDATION_LIST = "collectionexercisesvc.sample.validation";
   private static final String DISTRIBUTION_LIST = "collectionexercisesvc.sample.distribution";
@@ -223,8 +223,8 @@ public class CollectionExerciseApplication implements CommandLineRunner {
     SpringApplication.run(CollectionExerciseApplication.class, args);
   }
 
-  @Override
-  public void run(String... args) throws Exception {
+  @PostConstruct
+  public void initJsonLogging() {
     if (appConfig.getLogging().isUseJson()) {
       LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
     }


### PR DESCRIPTION
# Motivation and Context
Bug discovered by @ajmaddaford in CI-latest where JSON not being used for key-value pairs.

# What has changed
Instead of flipping logging to use JSON in a `CommandLineRunner.run()` method, we're using a `@Postconstruct` instead, which should always fire.

# How to test?
Run with `--spring.profiles.active=cloud` or hack the `application.yml` to set `CLOUD` logger and `useJson=true`

# Links
Related Trello card: https://trello.com/c/KNOUa0pq/349-update-logging-in-all-java-services-to-use-key-value-pairs