### PR TITLE
Fix race condition on sample size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.product</groupId>
             <artifactId>samplesvc-api</artifactId>
-            <version>10.49.17</version>
+            <version>10.49.19</version>
         </dependency>
 
         <dependency>
@@ -320,7 +320,7 @@
             <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.3.4</version>
+                <version>1.4.4</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
@@ -20,5 +20,5 @@ public interface SampleSvcClient {
 
   SampleSummaryDTO getSampleSummary(UUID sampleSummaryId);
 
-  SampleUnitsRequestDTO getSampleUnitSize(List<UUID> sampleSummaryIdList);
+  SampleUnitsRequestDTO getSampleUnitCount(List<UUID> sampleSummaryIdList);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitSizeRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 
 /** Service responsible for making client calls to the Sample service */
@@ -18,4 +19,6 @@ public interface SampleSvcClient {
   SampleUnitsRequestDTO requestSampleUnits(CollectionExercise exercise) throws CTPException;
 
   SampleSummaryDTO getSampleSummary(UUID sampleSummaryId);
+
+  SampleUnitsRequestDTO getSampleUnitSize(SampleUnitSizeRequestDTO sampleUnitSizeRequestDTO);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
@@ -1,10 +1,10 @@
 package uk.gov.ons.ctp.response.collection.exercise.client;
 
+import java.util.List;
 import java.util.UUID;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitSizeRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 
 /** Service responsible for making client calls to the Sample service */
@@ -20,5 +20,5 @@ public interface SampleSvcClient {
 
   SampleSummaryDTO getSampleSummary(UUID sampleSummaryId);
 
-  SampleUnitsRequestDTO getSampleUnitSize(SampleUnitSizeRequestDTO sampleUnitSizeRequestDTO);
+  SampleUnitsRequestDTO getSampleUnitSize(List<UUID> sampleSummaryIdList);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
@@ -129,7 +129,7 @@ public class SampleSvcRestClientImpl implements SampleSvcClient {
 
     ResponseEntity<SampleUnitsRequestDTO> responseEntity =
         restTemplate.exchange(
-            uriComponents.toUri(), HttpMethod.POST, httpEntity, SampleUnitsRequestDTO.class);
+            uriComponents.toUri(), HttpMethod.GET, httpEntity, SampleUnitsRequestDTO.class);
 
     return responseEntity.getBody();
   }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
@@ -116,14 +116,14 @@ public class SampleSvcRestClientImpl implements SampleSvcClient {
   }
 
   @Override
-  public SampleUnitsRequestDTO getSampleUnitSize(List<UUID> sampleSummaryIdList) {
+  public SampleUnitsRequestDTO getSampleUnitCount(List<UUID> sampleSummaryIdList) {
 
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     sampleSummaryIdList.forEach(id -> queryParams.add("sampleSummaryId", id.toString()));
 
     UriComponents uriComponents =
         restUtility.createUriComponents(
-            appConfig.getSampleSvc().getRequestSampleUnitSizePath(), queryParams);
+            appConfig.getSampleSvc().getRequestSampleUnitCountPath(), queryParams);
 
     HttpEntity<UriComponents> httpEntity = restUtility.createHttpEntity(uriComponents);
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
@@ -3,7 +3,6 @@ package uk.gov.ons.ctp.response.collection.exercise.client.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -89,19 +88,10 @@ public class SampleSvcRestClientImpl implements SampleSvcClient {
           restUtility.createHttpEntity(requestDTO);
 
       log.with("collection_exercise_id", exercise.getId()).debug("about to get to the Sample SVC");
-      ResponseEntity<String> responseEntity =
-          restTemplate.exchange(uriComponents.toUri(), HttpMethod.POST, httpEntity, String.class);
-
-      SampleUnitsRequestDTO result = null;
-      if (responseEntity != null && responseEntity.getStatusCode().is2xxSuccessful()) {
-        String responseBody = responseEntity.getBody();
-        try {
-          result = objectMapper.readValue(responseBody, SampleUnitsRequestDTO.class);
-        } catch (IOException e) {
-          log.error("Unable to read party response", e);
-        }
-      }
-      return result;
+      ResponseEntity<SampleUnitsRequestDTO> responseEntity =
+          restTemplate.exchange(
+              uriComponents.toUri(), HttpMethod.POST, httpEntity, SampleUnitsRequestDTO.class);
+      return responseEntity.getBody();
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
@@ -14,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
@@ -27,7 +29,6 @@ import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkReposito
 import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
 import uk.gov.ons.ctp.response.sample.representation.CollectionExerciseJobCreationRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitSizeRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
@@ -115,15 +116,16 @@ public class SampleSvcRestClientImpl implements SampleSvcClient {
   }
 
   @Override
-  public SampleUnitsRequestDTO getSampleUnitSize(
-      SampleUnitSizeRequestDTO sampleUnitSizeRequestDTO) {
+  public SampleUnitsRequestDTO getSampleUnitSize(List<UUID> sampleSummaryIdList) {
+
+    MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+    sampleSummaryIdList.forEach(id -> queryParams.add("sampleSummaryId", id.toString()));
 
     UriComponents uriComponents =
         restUtility.createUriComponents(
-            appConfig.getSampleSvc().getRequestSampleUnitSizePath(), null);
+            appConfig.getSampleSvc().getRequestSampleUnitSizePath(), queryParams);
 
-    HttpEntity<SampleUnitSizeRequestDTO> httpEntity =
-        restUtility.createHttpEntity(sampleUnitSizeRequestDTO);
+    HttpEntity<UriComponents> httpEntity = restUtility.createHttpEntity(uriComponents);
 
     ResponseEntity<SampleUnitsRequestDTO> responseEntity =
         restTemplate.exchange(

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImpl.java
@@ -28,6 +28,7 @@ import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkReposito
 import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
 import uk.gov.ons.ctp.response.sample.representation.CollectionExerciseJobCreationRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitSizeRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
@@ -121,5 +122,23 @@ public class SampleSvcRestClientImpl implements SampleSvcClient {
     SampleSummaryDTO sampleSummary = response.getBody();
     log.with("sample_summary", sampleSummary).debug("Got sample Summary");
     return sampleSummary;
+  }
+
+  @Override
+  public SampleUnitsRequestDTO getSampleUnitSize(
+      SampleUnitSizeRequestDTO sampleUnitSizeRequestDTO) {
+
+    UriComponents uriComponents =
+        restUtility.createUriComponents(
+            appConfig.getSampleSvc().getRequestSampleUnitSizePath(), null);
+
+    HttpEntity<SampleUnitSizeRequestDTO> httpEntity =
+        restUtility.createHttpEntity(sampleUnitSizeRequestDTO);
+
+    ResponseEntity<SampleUnitsRequestDTO> responseEntity =
+        restTemplate.exchange(
+            uriComponents.toUri(), HttpMethod.POST, httpEntity, SampleUnitsRequestDTO.class);
+
+    return responseEntity.getBody();
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SampleSvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SampleSvc.java
@@ -10,5 +10,5 @@ import uk.gov.ons.ctp.common.rest.RestUtilityConfig;
 public class SampleSvc {
   private RestUtilityConfig connectionConfig;
   private String requestSampleUnitsPath;
-  private String requestSampleUnitSizePath;
+  private String requestSampleUnitCountPath;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SampleSvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/SampleSvc.java
@@ -10,4 +10,5 @@ import uk.gov.ons.ctp.common.rest.RestUtilityConfig;
 public class SampleSvc {
   private RestUtilityConfig connectionConfig;
   private String requestSampleUnitsPath;
+  private String requestSampleUnitSizePath;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollexSampleCountUpdater.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollexSampleCountUpdater.java
@@ -1,0 +1,26 @@
+package uk.gov.ons.ctp.response.collection.exercise.service;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
+
+@Component
+public class CollexSampleCountUpdater {
+  private final CollectionExerciseRepository collexRepo;
+
+  public CollexSampleCountUpdater(CollectionExerciseRepository collexRepo) {
+    this.collexRepo = collexRepo;
+  }
+
+  // REQUIRES_NEW forces this to happen in a new transaction, so we know that it's been committed
+  // when this method exits - it's important to avoid race condition
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void updateSampleSize(UUID collexId, int sampleSize) {
+    CollectionExercise collex = collexRepo.findOneById(collexId);
+    collex.setSampleSize(sampleSize);
+    collexRepo.saveAndFlush(collex);
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -30,10 +31,12 @@ import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExer
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitValidationErrorDTO;
+import uk.gov.ons.ctp.response.collection.exercise.service.CollexSampleCountUpdater;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
 import uk.gov.ons.ctp.response.collection.exercise.validation.ValidateSampleUnits;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitSizeRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
@@ -55,6 +58,8 @@ public class SampleServiceImpl implements SampleService {
   @Autowired private CollectionExerciseRepository collectRepo;
 
   @Autowired private SampleSvcClient sampleSvcClient;
+
+  @Autowired private CollexSampleCountUpdater collexSampleCountUpdater;
 
   @Autowired
   @Qualifier("collectionExercise")
@@ -93,31 +98,38 @@ public class SampleServiceImpl implements SampleService {
 
   @Override
   public SampleUnitsRequestDTO requestSampleUnits(final UUID id) throws CTPException {
-
-    SampleUnitsRequestDTO replyDTO = null;
-
     CollectionExercise collectionExercise = collectRepo.findOneById(id);
 
-    // Check collection exercise exists
-    if (collectionExercise != null) {
-      replyDTO = sampleSvcClient.requestSampleUnits(collectionExercise);
-
-      if (replyDTO != null && replyDTO.getSampleUnitsTotal() > 0) {
-
-        List<SampleLink> sampleLinks =
-            sampleLinkRepository.findByCollectionExerciseId(collectionExercise.getId());
-        for (SampleLink samplelink : sampleLinks) {
-          partySvcClient.linkSampleSummaryId(
-              samplelink.getSampleSummaryId().toString(), collectionExercise.getId().toString());
-        }
-
-        collectionExercise.setSampleSize(replyDTO.getSampleUnitsTotal());
-        collectionExercise.setState(
-            collectionExerciseTransitionState.transition(
-                collectionExercise.getState(), CollectionExerciseEvent.EXECUTE));
-        collectRepo.saveAndFlush(collectionExercise);
-      }
+    if (collectionExercise == null) {
+      throw new IllegalArgumentException(String.format("Collection exercise %s not found", id));
     }
+
+    List<SampleLink> sampleLinks = sampleLinkRepository.findByCollectionExerciseId(id);
+    List<UUID> sampleSummaryUUIDList = sampleLinks.stream().map(SampleLink::getSampleSummaryId)
+      .collect(Collectors.toList());
+
+    // Pre-grab and save the total number of sample units we expect to receive from the sample
+    // service BEFORE it starts to send them, to ensure no race condition
+    SampleUnitSizeRequestDTO requestDTO = new SampleUnitSizeRequestDTO(sampleSummaryUUIDList);
+    SampleUnitsRequestDTO responseDTO = sampleSvcClient.getSampleUnitSize(requestDTO);
+    collexSampleCountUpdater.updateSampleSize(id, responseDTO.getSampleUnitsTotal());
+
+    // Request the sample units. They'll start arriving as soon as this line executes. Be ready!
+    SampleUnitsRequestDTO replyDTO = sampleSvcClient.requestSampleUnits(collectionExercise);
+
+    if (replyDTO != null && replyDTO.getSampleUnitsTotal() > 0) {
+      for (SampleLink samplelink : sampleLinks) {
+        partySvcClient.linkSampleSummaryId(
+            samplelink.getSampleSummaryId().toString(), collectionExercise.getId().toString());
+      }
+
+      collectionExercise.setSampleSize(replyDTO.getSampleUnitsTotal());
+      collectionExercise.setState(
+          collectionExerciseTransitionState.transition(
+              collectionExercise.getState(), CollectionExerciseEvent.EXECUTE));
+      collectRepo.saveAndFlush(collectionExercise);
+    }
+
     return replyDTO;
   }
 
@@ -166,9 +178,8 @@ public class SampleServiceImpl implements SampleService {
 
         sampleUnitRepo.saveAndFlush(exerciseSampleUnit);
 
-        if (collectionExercise.getSampleSize() != null
-            && sampleUnitRepo.countBySampleUnitGroupCollectionExercise(collectionExercise)
-                == collectionExercise.getSampleSize()) {
+        if (sampleUnitRepo.countBySampleUnitGroupCollectionExercise(collectionExercise)
+            == collectionExercise.getSampleSize()) {
           collectionExercise.setState(
               collectionExerciseTransitionState.transition(
                   collectionExercise.getState(), CollectionExerciseEvent.EXECUTION_COMPLETE));

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -105,8 +105,8 @@ public class SampleServiceImpl implements SampleService {
     }
 
     List<SampleLink> sampleLinks = sampleLinkRepository.findByCollectionExerciseId(id);
-    List<UUID> sampleSummaryUUIDList = sampleLinks.stream().map(SampleLink::getSampleSummaryId)
-      .collect(Collectors.toList());
+    List<UUID> sampleSummaryUUIDList =
+        sampleLinks.stream().map(SampleLink::getSampleSummaryId).collect(Collectors.toList());
 
     // Pre-grab and save the total number of sample units we expect to receive from the sample
     // service BEFORE it starts to send them, to ensure no race condition

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -109,7 +109,7 @@ public class SampleServiceImpl implements SampleService {
 
     // Pre-grab and save the total number of sample units we expect to receive from the sample
     // service BEFORE it starts to send them, to ensure no race condition
-    SampleUnitsRequestDTO responseDTO = sampleSvcClient.getSampleUnitSize(sampleSummaryIdList);
+    SampleUnitsRequestDTO responseDTO = sampleSvcClient.getSampleUnitCount(sampleSummaryIdList);
     collexSampleCountUpdater.updateSampleSize(id, responseDTO.getSampleUnitsTotal());
 
     // Request the sample units. They'll start arriving as soon as this line executes. Be ready!
@@ -176,8 +176,9 @@ public class SampleServiceImpl implements SampleService {
 
         sampleUnitRepo.saveAndFlush(exerciseSampleUnit);
 
-        if (sampleUnitRepo.countBySampleUnitGroupCollectionExercise(collectionExercise)
-            == collectionExercise.getSampleSize()) {
+        if (collectionExercise.getSampleSize() != null
+            && sampleUnitRepo.countBySampleUnitGroupCollectionExercise(collectionExercise)
+                == collectionExercise.getSampleSize()) {
           collectionExercise.setState(
               collectionExerciseTransitionState.transition(
                   collectionExercise.getState(), CollectionExerciseEvent.EXECUTION_COMPLETE));

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImpl.java
@@ -36,7 +36,6 @@ import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
 import uk.gov.ons.ctp.response.collection.exercise.validation.ValidateSampleUnits;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitSizeRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
@@ -105,13 +104,12 @@ public class SampleServiceImpl implements SampleService {
     }
 
     List<SampleLink> sampleLinks = sampleLinkRepository.findByCollectionExerciseId(id);
-    List<UUID> sampleSummaryUUIDList =
+    List<UUID> sampleSummaryIdList =
         sampleLinks.stream().map(SampleLink::getSampleSummaryId).collect(Collectors.toList());
 
     // Pre-grab and save the total number of sample units we expect to receive from the sample
     // service BEFORE it starts to send them, to ensure no race condition
-    SampleUnitSizeRequestDTO requestDTO = new SampleUnitSizeRequestDTO(sampleSummaryUUIDList);
-    SampleUnitsRequestDTO responseDTO = sampleSvcClient.getSampleUnitSize(requestDTO);
+    SampleUnitsRequestDTO responseDTO = sampleSvcClient.getSampleUnitSize(sampleSummaryIdList);
     collexSampleCountUpdater.updateSampleSize(id, responseDTO.getSampleUnitsTotal());
 
     // Request the sample units. They'll start arriving as soon as this line executes. Be ready!

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,7 +83,7 @@ spring:
 
 sample-svc:
   request-sample-units-path: /samples/sampleunitrequests
-  request-sample-unit-size-path: /samples/samplecount
+  request-sample-unit-count-path: /samples/count
   connection-config:
     scheme: http
     host: localhost

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,6 +83,7 @@ spring:
 
 sample-svc:
   request-sample-units-path: /samples/sampleunitrequests
+  request-sample-unit-size-path: /samples/sampleunitsize
   connection-config:
     scheme: http
     host: localhost

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,7 +83,7 @@ spring:
 
 sample-svc:
   request-sample-units-path: /samples/sampleunitrequests
-  request-sample-unit-size-path: /samples/sampleunitsize
+  request-sample-unit-size-path: /samples/samplecount
   connection-config:
     scheme: http
     host: localhost

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImplTest.java
@@ -99,7 +99,7 @@ public class SampleSvcRestClientImplTest {
     given(
             restTemplate.exchange(
                 any(URI.class),
-                eq(HttpMethod.POST),
+                eq(HttpMethod.GET),
                 any(HttpEntity.class),
                 eq(SampleUnitsRequestDTO.class)))
         .willReturn(responseEntity);

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImplTest.java
@@ -27,7 +27,6 @@ import uk.gov.ons.ctp.common.rest.RestUtilityConfig;
 import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 import uk.gov.ons.ctp.response.collection.exercise.config.SampleSvc;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitSizeRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -88,8 +87,6 @@ public class SampleSvcRestClientImplTest {
 
   @Test
   public void getSampleUnitSizeHappyPath() {
-    SampleUnitSizeRequestDTO request =
-        new SampleUnitSizeRequestDTO(Collections.singletonList(UUID.randomUUID()));
     SampleUnitsRequestDTO response = new SampleUnitsRequestDTO(666);
     SampleSvc sampleSvc = Mockito.mock(SampleSvc.class);
     ResponseEntity<SampleUnitsRequestDTO> responseEntity = Mockito.mock(ResponseEntity.class);
@@ -108,7 +105,8 @@ public class SampleSvcRestClientImplTest {
         .willReturn(responseEntity);
 
     // When
-    SampleUnitsRequestDTO actualResponse = sampleSvcRestClient.getSampleUnitSize(request);
+    SampleUnitsRequestDTO actualResponse =
+        sampleSvcRestClient.getSampleUnitSize(Collections.singletonList(UUID.randomUUID()));
 
     // Then
     assertEquals(666, actualResponse.getSampleUnitsTotal().intValue());

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImplTest.java
@@ -88,8 +88,8 @@ public class SampleSvcRestClientImplTest {
 
   @Test
   public void getSampleUnitSizeHappyPath() {
-    SampleUnitSizeRequestDTO request = new SampleUnitSizeRequestDTO(
-      Collections.singletonList(UUID.randomUUID()));
+    SampleUnitSizeRequestDTO request =
+        new SampleUnitSizeRequestDTO(Collections.singletonList(UUID.randomUUID()));
     SampleUnitsRequestDTO response = new SampleUnitsRequestDTO(666);
     SampleSvc sampleSvc = Mockito.mock(SampleSvc.class);
     ResponseEntity<SampleUnitsRequestDTO> responseEntity = Mockito.mock(ResponseEntity.class);
@@ -100,12 +100,12 @@ public class SampleSvcRestClientImplTest {
     given(responseEntity.getStatusCode()).willReturn(HttpStatus.OK);
     given(responseEntity.getBody()).willReturn(response);
     given(
-      restTemplate.exchange(
-        any(URI.class),
-        eq(HttpMethod.POST),
-        any(HttpEntity.class),
-        eq(SampleUnitsRequestDTO.class)))
-      .willReturn(responseEntity);
+            restTemplate.exchange(
+                any(URI.class),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(SampleUnitsRequestDTO.class)))
+        .willReturn(responseEntity);
 
     // When
     SampleUnitsRequestDTO actualResponse = sampleSvcRestClient.getSampleUnitSize(request);

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/impl/SampleSvcRestClientImplTest.java
@@ -93,7 +93,7 @@ public class SampleSvcRestClientImplTest {
 
     // Given
     given(appConfig.getSampleSvc()).willReturn(sampleSvc);
-    given(sampleSvc.getRequestSampleUnitSizePath()).willReturn("test/path");
+    given(sampleSvc.getRequestSampleUnitCountPath()).willReturn("test/path");
     given(responseEntity.getStatusCode()).willReturn(HttpStatus.OK);
     given(responseEntity.getBody()).willReturn(response);
     given(
@@ -106,7 +106,7 @@ public class SampleSvcRestClientImplTest {
 
     // When
     SampleUnitsRequestDTO actualResponse =
-        sampleSvcRestClient.getSampleUnitSize(Collections.singletonList(UUID.randomUUID()));
+        sampleSvcRestClient.getSampleUnitCount(Collections.singletonList(UUID.randomUUID()));
 
     // Then
     assertEquals(666, actualResponse.getSampleUnitsTotal().intValue());

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/CollexSampleCountUpdaterTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/CollexSampleCountUpdaterTest.java
@@ -17,11 +17,9 @@ import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExercise
 
 @RunWith(MockitoJUnitRunner.class)
 public class CollexSampleCountUpdaterTest {
-  @Mock
-  private CollectionExerciseRepository collexRepo;
+  @Mock private CollectionExerciseRepository collexRepo;
 
-  @InjectMocks
-  private CollexSampleCountUpdater underTest;
+  @InjectMocks private CollexSampleCountUpdater underTest;
 
   @Test
   public void updateSampleSizeHappyPath() {

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/CollexSampleCountUpdaterTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/CollexSampleCountUpdaterTest.java
@@ -1,0 +1,43 @@
+package uk.gov.ons.ctp.response.collection.exercise.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
+import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CollexSampleCountUpdaterTest {
+  @Mock
+  private CollectionExerciseRepository collexRepo;
+
+  @InjectMocks
+  private CollexSampleCountUpdater underTest;
+
+  @Test
+  public void updateSampleSizeHappyPath() {
+    UUID collexId = UUID.randomUUID();
+    CollectionExercise collex = new CollectionExercise();
+
+    // Given
+    when(collexRepo.findOneById(eq(collexId))).thenReturn(collex);
+
+    // When
+    underTest.updateSampleSize(collexId, 666);
+
+    // Then
+    ArgumentCaptor<CollectionExercise> actual = ArgumentCaptor.forClass(CollectionExercise.class);
+    verify(collexRepo).saveAndFlush(actual.capture());
+    assertEquals(collex, actual.getValue());
+    assertEquals(666, actual.getValue().getSampleSize().intValue());
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImplTest.java
@@ -4,10 +4,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,16 +20,22 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
+import uk.gov.ons.ctp.response.collection.exercise.client.PartySvcClient;
+import uk.gov.ons.ctp.response.collection.exercise.client.SampleSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
+import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
+import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitGroupRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
+import uk.gov.ons.ctp.response.collection.exercise.service.CollexSampleCountUpdater;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitType;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
 /** Unit tests */
@@ -39,7 +48,15 @@ public class SampleServiceImplTest {
 
   @Mock private SampleUnitGroupRepository sampleUnitGroupRepo;
 
+  @Mock private SampleLinkRepository sampleLinkRepo;
+
   @Mock private CollectionExerciseRepository collectRepo;
+
+  @Mock private SampleSvcClient sampleSvcClient;
+
+  @Mock private CollexSampleCountUpdater collexSampleCountUpdater;
+
+  @Mock private PartySvcClient partySvcClient;
 
   @Mock
   private StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent>
@@ -109,6 +126,34 @@ public class SampleServiceImplTest {
     verify(sampleUnitGroupRepo, never()).saveAndFlush(any());
     verify(sampleUnitRepo, never()).saveAndFlush(any());
     verify(collectRepo, never()).saveAndFlush(any());
+  }
+
+  @Test
+  public void requestSampleUnitsHappyPath() throws CTPException {
+    UUID collexId = UUID.randomUUID();
+    UUID sampleSummaryId = UUID.randomUUID();
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setId(collexId);
+    SampleLink sampleLink = new SampleLink();
+    sampleLink.setSampleSummaryId(sampleSummaryId);
+    List<SampleLink> sampleLinks = Collections.singletonList(sampleLink);
+    SampleUnitsRequestDTO sampleUnitsRequestDTO = new SampleUnitsRequestDTO();
+    sampleUnitsRequestDTO.setSampleUnitsTotal(666);
+
+    // Given
+    when(collectRepo.findOneById(eq(collexId))).thenReturn(collectionExercise);
+    when(sampleLinkRepo.findByCollectionExerciseId(any())).thenReturn(sampleLinks);
+    when(sampleSvcClient.getSampleUnitSize(any())).thenReturn(sampleUnitsRequestDTO);
+    when(sampleSvcClient.requestSampleUnits(any())).thenReturn(sampleUnitsRequestDTO);
+
+    // When
+    underTest.requestSampleUnits(collexId);
+
+    // Then
+    verify(collexSampleCountUpdater).updateSampleSize(eq(collexId), eq(666));
+    verify(partySvcClient).linkSampleSummaryId(any(), any());
+    verify(collectionExerciseTransitionState).transition(any(), any());
+    verify(collectRepo).saveAndFlush(any());
   }
 
   private void acceptSampleUnitWithCollex(CollectionExercise collex) throws CTPException {

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/SampleServiceImplTest.java
@@ -143,7 +143,7 @@ public class SampleServiceImplTest {
     // Given
     when(collectRepo.findOneById(eq(collexId))).thenReturn(collectionExercise);
     when(sampleLinkRepo.findByCollectionExerciseId(any())).thenReturn(sampleLinks);
-    when(sampleSvcClient.getSampleUnitSize(any())).thenReturn(sampleUnitsRequestDTO);
+    when(sampleSvcClient.getSampleUnitCount(any())).thenReturn(sampleUnitsRequestDTO);
     when(sampleSvcClient.requestSampleUnits(any())).thenReturn(sampleUnitsRequestDTO);
 
     // When


### PR DESCRIPTION
# Motivation and Context
Presently the Collection Exercise service doesn't know how many sample units it expects to be sent by the Sample service until it requests the sample units to be sent, which causes a race condition - if the sample units start arriving before Collex has managed to store the expected number to the database.

This was causing intermittent failures in the CI pipeline and in production, and a temporary fix was to ignore the count check if we didn't have an expected value, but this fix was less than ideal, because the race condition still potentially existed for very small sample sizes.

This fix is intended to close all the loopholes by asking for the number of expected sample units _before_ they start to be sent by the Sample service. This is **one of three** related PRs.

# What has changed
Before instructing Sample service to send the sample units, while handling a `CollectionExerciseExecutionEndpoint.requestSampleUnits` request, we first request the total number of sample units we expect to receive from the Sample service, using a new REST API call.

We have to ensure that the transaction is committed before any Rabbit messages start arriving, so the update to the database for the count is done in its own transaction.

# How to test?
This is an intermittent bug which is hard to reproduce. Try uploading some samples to make sure there's no regression

# Links
Trello: https://trello.com/c/DaKcP1zA/379-race-condition-fix-for-sample-collex-exchange-of-sample-data