### PR TITLE
Adjust reminder event validation

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/validator/ReminderEventValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/validator/ReminderEventValidator.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.impl.validator;
 
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,8 @@ public class ReminderEventValidator implements EventValidator {
       return false;
     }
 
-    if (isExsistingReminderInPast(submittedEvent, existingEventsMap)) {
+    if (isCollectionExerciseLockedState(collectionExerciseState)
+        && isExistingReminderInPast(submittedEvent, existingEventsMap)) {
       return false;
     }
 
@@ -55,7 +57,7 @@ public class ReminderEventValidator implements EventValidator {
     return eventDateOrderChecker.isEventDatesInOrder(reminders);
   }
 
-  private boolean isExsistingReminderInPast(
+  private boolean isExistingReminderInPast(
       Event submittedEvent, Map<String, Event> existingEventsMap) {
     final Event existingReminder = existingEventsMap.get(submittedEvent.getTag());
     if (existingReminder == null) {
@@ -63,6 +65,18 @@ public class ReminderEventValidator implements EventValidator {
     }
     final Timestamp currentTimestamp = new Timestamp(Calendar.getInstance().getTime().getTime());
     return existingReminder.getTimestamp().before(currentTimestamp);
+  }
+
+  private boolean isCollectionExerciseLockedState(CollectionExerciseState collectionExerciseState) {
+    final List<CollectionExerciseState> lockedStates =
+        Arrays.asList(
+            CollectionExerciseState.EXECUTION_STARTED,
+            CollectionExerciseState.VALIDATED,
+            CollectionExerciseState.EXECUTED,
+            CollectionExerciseState.READY_FOR_LIVE,
+            CollectionExerciseState.LIVE);
+
+    return lockedStates.contains(collectionExerciseState);
   }
 
   private boolean eventDuringExercise(Event goLive, Event event, Event exerciseEnd) {

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/validator/ReminderEventValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/validator/ReminderEventValidatorTest.java
@@ -74,7 +74,7 @@ public class ReminderEventValidatorTest {
   }
 
   @Test
-  public void testCantUpdatePastReminder() {
+  public void testCantUpdateReminderThatHasPastAndCollectionExerciseInLockedState() {
     final Event reminder = new Event();
     reminder.setTag((Tag.reminder.toString()));
     reminder.setTimestamp(Timestamp.from(Instant.now().minus(2, ChronoUnit.DAYS)));
@@ -85,7 +85,22 @@ public class ReminderEventValidatorTest {
 
     final List<Event> events = Collections.singletonList(reminder);
 
-    assertFalse(reminderValidator.validate(events, newReminder, CollectionExerciseState.CREATED));
+    assertFalse(reminderValidator.validate(events, newReminder, CollectionExerciseState.LIVE));
+  }
+
+  @Test
+  public void testCanUpdateReminderThatHasPastAndCollectionExerciseNotInLockedState() {
+    final Event reminder = new Event();
+    reminder.setTag((Tag.reminder.toString()));
+    reminder.setTimestamp(Timestamp.from(Instant.now().minus(2, ChronoUnit.DAYS)));
+
+    final Event newReminder = new Event();
+    newReminder.setTag((Tag.reminder.toString()));
+    newReminder.setTimestamp(Timestamp.from(Instant.now().plus(2, ChronoUnit.DAYS)));
+
+    final List<Event> events = Collections.singletonList(reminder);
+
+    assertTrue(reminderValidator.validate(events, newReminder, CollectionExerciseState.SCHEDULED));
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently reminder events that are in the past can not be updated,
which is a valid validation, but this check should only apply if the
collection exercise has been executed. This PR adds a check for CE
state before validating the reminder event has passed. Allowing a user
to update reminder events that have passed but not actually created any
notification files/emails.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Only validate existing reminder event hasn't passed if collection exercise has been executed.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Ran unit tests, integration tests and acceptance tests.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
