### PR TITLE
Add optional parameter to REST API to allow filter by only live collexes

### DIFF
--- a/API.md
+++ b/API.md
@@ -18,6 +18,7 @@ This page documents the Collection Exercise service API endpoints. Apart from th
 
 ## Get Collection Exercises for Survey
 * `GET /collectionexercises/survey/{survey_id}` will return a list of known collection exercises for the survey id.
+* `GET /collectionexercises/survey/{survey_id}?liveOnly=true` will return a list of LIVE collection exercises for the survey id.
 
 ### Example JSON Response
 ```json

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 
 /** Spring JPA Repository for Collection Exercise */
 public interface CollectionExerciseRepository extends JpaRepository<CollectionExercise, Integer> {
@@ -27,6 +28,8 @@ public interface CollectionExerciseRepository extends JpaRepository<CollectionEx
   List<CollectionExercise> findByExerciseRefAndSurveyId(String exerciseRef, UUID surveyUuid);
 
   List<CollectionExercise> findBySurveyId(UUID surveyUuid);
+
+  List<CollectionExercise> findBySurveyIdAndState(UUID surveyUuid, CollectionExerciseState state);
 
   /**
    * Query repository for list of collection exercises associated with a certain state.

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
@@ -8,6 +8,7 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.CaseType;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.response.survey.representation.SurveyDTO;
 
 /** Service responsible for dealing with collection exercises */
@@ -20,6 +21,9 @@ public interface CollectionExerciseService {
    * @return the associated collection exercises.
    */
   List<CollectionExercise> findCollectionExercisesForSurvey(SurveyDTO survey);
+
+  List<CollectionExercise> findCollectionExercisesBySurveyIdAndState(
+      UUID surveyId, CollectionExerciseState state);
 
   /**
    * Find a collection exercise associated to a collection exercise Id from the Collection Exercise

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java
@@ -35,6 +35,7 @@ import uk.gov.ons.ctp.response.collection.exercise.repository.CaseTypeOverrideRe
 import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionTransitionEvent;
 import uk.gov.ons.ctp.response.collection.exercise.service.SurveyService;
@@ -100,6 +101,12 @@ public class CollectionExerciseServiceImpl implements CollectionExerciseService 
   @Override
   public List<CollectionExercise> findCollectionExercisesForSurvey(SurveyDTO survey) {
     return this.collectRepo.findBySurveyId(UUID.fromString(survey.getId()));
+  }
+
+  @Override
+  public List<CollectionExercise> findCollectionExercisesBySurveyIdAndState(
+      UUID surveyId, CollectionExerciseState state) {
+    return collectRepo.findBySurveyIdAndState(surveyId, state);
   }
 
   @Override

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -52,6 +52,7 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeDefault;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.LinkedSampleSummariesDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
@@ -164,6 +165,35 @@ public class CollectionExerciseEndpointUnitTests {
     ResultActions actions =
         mockCollectionExerciseMvc.perform(
             getJson(String.format("/collectionexercises/survey/%s", SURVEY_ID_1)));
+
+    actions
+        .andExpect(status().isOk())
+        .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
+        .andExpect(handler().methodName("getCollectionExercisesForSurvey"))
+        .andExpect(jsonPath("$", hasSize(2)))
+        .andExpect(
+            jsonPath(
+                "$[*].id",
+                containsInAnyOrder(
+                    COLLECTIONEXERCISE_ID1.toString(), COLLECTIONEXERCISE_ID2.toString())))
+        .andExpect(
+            jsonPath(
+                "$[*].scheduledExecutionDateTime",
+                containsInAnyOrder(
+                    new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT),
+                    new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT))));
+  }
+
+  @Test
+  public void findCollectionExercisesForSurveyOnlyLive() throws Exception {
+    when(surveyService.findSurvey(SURVEY_ID_1)).thenReturn(surveyDtoResults.get(0));
+    when(collectionExerciseService.findCollectionExercisesBySurveyIdAndState(
+            SURVEY_ID_1, CollectionExerciseState.LIVE))
+        .thenReturn(collectionExerciseResults);
+
+    ResultActions actions =
+        mockCollectionExerciseMvc.perform(
+            getJson(String.format("/collectionexercises/survey/%s?liveOnly=true", SURVEY_ID_1)));
 
     actions
         .andExpect(status().isOk())


### PR DESCRIPTION
# Motivation and Context
We are currently filtering in the front end, to display only the live collection exercises. By adding an optional parameter to the REST API, we can simplify the front-end code and reduce the amount of data being transferred from DB -> Collex Service -> Front-end.

# What has changed
Added optional param to `CollectionExerciseEndpoint.getCollectionExercisesForSurvey`.

# How to test?
There's a new unit/REST test which covers this change.

To manually test, send a GET to `http://localhost:8145/collectionexercises/survey/{id}?liveOnly=true` and you should only receive collection exercises which are in the LIVE state.

# Links
Trello: https://trello.com/c/n7EcEA9y/344-add-ability-to-collection-exercise-to-only-return-live-collection-exercises-for-a-survey-m