### PR TITLE
Fix potential dead heat problem when processing sample units

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleUnitReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleUnitReceiver.java
@@ -25,7 +25,7 @@ public class SampleUnitReceiver {
    * @throws CTPException when collection exercise state transition error
    */
   @ServiceActivator(inputChannel = "sampleUnitTransformed", adviceChain = "sampleUnitRetryAdvice")
-  public void acceptSampleUnit(SampleUnit sampleUnit) throws CTPException {
+  public void acceptSampleUnit(final SampleUnit sampleUnit) throws CTPException {
     sampleService.acceptSampleUnit(sampleUnit);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
@@ -10,12 +10,10 @@ import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.common.error.CTPException;
-import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.collection.exercise.client.PartySvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.client.SampleSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.distribution.SampleUnitDistributor;
@@ -27,8 +25,6 @@ import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExercise
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitGroupRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitRepository;
-import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;
-import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitValidationErrorDTO;
 import uk.gov.ons.ctp.response.collection.exercise.validation.ValidateSampleUnits;
@@ -55,11 +51,6 @@ public class SampleService {
   @Autowired private CollectionExerciseRepository collectRepo;
 
   @Autowired private SampleSvcClient sampleSvcClient;
-
-  @Autowired
-  @Qualifier("collectionExercise")
-  private StateTransitionManager<CollectionExerciseState, CollectionExerciseEvent>
-      collectionExerciseTransitionState;
 
   @Autowired private CollexSampleUnitReceiptPreparer collexSampleUnitReceiptPreparer;
 
@@ -148,7 +139,7 @@ public class SampleService {
       propagation = Propagation.REQUIRED,
       readOnly = false,
       timeout = TRANSACTION_TIMEOUT)
-  public ExerciseSampleUnit acceptSampleUnit(SampleUnit sampleUnit) throws CTPException {
+  public ExerciseSampleUnit acceptSampleUnit(SampleUnit sampleUnit) {
     log.with("sample_unit", sampleUnit).debug("Processing sample unit");
     ExerciseSampleUnit exerciseSampleUnit = null;
 
@@ -179,17 +170,6 @@ public class SampleService {
             SampleUnitDTO.SampleUnitType.valueOf(sampleUnit.getSampleUnitType()));
 
         sampleUnitRepo.saveAndFlush(exerciseSampleUnit);
-
-        if (collectionExercise.getSampleSize() != null
-            && sampleUnitRepo.countBySampleUnitGroupCollectionExercise(collectionExercise)
-                == collectionExercise.getSampleSize()) {
-          collectionExercise.setState(
-              collectionExerciseTransitionState.transition(
-                  collectionExercise.getState(), CollectionExerciseEvent.EXECUTION_COMPLETE));
-          collectionExercise.setActualExecutionDateTime(new Timestamp(new Date().getTime()));
-          collectRepo.saveAndFlush(collectionExercise);
-        }
-
       } else {
         log.with("sample_unit_type_fk", sampleUnit.getSampleUnitType())
             .with("sample_unit_ref", sampleUnit.getSampleUnitRef())

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
@@ -11,7 +11,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.collection.exercise.client.PartySvcClient;

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleService.java
@@ -135,11 +135,8 @@ public class SampleService {
    * @param sampleUnit the sample unit from the message.
    * @return the saved sample unit.
    */
-  @Transactional(
-      propagation = Propagation.REQUIRED,
-      readOnly = false,
-      timeout = TRANSACTION_TIMEOUT)
-  public ExerciseSampleUnit acceptSampleUnit(SampleUnit sampleUnit) {
+  @Transactional
+  public ExerciseSampleUnit acceptSampleUnit(final SampleUnit sampleUnit) {
     log.with("sample_unit", sampleUnit).debug("Processing sample unit");
     ExerciseSampleUnit exerciseSampleUnit = null;
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
@@ -28,7 +28,6 @@ import uk.gov.ons.ctp.response.collection.exercise.config.ScheduleSettings;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
-import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;


### PR DESCRIPTION
# Motivation and Context
With multiple instances of the Collection Exercise service running in production, it's theoretically possible that the final couple of messages could be processed simultaneously, in which case the collection exercise would never transition from EXECUTION_STARTED to EXECUTED and trigger validation on the poller, because the expected number of sample units isn't reached by a single thread in a single process, in the event of a dead-heat.

Although this hasn't been seen definitely 'in the wild' it's theoretically possible and a fix was trivial. Multiple other fixes have gone in for the 'hanging' pipeline, due to the collection exercise not doing what it's supposed to after the sample upload. Although this doesn't fix the CI pipeline issues, it definitely eliminates a _potential_ production issue. The CI pipeline problems have hopefully now been resolved by **other** bug fixes.

Cumulatively, all these bug fixes should lead to a more reliable, predictable, stable production system which requires less 'black magic' poking and prodding by ops.

# What has changed
The check for any collection exercises which have received all their sample units has been moved into the validation poller (scheduled job) which will transition collection exercises to EXECUTED state as soon as the expected number of sample units matches the actual.

# How to test?
It's a theoretical bug which is hard to reproduce (it might not even happen). We could construct a load-test which might reproduce it, but it might be an unreproducible bug. Certainly the evidence from the CI pipeline is that it's never happened, although we only ever have 1 instance of the Collection Exercise service running.

Essentially, all we need to test is that there's no regression, so try uploading some samples of various sizes and make sure that the Collection Exercise goes to READY_FOR_LIVE without any issues.

# Links
Trello: https://trello.com/c/SXz1P5ZU/447-bug-collex-can-fail-to-update-state-after-receiving-all-sample-units-prod
