### PR TITLE
Add log of unexpected exceptions in acceptSampleUnit

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUnitReceiverImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUnitReceiverImpl.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.message.impl;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
@@ -7,6 +9,7 @@ import org.springframework.integration.annotation.ServiceActivator;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.message.SampleUnitReceiver;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
+import uk.gov.ons.ctp.response.collection.exercise.service.impl.SampleServiceImpl;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
 /**
@@ -16,6 +19,7 @@ import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 @CoverageIgnore
 @MessageEndpoint
 public class SampleUnitReceiverImpl implements SampleUnitReceiver {
+  private static final Logger log = LoggerFactory.getLogger(SampleUnitReceiverImpl.class);
 
   @Autowired private SampleService sampleService;
 
@@ -23,6 +27,13 @@ public class SampleUnitReceiverImpl implements SampleUnitReceiver {
   @Override
   @ServiceActivator(inputChannel = "sampleUnitTransformed", adviceChain = "sampleUnitRetryAdvice")
   public void acceptSampleUnit(SampleUnit sampleUnit) throws CTPException {
-    sampleService.acceptSampleUnit(sampleUnit);
+    try {
+      sampleService.acceptSampleUnit(sampleUnit);
+    } catch (Exception e) {
+      // We are seeing messages from the sample service being DLQ'ed. This log should help diagnose
+      log.with("sample_unit", sampleUnit)
+        .error("Unexpected exception processing sample unit", e);
+      throw e;
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUnitReceiverImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/SampleUnitReceiverImpl.java
@@ -9,7 +9,6 @@ import org.springframework.integration.annotation.ServiceActivator;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.message.SampleUnitReceiver;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
-import uk.gov.ons.ctp.response.collection.exercise.service.impl.SampleServiceImpl;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
 /**
@@ -31,8 +30,7 @@ public class SampleUnitReceiverImpl implements SampleUnitReceiver {
       sampleService.acceptSampleUnit(sampleUnit);
     } catch (Exception e) {
       // We are seeing messages from the sample service being DLQ'ed. This log should help diagnose
-      log.with("sample_unit", sampleUnit)
-        .error("Unexpected exception processing sample unit", e);
+      log.with("sample_unit", sampleUnit).error("Unexpected exception processing sample unit", e);
       throw e;
     }
   }


### PR DESCRIPTION
# Motivation and Context
We are seeing an intermittent failure of the collection exercise service to process all the sample units sent from the sample unit service via Rabbit. Occasionally a message is Dead-Letter-Queued (DLQ'ed) and this results in the collection exercise getting into a hung state expecting all the sample units to arrive.

There is no useful logging to tell us why the message is being DLQ'ed, so this PR adds in a blanket catch-all-log-and-rethrow to help us diagnose this intermittant issue in all environments.

# What has changed
Added a catch clause to catch any exceptions at the moment before they would cause a Rabbit message to be DLQ'ed, and to log out the details.

# How to test?
Because this is an intermittent failure, the CI environment run by concourse is the place where we're most likely to see this. We should let the pipeline run as normal, and when we see it hanging we can examine the logs, which should hopefully allow us to diagnose the problem.

# Links
Nope