### PR TITLE
Increase the app memory in the manifest file from 1Gb to 2Gb

### DIFF
--- a/manifest-template.yml
+++ b/manifest-template.yml
@@ -3,7 +3,7 @@ applications:
   instances: INSTANCES
   timeout: 180
   host: collectionexercisesvc-SPACE
-  memory: 1024M
+  memory: 2048M
   path: target/collectionexercisesvc.jar
   services:
     - DATABASE


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# What has changed
In Preprod and prod, the app memory has been manually increased to 2Gb.  If the app crashes then it restarts with the default memory as specified in the manifest (currently 1Gb) - this isn't enough so collection exercise falls over and large parts of the system become unusable.  This work increases the default memory to 2Gb.

# How to test?
- Everything should work as normal
