### PR TITLE
Fix race condition by checking if value is null before comparison

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -166,8 +166,9 @@ public class SampleServiceImpl implements SampleService {
 
         sampleUnitRepo.saveAndFlush(exerciseSampleUnit);
 
-        if (sampleUnitRepo.countBySampleUnitGroupCollectionExercise(collectionExercise)
-            == collectionExercise.getSampleSize()) {
+        if (collectionExercise.getSampleSize() != null
+            && sampleUnitRepo.countBySampleUnitGroupCollectionExercise(collectionExercise)
+                == collectionExercise.getSampleSize()) {
           collectionExercise.setState(
               collectionExerciseTransitionState.transition(
                   collectionExercise.getState(), CollectionExerciseEvent.EXECUTION_COMPLETE));


### PR DESCRIPTION
# Motivation and Context
There is a race condition where `CollectionExerciseExecutionEndpoint.requestSampleUnits` makes a REST API call to Sample service to send all the sample units _before_ it has recorded the number of sample units it's expecting.

To fix this _properly_ will require a change to the sample service to get the number of sample units separately from the request for them to be sent - a new API method.

This is a stop-gap fix which will improve things, but does not [yet] eliminate every edge case.

# What has changed
Updated `SampleServiceImpl.acceptSampleUnit` to check to make sure we have an expected number of sample units before we do the comparison to see if we've received them all.

Obviously, there's a problem if they all get received very quickly, but this ought to fix our null pointer exceptions causing messages to be DLQ'ed and therefore collection exercises getting stuck and never transitioning to the next state. There will need to be a much more complex fix for this, which requires two PRs with one dependent on the first.

# How to test?
Because this bug only occurs intermittently in CI and PROD, we should let it run through the pipeline and see if it happens over the course of a day or two.

# Links
Trello: https://trello.com/c/DvavjcNS/376-bug-investigate-intermittent-failure-of-collex-to-receive-process-all-sample-units-hanging