### PR TITLE
Update snapshot version to 10.49.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>collectionexercisesvc</artifactId>
-    <version>10.49.19-SNAPSHOT</version>
+    <version>10.49.21-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>CTP : CollectionExerciseService</name>


### PR DESCRIPTION
We recently had to do a bug fix off an earlier release and create a jar from it in artifactory. Because of that we are out of step and the snapshot version needs updating