### PR TITLE
Automate census docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag collectionexercisesvc "${DOCKER_GCP_LOCATION}"/collectionexercisesvc;
   docker push "${DOCKER_GCP_LOCATION}"/collectionexercisesvc;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ services:
 language: java
 jdk: openjdk8
 
+env:
+  global:
+    - SOURCE_IMAGE_NAME="collectionexercisesvc"
+    - DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-collectionexercisesvc"
+
 before_install:
 - cp .maven.settings.xml $HOME/.m2/settings.xml
 - mvn fmt:check
@@ -16,8 +21,8 @@ script: mvn verify cobertura:cobertura-integration-test
 after_success:
 - if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
-  docker tag collectionexercisesvc "${DOCKER_GCP_LOCATION}"/collectionexercisesvc;
-  docker push "${DOCKER_GCP_LOCATION}"/collectionexercisesvc;
+  docker tag "$SOURCE_IMAGE_NAME" "$DESTINATION_IMAGE_NAME";
+  docker push "$DESTINATION_IMAGE_NAME";
   fi
 - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag collectionexercisesvc "${DOCKER_GCP_LOCATION}"/collectionexercisesvc;
   docker push "${DOCKER_GCP_LOCATION}"/collectionexercisesvc;
@@ -34,4 +34,5 @@ cache:
 
 branches:
   only:
-  - rm-census
+    - rm-census
+    - automate-census-docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,16 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-  docker push sdcplatform/collectionexercisesvc;
+- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  docker tag collectionexercisesvc "${DOCKER_GCP_LOCATION}"/collectionexercisesvc;
+  docker push "${DOCKER_GCP_LOCATION}"/collectionexercisesvc;
   fi
 - bash <(curl -s https://codecov.io/bash)
 
 notifications:
   slack:
-    on_failure: always
+    on_failure: never
     on_success: never
     rooms:
       secure: xHvqsIklJ+gX67JbpTdi0TMHxMKV9llXH6htk8qIe/sRweq/8tgcTFhSnp6Zlw42cFH6jeweme8xXH6xS3Cft6gLj8nHwAzpkU6cgDndUDPiN1pgCZOBHmIccFcWrl81REfJVgyOVicyKgVthdV1VLCDUkj9Cq+67LKq+EUi9EUw5/1ZzAkPDmuhzinelZ50lu27jyWcPQkKjN4XnpLYB2ybyqqBAJkKaxwooxCZifq1Ghub7a/EH7wiCZgc0zyJfg6EvY4MkJgbfj6b449PRTYaqNxj8Cpy0hO7EsALSednjbjoJtH3+axAFoHdVvskj0QAc3Q9pZfddXWajK4uvWOxf8EifvbhOX+yMJDy7olfuDfVD+BuCSwUXKycbJNA5C4A9fSvj/aoHI/kxxm+/ydToSaZVxLmIa5WR8EU215AAzP3RnOfYDcpPAbYLtq+TdqMuxmns+4mNjOflu4EaRexlNgWbnEwRDvuvgoS/ALEFr2fHrC/LSoMDdgb0pxDE7ddFmAsutWT8zbhGjrNF3mXlfJWEu4xky3rmUsc3GiB5xebPnPaagrVciwHkyJenn8zywBn+zk3u/VfQuHTN9u04dwf38FNC/QZBNj9AFy9wyn9YxWVvsS7euEkpbMLorz1fcIQL+H1sP8C3tZqOleurY+0mkJRHMsiGSjwwx4=
@@ -33,4 +34,4 @@ cache:
 
 branches:
   only:
-  - master
+  - rm-census

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,6 @@ after_success:
   fi
 - bash <(curl -s https://codecov.io/bash)
 
-notifications:
-  slack:
-    on_failure: never
-    on_success: never
-    rooms:
-      secure: xHvqsIklJ+gX67JbpTdi0TMHxMKV9llXH6htk8qIe/sRweq/8tgcTFhSnp6Zlw42cFH6jeweme8xXH6xS3Cft6gLj8nHwAzpkU6cgDndUDPiN1pgCZOBHmIccFcWrl81REfJVgyOVicyKgVthdV1VLCDUkj9Cq+67LKq+EUi9EUw5/1ZzAkPDmuhzinelZ50lu27jyWcPQkKjN4XnpLYB2ybyqqBAJkKaxwooxCZifq1Ghub7a/EH7wiCZgc0zyJfg6EvY4MkJgbfj6b449PRTYaqNxj8Cpy0hO7EsALSednjbjoJtH3+axAFoHdVvskj0QAc3Q9pZfddXWajK4uvWOxf8EifvbhOX+yMJDy7olfuDfVD+BuCSwUXKycbJNA5C4A9fSvj/aoHI/kxxm+/ydToSaZVxLmIa5WR8EU215AAzP3RnOfYDcpPAbYLtq+TdqMuxmns+4mNjOflu4EaRexlNgWbnEwRDvuvgoS/ALEFr2fHrC/LSoMDdgb0pxDE7ddFmAsutWT8zbhGjrNF3mXlfJWEu4xky3rmUsc3GiB5xebPnPaagrVciwHkyJenn8zywBn+zk3u/VfQuHTN9u04dwf38FNC/QZBNj9AFy9wyn9YxWVvsS7euEkpbMLorz1fcIQL+H1sP8C3tZqOleurY+0mkJRHMsiGSjwwx4=
-
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,4 @@ cache:
 
 branches:
   only:
-    - rm-census
     - automate-census-docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
+- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag "$SOURCE_IMAGE_NAME" "$DESTINATION_IMAGE_NAME";
   docker push "$DESTINATION_IMAGE_NAME";
@@ -32,4 +32,4 @@ cache:
 
 branches:
   only:
-    - automate-census-docker-build
+    - rm-census

--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <repository>sdcplatform/${project.artifactId}</repository>
+                            <repository>${project.artifactId}</repository>
                             <buildArgs>
                                 <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
                             </buildArgs>


### PR DESCRIPTION
# Motivation and Context
We want travis build to push docker images to Google Container Registry instead of dockerhub

# What has changed
Replaced docker image prefix with GCR registry location
NOTE: before merge, remove "automate-census-docker-build" branch condition and "branches only" section in .travis.yml file

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
From travis dashboard, switch to  "automate-census-docker-build" branch and "Restart Build". Once complete, check latest Docker image is in GCR.
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/dC6sEWqE/443-set-up-automated-docker-image-build)