### PR TITLE
Refactor sample validation

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepository.java
@@ -54,7 +54,14 @@ public interface SampleUnitRepository extends JpaRepository<ExerciseSampleUnit, 
   List<ExerciseSampleUnit> findBySampleUnitGroupCollectionExerciseAndSampleUnitGroupStateFK(
       CollectionExercise collectionExercise, SampleUnitGroupState sampleUnitGroupState);
 
+  /**
+   * Find sample units with collection exercise and group in a particular state
+   *
+   * @param collexState a collection exercise state
+   * @param sampleUnitGroupState a group state
+   * @return a stream of sample units with collection exercise and group in a particular state
+   */
   Stream<ExerciseSampleUnit> findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
-      CollectionExerciseDTO.CollectionExerciseState state,
+      CollectionExerciseDTO.CollectionExerciseState collexState,
       SampleUnitGroupState sampleUnitGroupState);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/SampleUnitRepository.java
@@ -1,11 +1,13 @@
 package uk.gov.ons.ctp.response.collection.exercise.repository;
 
 import java.util.List;
+import java.util.stream.Stream;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
+import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 
@@ -51,4 +53,8 @@ public interface SampleUnitRepository extends JpaRepository<ExerciseSampleUnit, 
    */
   List<ExerciseSampleUnit> findBySampleUnitGroupCollectionExerciseAndSampleUnitGroupStateFK(
       CollectionExercise collectionExercise, SampleUnitGroupState sampleUnitGroupState);
+
+  Stream<ExerciseSampleUnit> findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+      CollectionExerciseDTO.CollectionExerciseState state,
+      SampleUnitGroupState sampleUnitGroupState);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java
@@ -3,39 +3,36 @@ package uk.gov.ons.ctp.response.collection.exercise.validation;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import org.apache.commons.collections.CollectionUtils;
+import java.util.stream.Stream;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
-import uk.gov.ons.ctp.common.distributed.DistributedListManager;
-import uk.gov.ons.ctp.common.distributed.LockingException;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.collection.exercise.client.CollectionInstrumentSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.client.PartySvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.client.SurveySvcClient;
-import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitRepository;
-import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.ExerciseSampleUnitGroupService;
-import uk.gov.ons.ctp.response.collection.exercise.service.ExerciseSampleUnitService;
 import uk.gov.ons.ctp.response.collection.instrument.representation.CollectionInstrumentDTO;
 import uk.gov.ons.ctp.response.party.representation.PartyDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
@@ -45,19 +42,12 @@ import uk.gov.ons.response.survey.representation.SurveyClassifierTypeDTO;
 /** Class responsible for business logic to validate SampleUnits. */
 @Component
 public class ValidateSampleUnits {
+
   private static final Logger log = LoggerFactory.getLogger(ValidateSampleUnits.class);
 
   private static final String CASE_TYPE_SELECTOR = "COLLECTION_INSTRUMENT";
-  private static final String VALIDATION_LIST_ID = "group";
-  private static final int IMPOSSIBLE_ID = Integer.MAX_VALUE;
-
-  private static final String SURVEY_CLASSIFIER_TYPES_NOT_FOUND =
-      "Survey classifier types not found";
-
-  private AppConfig appConfig;
 
   private CollectionExerciseService collexService;
-  private ExerciseSampleUnitService sampleUnitSvc;
   private ExerciseSampleUnitGroupService sampleUnitGroupSvc;
 
   private CollectionInstrumentSvcClient collectionInstrumentSvcClient;
@@ -68,12 +58,8 @@ public class ValidateSampleUnits {
 
   private StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent> sampleUnitGroupState;
 
-  private DistributedListManager<Integer> sampleValidationListManager;
-
   public ValidateSampleUnits(
-      final AppConfig appConfig,
       final CollectionExerciseService collexService,
-      final ExerciseSampleUnitService sampleUnitSvc,
       final ExerciseSampleUnitGroupService sampleUnitGroupSvc,
       final CollectionInstrumentSvcClient collectionInstrumentSvcClient,
       final PartySvcClient partySvcClient,
@@ -81,62 +67,101 @@ public class ValidateSampleUnits {
       final SampleUnitRepository sampleUnitRepo,
       final @Qualifier("sampleUnitGroup") StateTransitionManager<
                   SampleUnitGroupState, SampleUnitGroupEvent>
-              sampleUnitGroupState,
-      final @Qualifier("validation") DistributedListManager<Integer> sampleValidationListManager) {
-    this.appConfig = appConfig;
+              sampleUnitGroupState) {
     this.collexService = collexService;
-    this.sampleUnitSvc = sampleUnitSvc;
     this.sampleUnitGroupSvc = sampleUnitGroupSvc;
     this.collectionInstrumentSvcClient = collectionInstrumentSvcClient;
     this.partySvcClient = partySvcClient;
     this.surveySvcClient = surveySvcClient;
     this.sampleUnitRepo = sampleUnitRepo;
     this.sampleUnitGroupState = sampleUnitGroupState;
-    this.sampleValidationListManager = sampleValidationListManager;
   }
 
   /** Validate SampleUnits */
+  @Transactional
   public void validateSampleUnits() {
 
     // Make sure that any collection exercises which were having their sample units sent from
     // the sample service are state transitioned once they've got all their sample units.
     updateExecutingCollectionExercises();
 
-    List<CollectionExercise> exercises =
-        collexService.findByState(CollectionExerciseDTO.CollectionExerciseState.EXECUTED);
-    if (exercises.isEmpty()) {
-      return;
-    }
+    Set<CollectionExercise> collectionExerciseSet = new HashSet<>();
 
-    try {
-      List<ExerciseSampleUnitGroup> sampleUnitGroups = retrieveSampleUnitGroups(exercises);
-      Map<CollectionExercise, List<ExerciseSampleUnitGroup>> collections =
-          sampleUnitGroups
-              .stream()
-              .collect(Collectors.groupingBy(ExerciseSampleUnitGroup::getCollectionExercise));
+    try (Stream<ExerciseSampleUnit> sampleUnits =
+        sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+            CollectionExerciseState.EXECUTED, SampleUnitGroupState.INIT)) {
 
-      collections.forEach(
-          (exercise, groups) -> {
+      sampleUnits.forEach(
+          (sampleUnit) -> {
+            collectionExerciseSet.add(sampleUnit.getSampleUnitGroup().getCollectionExercise());
+
+            List<String> classifierTypes =
+                requestSurveyClassifiers(sampleUnit.getSampleUnitGroup().getCollectionExercise());
+
             try {
-              addCollectionInstrumentIds(exercise, groups);
-              transitionCollectionExercise(exercise);
-            } catch (CTPException e) {
-              log.error(
-                  "Error validating collection exercise, collectionExerciseId: {}",
-                  exercise.getId());
-              log.error("Stack trace: {}", e);
+              UUID collectionInstrumentId =
+                  requestCollectionInstrumentId(
+                      classifierTypes,
+                      sampleUnit,
+                      sampleUnit
+                          .getSampleUnitGroup()
+                          .getCollectionExercise()
+                          .getSurveyId()
+                          .toString());
+              sampleUnit.setCollectionInstrumentId(collectionInstrumentId);
+            } catch (HttpClientErrorException e) {
+              if (e.getStatusCode() != HttpStatus.NOT_FOUND) {
+                log.with("sample_unit", sampleUnit)
+                    .with("status_code", e.getStatusCode())
+                    .error("Unexpected HTTP response code from collection instrument service");
+                throw e; // Re-throw anything that's not a 404 so that we retry
+              }
             }
-          });
 
-    } catch (LockingException ex) {
-      log.error("Failed to get lock", ex);
-    } finally {
-      try {
-        sampleValidationListManager.deleteList(VALIDATION_LIST_ID, true);
-      } catch (LockingException ex) {
-        log.error("Failed to delete lock list", ex);
-      }
+            if (sampleUnit.getSampleUnitType() == SampleUnitDTO.SampleUnitType.B) {
+              try {
+                PartyDTO party =
+                    partySvcClient.requestParty(
+                        sampleUnit.getSampleUnitType(), sampleUnit.getSampleUnitRef());
+                sampleUnit.setPartyId(UUID.fromString(party.getId()));
+              } catch (HttpClientErrorException e) {
+                if (e.getStatusCode() != HttpStatus.NOT_FOUND) {
+                  log.with("sample_unit", sampleUnit)
+                      .with("status_code", e.getStatusCode())
+                      .error("Unexpected HTTP response code from party service");
+                  throw e; // Re-throw anything that's not a 404 so that we retry
+                }
+              }
+            }
+
+            ExerciseSampleUnitGroup sampleUnitGroup = sampleUnit.getSampleUnitGroup();
+            sampleUnitGroup.setModifiedDateTime(new Timestamp(new Date().getTime()));
+
+            SampleUnitGroupEvent event = SampleUnitGroupEvent.VALIDATE;
+            if (!isSampleUnitValid(sampleUnit)) {
+              event = SampleUnitGroupEvent.INVALIDATE;
+            }
+
+            try {
+              sampleUnitGroup.setStateFK(
+                  sampleUnitGroupState.transition(
+                      sampleUnit.getSampleUnitGroup().getStateFK(), event));
+            } catch (CTPException e) {
+              // Ignored because this should never happen - we know the transition is valid
+            }
+
+            sampleUnitRepo.save(sampleUnit);
+          });
     }
+
+    collectionExerciseSet.forEach(
+        (exercise) -> {
+          try {
+            transitionCollectionExercise(exercise);
+          } catch (CTPException e) {
+            // Ignored because this should never happen - we know the transition is valid
+          }
+        });
   }
 
   private void updateExecutingCollectionExercises() {
@@ -161,96 +186,6 @@ public class ValidateSampleUnits {
   }
 
   /**
-   * Retrieve SampleUnitGroups to be validated - state INIT - but do not retrieve the same
-   * SampleUnitGroups as other service instances.
-   *
-   * @param exercises for which to return sampleUnitGroups.
-   * @return list of SampleUnitGroups.
-   * @throws LockingException problem obtaining lock for data shared across instances.
-   */
-  private List<ExerciseSampleUnitGroup> retrieveSampleUnitGroups(List<CollectionExercise> exercises)
-      throws LockingException {
-
-    List<Integer> excludedGroups = sampleValidationListManager.findList(VALIDATION_LIST_ID, false);
-    log.with("excluded_groups", excludedGroups)
-        .debug("VALIDATION - Retrieve sampleUnitGroups excluding");
-
-    excludedGroups.add(IMPOSSIBLE_ID);
-    List<ExerciseSampleUnitGroup> sampleUnitGroups =
-        sampleUnitGroupSvc
-            .findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
-                SampleUnitGroupState.INIT,
-                exercises,
-                excludedGroups,
-                new PageRequest(0, appConfig.getSchedules().getValidationScheduleRetrievalMax()));
-
-    if (!CollectionUtils.isEmpty(sampleUnitGroups)) {
-      String sampleGroupPks =
-          sampleUnitGroups
-              .stream()
-              .map(group -> group.getSampleUnitGroupPK().toString())
-              .collect(Collectors.joining(","));
-      log.with("sample_unit_group_pks", sampleGroupPks)
-          .debug("VALIDATION retrieved sampleUnitGroup PKs");
-      sampleValidationListManager.saveList(
-          VALIDATION_LIST_ID,
-          sampleUnitGroups
-              .stream()
-              .map(ExerciseSampleUnitGroup::getSampleUnitGroupPK)
-              .collect(Collectors.toList()),
-          true);
-    } else {
-      log.debug("VALIDATION retrieved 0 sampleUnitGroup PKs");
-      sampleValidationListManager.unlockContainer();
-    }
-    return sampleUnitGroups;
-  }
-
-  /**
-   * Add collection instrument id and party id to each SampleUnit
-   *
-   * @param exercise for which to validate the SampleUnitGroups
-   * @param sampleUnitGroups in exercise
-   */
-  private void addCollectionInstrumentIds(
-      CollectionExercise exercise, List<ExerciseSampleUnitGroup> sampleUnitGroups)
-      throws CTPException {
-
-    List<String> classifierTypes = requestSurveyClassifiers(exercise);
-    if (classifierTypes.isEmpty()) {
-      log.with("survey_id", exercise.getSurveyId().toString())
-          .error("Failed to retrieve survey classifiers");
-      throw new CTPException(
-          CTPException.Fault.RESOURCE_NOT_FOUND,
-          String.format(
-              "%s, surveyId: %s", SURVEY_CLASSIFIER_TYPES_NOT_FOUND, exercise.getId().toString()));
-    }
-
-    for (ExerciseSampleUnitGroup sampleUnitGroup : sampleUnitGroups) {
-      List<ExerciseSampleUnit> sampleUnits = sampleUnitSvc.findBySampleUnitGroup(sampleUnitGroup);
-      for (ExerciseSampleUnit sampleUnit : sampleUnits) {
-        try {
-          UUID collectionInstrumentId =
-              requestCollectionInstrumentId(
-                  classifierTypes, sampleUnit, exercise.getSurveyId().toString());
-          sampleUnit.setCollectionInstrumentId(collectionInstrumentId);
-
-          if (sampleUnit.getSampleUnitType() == SampleUnitDTO.SampleUnitType.B) {
-            PartyDTO party =
-                partySvcClient.requestParty(
-                    sampleUnit.getSampleUnitType(), sampleUnit.getSampleUnitRef());
-            sampleUnit.setPartyId(UUID.fromString(party.getId()));
-          }
-        } catch (RestClientException ex) {
-          log.with("sample_unit_group_PK", sampleUnitGroup.getSampleUnitGroupPK())
-              .error("Error in validation of SampleUnitGroup", ex);
-        }
-      }
-      saveUpdatedSampleUnits(sampleUnitGroup, sampleUnits);
-    }
-  }
-
-  /**
    * Request the classifier type selectors from the Survey service.
    *
    * @param exercise for which to get collection instrument classifier selectors.
@@ -259,41 +194,34 @@ public class ValidateSampleUnits {
   private List<String> requestSurveyClassifiers(CollectionExercise exercise) {
 
     SurveyClassifierTypeDTO classifierTypeSelector;
-    List<String> classifierTypes = new ArrayList<>();
 
     // Call Survey Service
     // Get Classifier types for Collection Instruments
-    try {
-      List<SurveyClassifierDTO> classifierTypeSelectors =
-          surveySvcClient.requestClassifierTypeSelectors(exercise.getSurveyId());
-      SurveyClassifierDTO chosenSelector =
-          classifierTypeSelectors
-              .stream()
-              .filter(classifierType -> CASE_TYPE_SELECTOR.equals(classifierType.getName()))
-              .findAny()
-              .orElse(null);
-      if (chosenSelector != null) {
-        classifierTypeSelector =
-            surveySvcClient.requestClassifierTypeSelector(
-                exercise.getSurveyId(), UUID.fromString(chosenSelector.getId()));
-        if (classifierTypeSelector != null) {
-          classifierTypes = classifierTypeSelector.getClassifierTypes();
-        } else {
-          log.error(
-              "Error requesting Survey Classifier Types for SurveyId: {},  caseTypeSelectorId: {}",
-              exercise.getSurveyId(),
-              chosenSelector.getId());
-        }
+    List<SurveyClassifierDTO> classifierTypeSelectors =
+        surveySvcClient.requestClassifierTypeSelectors(exercise.getSurveyId());
+    SurveyClassifierDTO chosenSelector =
+        classifierTypeSelectors
+            .stream()
+            .filter(classifierType -> CASE_TYPE_SELECTOR.equals(classifierType.getName()))
+            .findAny()
+            .orElse(null);
+    if (chosenSelector != null) {
+      classifierTypeSelector =
+          surveySvcClient.requestClassifierTypeSelector(
+              exercise.getSurveyId(), UUID.fromString(chosenSelector.getId()));
+      if (classifierTypeSelector != null) {
+        return classifierTypeSelector.getClassifierTypes();
       } else {
-        log.error(
-            "Error requesting Survey Classifier Types for SurveyId: {}", exercise.getSurveyId());
+        log.with("survey_id", exercise.getSurveyId())
+            .with("case_type_selector_id", chosenSelector.getId())
+            .error("Error requesting Survey Classifier Types");
+        throw new IllegalStateException("Error requesting Survey Classifier Types");
       }
-    } catch (RestClientException ex) {
-      log.error("Error retrieving survey classifiers, error: {}", ex.getMessage());
-      log.error(ex.toString());
+    } else {
+      log.with("survey_id", exercise.getSurveyId())
+          .error("Error requesting Survey Classifier Types");
+      throw new IllegalStateException("Error requesting Survey Classifier Types");
     }
-
-    return classifierTypes;
   }
 
   /**
@@ -349,14 +277,6 @@ public class ValidateSampleUnits {
     return searchString.toString();
   }
 
-  private void saveUpdatedSampleUnits(
-      final ExerciseSampleUnitGroup sampleUnitGroup, final List<ExerciseSampleUnit> sampleUnits) {
-    ExerciseSampleUnitGroup updatedSampleUnitGroup =
-        transitionSampleUnitGroupState(sampleUnitGroup, sampleUnits);
-    updatedSampleUnitGroup.setModifiedDateTime(new Timestamp(new Date().getTime()));
-    sampleUnitGroupSvc.storeExerciseSampleUnitGroup(updatedSampleUnitGroup, sampleUnits);
-  }
-
   private void transitionCollectionExercise(CollectionExercise exercise) throws CTPException {
     CollectionExerciseEvent event = null;
     long init =
@@ -381,43 +301,11 @@ public class ValidateSampleUnits {
     }
 
     if (event != null) {
-      this.collexService.transitionCollectionExercise(exercise, event);
+      collexService.transitionCollectionExercise(exercise, event);
     }
   }
 
-  /**
-   * Transition Sample Unit Group state for validation.
-   *
-   * @param sampleUnitGroup to be transitioned.
-   * @param sampleUnits in SampleUnitGroup.
-   * @return sampleUnitGroup with new state.
-   */
-  private ExerciseSampleUnitGroup transitionSampleUnitGroupState(
-      ExerciseSampleUnitGroup sampleUnitGroup, List<ExerciseSampleUnit> sampleUnits) {
-
-    boolean stateValidated =
-        sampleUnits.size() > 0
-            && sampleUnits.stream().allMatch(ValidateSampleUnits::isSampleUnitValid);
-    try {
-      if (stateValidated) {
-        sampleUnitGroup.setStateFK(
-            sampleUnitGroupState.transition(
-                sampleUnitGroup.getStateFK(), SampleUnitGroupEvent.VALIDATE));
-      } else {
-        log.info(
-            "Setting sample unit group to FAILEDVALIDATION, sampleUnitGroupPK: {}",
-            sampleUnitGroup.getSampleUnitGroupPK());
-        sampleUnitGroup.setStateFK(
-            sampleUnitGroupState.transition(
-                sampleUnitGroup.getStateFK(), SampleUnitGroupEvent.INVALIDATE));
-      }
-    } catch (CTPException ex) {
-      log.error("Sample Unit group state transition failed", ex);
-    }
-    return sampleUnitGroup;
-  }
-
-  private static boolean isSampleUnitValid(ExerciseSampleUnit sampleUnit) {
+  private boolean isSampleUnitValid(ExerciseSampleUnit sampleUnit) {
     if (sampleUnit.getSampleUnitType() == SampleUnitDTO.SampleUnitType.H) {
       return sampleUnit.getCollectionInstrumentId() != null && sampleUnit.getPartyId() == null;
     } else if (sampleUnit.getSampleUnitType() == SampleUnitDTO.SampleUnitType.B

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java
@@ -42,7 +42,6 @@ import uk.gov.ons.response.survey.representation.SurveyClassifierTypeDTO;
 /** Class responsible for business logic to validate SampleUnits. */
 @Component
 public class ValidateSampleUnits {
-
   private static final Logger log = LoggerFactory.getLogger(ValidateSampleUnits.class);
 
   private static final String CASE_TYPE_SELECTOR = "COLLECTION_INSTRUMENT";
@@ -147,7 +146,7 @@ public class ValidateSampleUnits {
                   sampleUnitGroupState.transition(
                       sampleUnit.getSampleUnitGroup().getStateFK(), event));
             } catch (CTPException e) {
-              // Ignored because this should never happen - we know the transition is valid
+              throw new IllegalStateException(); // Not thrown because we already checked the state
             }
 
             sampleUnitRepo.save(sampleUnit);
@@ -159,7 +158,7 @@ public class ValidateSampleUnits {
           try {
             transitionCollectionExercise(exercise);
           } catch (CTPException e) {
-            // Ignored because this should never happen - we know the transition is valid
+            throw new IllegalStateException(); // Not thrown because we already checked the state
           }
         });
   }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidationScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidationScheduler.java
@@ -1,5 +1,8 @@
 package uk.gov.ons.ctp.response.collection.exercise.validation;
 
+import java.util.concurrent.TimeUnit;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -11,17 +14,34 @@ import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
  */
 @Component
 public class ValidationScheduler {
+  private static final String VALIDATION_GLOBAL_LOCK_NAME = "SampleValidationCollexLock";
 
   private SampleService sampleService;
+  private RedissonClient redissonClient;
 
   @Autowired
-  public ValidationScheduler(SampleService sampleService) {
+  public ValidationScheduler(SampleService sampleService, RedissonClient redissonClient) {
     this.sampleService = sampleService;
+    this.redissonClient = redissonClient;
   }
 
   /** Carry out scheduled validation according to configured fixed delay. */
   @Scheduled(fixedDelayString = "#{appConfig.schedules.validationScheduleDelayMilliSeconds}")
   public void scheduleValidation() {
-    sampleService.validateSampleUnits();
+    RLock lock = redissonClient.getFairLock(VALIDATION_GLOBAL_LOCK_NAME);
+
+    // Get a lock. Automatically unlock after a certain amount of time to prevent issues
+    // when lock holder crashes or Redis crashes causing permanent lockout
+    try {
+      if (lock.tryLock(1, TimeUnit.HOURS)) {
+        try {
+          sampleService.validateSampleUnits();
+        } finally {
+          lock.unlock();
+        }
+      }
+    } catch (InterruptedException e) {
+      // Ignored
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
@@ -261,7 +261,6 @@ public class ValidateSampleUnitsTest {
         .transitionCollectionExercise(collectionExercise, CollectionExerciseEvent.INVALIDATE);
   }
 
-
   @Test(expected = HttpClientErrorException.class)
   public void testValidateSampleUnitsCollectionInstrumentFail() {
     // Given
@@ -284,16 +283,16 @@ public class ValidateSampleUnitsTest {
     classifierTypeSelector.setClassifierTypes(Collections.emptyList());
 
     when(sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
-      any(), any()))
-      .thenReturn(sampleUnits.stream());
+            any(), any()))
+        .thenReturn(sampleUnits.stream());
 
     when(surveySvcClient.requestClassifierTypeSelectors(any())).thenReturn(classifierTypeSelectors);
 
     when(surveySvcClient.requestClassifierTypeSelector(any(), any()))
-      .thenReturn(classifierTypeSelector);
+        .thenReturn(classifierTypeSelector);
 
     when(collectionInstrumentSvcClient.requestCollectionInstruments(any()))
-      .thenThrow(new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Error"));
+        .thenThrow(new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Error"));
 
     // When
     validateSampleUnits.validateSampleUnits();

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
@@ -1,45 +1,38 @@
 package uk.gov.ons.ctp.response.collection.exercise.validation;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.*;
-import org.json.JSONObject;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.web.client.RestClientException;
-import uk.gov.ons.ctp.common.FixtureHelper;
-import uk.gov.ons.ctp.common.distributed.DistributedListManager;
-import uk.gov.ons.ctp.common.distributed.LockingException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.collection.exercise.client.CollectionInstrumentSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.client.PartySvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.client.SurveySvcClient;
-import uk.gov.ons.ctp.response.collection.exercise.config.AppConfig;
-import uk.gov.ons.ctp.response.collection.exercise.config.ScheduleSettings;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnit;
 import uk.gov.ons.ctp.response.collection.exercise.domain.ExerciseSampleUnitGroup;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleUnitRepository;
-import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
-import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupState;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.ExerciseSampleUnitGroupService;
-import uk.gov.ons.ctp.response.collection.exercise.service.ExerciseSampleUnitService;
 import uk.gov.ons.ctp.response.collection.instrument.representation.CollectionInstrumentDTO;
 import uk.gov.ons.ctp.response.party.representation.PartyDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.response.survey.representation.SurveyClassifierDTO;
 import uk.gov.ons.response.survey.representation.SurveyClassifierTypeDTO;
 
@@ -47,11 +40,7 @@ import uk.gov.ons.response.survey.representation.SurveyClassifierTypeDTO;
 @RunWith(MockitoJUnitRunner.class)
 public class ValidateSampleUnitsTest {
 
-  @Mock private DistributedListManager<Integer> sampleValidationListManager;
-
   @Mock private ExerciseSampleUnitGroupService sampleUnitGroupSvc;
-
-  @Mock private ExerciseSampleUnitService sampleUnitSvc;
 
   @Mock private SurveySvcClient surveySvcClient;
 
@@ -65,388 +54,359 @@ public class ValidateSampleUnitsTest {
   @Qualifier("sampleUnitGroup")
   private StateTransitionManager<SampleUnitGroupState, SampleUnitGroupEvent> sampleUnitGroupState;
 
-  @Mock private AppConfig appConfig;
-
-  @Mock private ScheduleSettings scheduleSettings;
-
   @Mock private CollectionExerciseService collexService;
 
   @InjectMocks private ValidateSampleUnits validateSampleUnits;
 
-  private static final String VALIDATION_LIST_ID = "group";
-  private static final List<Integer> EMPTY_VALIDATION_LIST = new ArrayList<>();
-
-  private static final Integer DISTRIBUTION_SCHEDULE_RETRIEVAL_MAX = 10;
-
   private static final String COLLECTION_EXERCISE_ID_1 = "14fb3e68-4dca-46db-bf49-04b84e07e77c";
-  private static final String SAMPLE_UNIT_REF = "50000065975";
+  private static final String PARTY_ID_1 = "628ed030-19f3-406d-8c1c-b3dc2f4793a0";
+  private static final String COLLECTION_INSTRUMENT_ID_1 = "2a6edbe3-0849-48ae-95de-091eb5a08587";
 
-  private static final Map<String, String> CI_1_SVC_SEARCH =
-      ImmutableMap.<String, String>builder()
-          .put("RU_REF", SAMPLE_UNIT_REF)
-          .put("COLLECTION_EXERCISE", COLLECTION_EXERCISE_ID_1)
-          .put("SURVEY_ID", "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87")
-          .build();
-
-  private List<CollectionExercise> collectionExercises;
-  private List<ExerciseSampleUnit> sampleUnits;
-  private List<ExerciseSampleUnitGroup> sampleUnitGroups;
-  private List<SurveyClassifierDTO> classifierTypeSelectors;
-  private List<SurveyClassifierTypeDTO> classifierTypeSelector;
-  private List<CollectionInstrumentDTO> collectionInstruments;
-  private List<PartyDTO> parties;
-
-  /**
-   * Setup Mock responses when all created and injected into test subject.
-   *
-   * @throws Exception from FixtureHelper loading test data flat files.
-   */
-  @Before
-  public void setUp() throws Exception {
-    when(appConfig.getSchedules()).thenReturn(scheduleSettings);
-    when(scheduleSettings.getValidationScheduleRetrievalMax())
-        .thenReturn(DISTRIBUTION_SCHEDULE_RETRIEVAL_MAX);
-
-    // Mock data
-    collectionExercises = FixtureHelper.loadClassFixtures(CollectionExercise[].class);
-    sampleUnits = FixtureHelper.loadClassFixtures(ExerciseSampleUnit[].class);
-    sampleUnitGroups = FixtureHelper.loadClassFixtures(ExerciseSampleUnitGroup[].class);
-    classifierTypeSelectors = FixtureHelper.loadClassFixtures(SurveyClassifierDTO[].class);
-    classifierTypeSelector = FixtureHelper.loadClassFixtures(SurveyClassifierTypeDTO[].class);
-    collectionInstruments = FixtureHelper.loadClassFixtures(CollectionInstrumentDTO[].class);
-    parties = FixtureHelper.loadClassFixtures(PartyDTO[].class);
-
+  @Test
+  public void testValidateSampleUnits() throws CTPException {
     // Given
-    when(collexService.findByState(CollectionExerciseDTO.CollectionExerciseState.EXECUTED))
-        .thenReturn(collectionExercises);
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setSurveyId(UUID.fromString(COLLECTION_EXERCISE_ID_1));
+    collectionExercise.setSampleSize(1);
+    ExerciseSampleUnitGroup sampleUnitGroup = new ExerciseSampleUnitGroup();
+    sampleUnitGroup.setCollectionExercise(collectionExercise);
+    ExerciseSampleUnit sampleUnit = new ExerciseSampleUnit();
+    sampleUnit.setSampleUnitGroup(sampleUnitGroup);
+    sampleUnit.setSampleUnitType(SampleUnitDTO.SampleUnitType.B);
+    List<ExerciseSampleUnit> sampleUnits = Collections.singletonList(sampleUnit);
+    CollectionInstrumentDTO collectionInstrument = new CollectionInstrumentDTO();
+    collectionInstrument.setId(UUID.fromString(COLLECTION_INSTRUMENT_ID_1));
+    List<CollectionInstrumentDTO> collectionInstruments =
+        Collections.singletonList(collectionInstrument);
+    PartyDTO party = new PartyDTO();
+    party.setId(PARTY_ID_1);
+    SurveyClassifierDTO surveyClassifier = new SurveyClassifierDTO();
+    surveyClassifier.setName("COLLECTION_INSTRUMENT");
+    surveyClassifier.setId(UUID.randomUUID().toString());
+    List<SurveyClassifierDTO> classifierTypeSelectors = Collections.singletonList(surveyClassifier);
+    SurveyClassifierTypeDTO classifierTypeSelector = new SurveyClassifierTypeDTO();
+    classifierTypeSelector.setClassifierTypes(Collections.emptyList());
 
-    // Mock retrieveSampleUnitGroups
-    when(sampleValidationListManager.findList(VALIDATION_LIST_ID, false))
-        .thenReturn(EMPTY_VALIDATION_LIST);
-    when(sampleUnitGroupSvc
-            .findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
-                SampleUnitGroupDTO.SampleUnitGroupState.INIT,
-                collectionExercises,
-                EMPTY_VALIDATION_LIST,
-                new PageRequest(0, appConfig.getSchedules().getValidationScheduleRetrievalMax())))
-        .thenReturn(sampleUnitGroups);
+    when(sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+            any(), any()))
+        .thenReturn(sampleUnits.stream());
 
-    // Mock addCollectionInstrumentIds
-    when(sampleUnitSvc.findBySampleUnitGroup(any())).thenReturn(sampleUnits);
-
-    // Mock requestSurveyClassifiers
     when(surveySvcClient.requestClassifierTypeSelectors(any())).thenReturn(classifierTypeSelectors);
+
     when(surveySvcClient.requestClassifierTypeSelector(any(), any()))
-        .thenReturn(classifierTypeSelector.get(0));
+        .thenReturn(classifierTypeSelector);
 
-    // Mock requestCollectionInstrumentId
-    when(collectionInstrumentSvcClient.requestCollectionInstruments(
-            new JSONObject(CI_1_SVC_SEARCH).toString()))
-        .thenReturn(collectionInstruments.subList(0, 1));
-    when(partySvcClient.requestParty(
-            sampleUnits.get(0).getSampleUnitType(), sampleUnits.get(0).getSampleUnitRef()))
-        .thenReturn(parties.get(0));
-
-    when(sampleUnitGroupState.transition(SampleUnitGroupState.INIT, SampleUnitGroupEvent.VALIDATE))
-        .thenReturn(SampleUnitGroupState.VALIDATED);
-    when(sampleUnitGroupState.transition(
-            SampleUnitGroupState.INIT, SampleUnitGroupEvent.INVALIDATE))
-        .thenReturn(SampleUnitGroupState.FAILEDVALIDATION);
-
-    // Mock getCollectionExerciseTransistionState
-    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
-            SampleUnitGroupState.INIT, collectionExercises.get(0)))
-        .thenReturn(0L);
-    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
-            SampleUnitGroupState.VALIDATED, collectionExercises.get(0)))
-        .thenReturn(collectionExercises.get(0).getSampleSize().longValue());
-    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
-            SampleUnitGroupState.FAILEDVALIDATION, collectionExercises.get(0)))
-        .thenReturn(0L);
-    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
-            SampleUnitGroupState.INIT, collectionExercises.get(1)))
-        .thenReturn(0L);
-    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
-            SampleUnitGroupState.VALIDATED, collectionExercises.get(1)))
-        .thenReturn(collectionExercises.get(1).getSampleSize().longValue());
-    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
-            SampleUnitGroupState.FAILEDVALIDATION, collectionExercises.get(1)))
-        .thenReturn(0L);
-  }
-
-  /** Test validate all SampleUnitGroups and CollectionExercises */
-  @Test
-  public void testValidateSampleUnits() throws Exception {
-
-    // Given setup()
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, times(4)).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, times(1))
-        .transitionCollectionExercise(collectionExercises.get(0), CollectionExerciseEvent.VALIDATE);
-    verify(collexService, times(1))
-        .transitionCollectionExercise(collectionExercises.get(1), CollectionExerciseEvent.VALIDATE);
-  }
-
-  /** Test no exerises in EXECUTED state */
-  @Test
-  public void testValidateSampleUnitsNoExercises() throws Exception {
-
-    // Given
-    when(collexService.findByState(CollectionExerciseDTO.CollectionExerciseState.EXECUTED))
-        .thenReturn(Collections.EMPTY_LIST);
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, never()).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, never())
-        .transitionCollectionExercise(
-            isA(CollectionExercise.class), isA(CollectionExerciseEvent.class));
-  }
-
-  /** Test no sample unit groups found for collection exercises */
-  @Test
-  public void testValidateSampleUnitsNoSampleUnitGroups() throws Exception {
-
-    // Given
-    when(sampleUnitGroupSvc
-            .findByStateFKAndCollectionExerciseInAndSampleUnitGroupPKNotInOrderByCreatedDateTimeAsc(
-                SampleUnitGroupDTO.SampleUnitGroupState.INIT,
-                collectionExercises,
-                EMPTY_VALIDATION_LIST,
-                new PageRequest(0, appConfig.getSchedules().getValidationScheduleRetrievalMax())))
-        .thenReturn(Collections.EMPTY_LIST);
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, never()).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, never())
-        .transitionCollectionExercise(
-            isA(CollectionExercise.class), isA(CollectionExerciseEvent.class));
-  }
-
-  /** Test party service throws RestClientException */
-  @Test
-  public void testValidateSampleUnitsRequestPartyFail() throws Exception {
-
-    // Given
-    when(partySvcClient.requestParty(
-            sampleUnits.get(0).getSampleUnitType(), sampleUnits.get(0).getSampleUnitRef()))
-        .thenThrow(RestClientException.class);
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, times(4)).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, times(2))
-        .transitionCollectionExercise(
-            isA(CollectionExercise.class), isA(CollectionExerciseEvent.class));
-  }
-
-  /**
-   * Test sampleUnitGroup transition to FAILEDVALIDATION state when not all sample groups are
-   * VALIDATED
-   */
-  @Test
-  public void testValidateSampleUnitsInvalidTransition() throws Exception {
-
-    // Given
-    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
-            SampleUnitGroupState.VALIDATED, collectionExercises.get(0)))
-        .thenReturn(collectionExercises.get(0).getSampleSize().longValue() - 1);
-    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
-            SampleUnitGroupState.FAILEDVALIDATION, collectionExercises.get(0)))
-        .thenReturn(1L);
-    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
-            SampleUnitGroupState.VALIDATED, collectionExercises.get(1)))
-        .thenReturn(collectionExercises.get(1).getSampleSize().longValue() - 1);
-    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
-            SampleUnitGroupState.FAILEDVALIDATION, collectionExercises.get(1)))
-        .thenReturn(1L);
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, times(4)).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, times(1))
-        .transitionCollectionExercise(
-            collectionExercises.get(0), CollectionExerciseEvent.INVALIDATE);
-    verify(collexService, times(1))
-        .transitionCollectionExercise(
-            collectionExercises.get(1), CollectionExerciseEvent.INVALIDATE);
-  }
-
-  /** Test transition collection exercise throws CTPException */
-  @Test
-  public void testValidateSampleUnitsTransitionCTPError() throws Exception {
-
-    // Given
-    doThrow(CTPException.class)
-        .when(collexService)
-        .transitionCollectionExercise(collectionExercises.get(0), CollectionExerciseEvent.VALIDATE);
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, times(4)).storeExerciseSampleUnitGroup(any(), any());
-  }
-
-  @Test
-  public void testValidateSampleUnitsRequestSurveyClassifierTypeSelectorsFail() throws Exception {
-
-    // Given
-    when(surveySvcClient.requestClassifierTypeSelectors(any()))
-        .thenThrow(RestClientException.class);
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, never()).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, never())
-        .transitionCollectionExercise(
-            isA(CollectionExercise.class), isA(CollectionExerciseEvent.class));
-  }
-
-  @Test
-  public void testValidateSampleUnitsRequestSurveyClassifierTypeSelectorsEmpty() throws Exception {
-
-    // Given
-    when(surveySvcClient.requestClassifierTypeSelectors(any())).thenReturn(Collections.EMPTY_LIST);
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, never()).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, never())
-        .transitionCollectionExercise(
-            isA(CollectionExercise.class), isA(CollectionExerciseEvent.class));
-  }
-
-  @Test
-  public void testValidateSampleUnitsRequestSurveyClassifierTypeSelectorEmpty() throws Exception {
-
-    // Given
-    when(surveySvcClient.requestClassifierTypeSelector(any(), any())).thenReturn(null);
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, never()).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, never())
-        .transitionCollectionExercise(
-            isA(CollectionExercise.class), isA(CollectionExerciseEvent.class));
-  }
-
-  @Test
-  public void testValidateSampleUnitsListLockingException() throws Exception {
-
-    // Given
-    when(sampleValidationListManager.findList(VALIDATION_LIST_ID, false))
-        .thenThrow(LockingException.class);
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, never()).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, never())
-        .transitionCollectionExercise(
-            isA(CollectionExercise.class), isA(CollectionExerciseEvent.class));
-  }
-
-  @Test
-  public void testValidateSampleUnitsFailsValidation() throws Exception {
-
-    // Given one of the sample units will fail validation
-    when(partySvcClient.requestParty(
-            sampleUnits.get(0).getSampleUnitType(), sampleUnits.get(0).getSampleUnitRef()))
-        .thenThrow(RestClientException.class);
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, times(4)).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, times(2))
-        .transitionCollectionExercise(
-            isA(CollectionExercise.class), isA(CollectionExerciseEvent.class));
-  }
-
-  @Test
-  public void testValidateSampleUnitsInvalidClassifier() throws Exception {
-
-    // Given one of the sample units will fail validation
-    when(surveySvcClient.requestClassifierTypeSelector(any(), any()))
-        .thenReturn(classifierTypeSelector.get(1));
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, times(4)).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, times(2))
-        .transitionCollectionExercise(
-            isA(CollectionExercise.class), isA(CollectionExerciseEvent.class));
-  }
-
-  @Test
-  public void testValidateSampleUnitsNoCollectionInstruments() throws Exception {
-
-    // Given one of the sample units will fail validation
-    when(collectionInstrumentSvcClient.requestCollectionInstruments(
-            new JSONObject(CI_1_SVC_SEARCH).toString()))
-        .thenReturn(Collections.EMPTY_LIST);
-
-    // When
-    validateSampleUnits.validateSampleUnits();
-
-    // Then
-    verify(sampleUnitGroupSvc, times(4)).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, times(2))
-        .transitionCollectionExercise(
-            isA(CollectionExercise.class), isA(CollectionExerciseEvent.class));
-  }
-
-  @Test
-  public void testValidateSampleUnitsMultipleCollectionInstruments() throws Exception {
-
-    // Given one of the sample units will fail validation
-    when(collectionInstrumentSvcClient.requestCollectionInstruments(
-            new JSONObject(CI_1_SVC_SEARCH).toString()))
+    when(collectionInstrumentSvcClient.requestCollectionInstruments(any()))
         .thenReturn(collectionInstruments);
 
+    when(partySvcClient.requestParty(any(), any())).thenReturn(party);
+
+    when(sampleUnitGroupState.transition(any(), any())).thenReturn(SampleUnitGroupState.VALIDATED);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.INIT), any(CollectionExercise.class)))
+        .thenReturn(0L);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.VALIDATED), any(CollectionExercise.class)))
+        .thenReturn(1L);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.FAILEDVALIDATION), any(CollectionExercise.class)))
+        .thenReturn(0L);
+
     // When
     validateSampleUnits.validateSampleUnits();
 
     // Then
-    verify(sampleUnitGroupSvc, times(4)).storeExerciseSampleUnitGroup(any(), any());
-    verify(collexService, times(2))
-        .transitionCollectionExercise(
-            isA(CollectionExercise.class), isA(CollectionExerciseEvent.class));
+    ArgumentCaptor<ExerciseSampleUnit> exerciseSampleUnitArgCapt =
+        ArgumentCaptor.forClass(ExerciseSampleUnit.class);
+    verify(sampleUnitRepo).save(exerciseSampleUnitArgCapt.capture());
+    assertEquals(
+        SampleUnitGroupState.VALIDATED,
+        exerciseSampleUnitArgCapt.getValue().getSampleUnitGroup().getStateFK());
+    assertEquals(PARTY_ID_1, exerciseSampleUnitArgCapt.getValue().getPartyId().toString());
+    assertEquals(
+        COLLECTION_INSTRUMENT_ID_1,
+        exerciseSampleUnitArgCapt.getValue().getCollectionInstrumentId().toString());
+    verify(collexService)
+        .transitionCollectionExercise(collectionExercise, CollectionExerciseEvent.VALIDATE);
+  }
+
+  @Test
+  public void testValidateNoSampleUnits() throws CTPException {
+    // Given
+    List<ExerciseSampleUnit> sampleUnits = Collections.emptyList();
+
+    when(sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+            any(), any()))
+        .thenReturn(sampleUnits.stream());
+
+    // When
+    validateSampleUnits.validateSampleUnits();
+
+    // Then
+    verify(sampleUnitRepo, never()).save(any(ExerciseSampleUnit.class));
+    verify(collexService, never())
+        .transitionCollectionExercise(any(CollectionExercise.class), any());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testValidateSampleUnitsRequestPartyFail() {
+    // Given
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setSurveyId(UUID.fromString(COLLECTION_EXERCISE_ID_1));
+    collectionExercise.setSampleSize(1);
+    ExerciseSampleUnitGroup sampleUnitGroup = new ExerciseSampleUnitGroup();
+    sampleUnitGroup.setCollectionExercise(collectionExercise);
+    ExerciseSampleUnit sampleUnit = new ExerciseSampleUnit();
+    sampleUnit.setSampleUnitGroup(sampleUnitGroup);
+    sampleUnit.setSampleUnitType(SampleUnitDTO.SampleUnitType.B);
+    List<ExerciseSampleUnit> sampleUnits = Collections.singletonList(sampleUnit);
+    CollectionInstrumentDTO collectionInstrument = new CollectionInstrumentDTO();
+    List<CollectionInstrumentDTO> collectionInstruments =
+        Collections.singletonList(collectionInstrument);
+    SurveyClassifierDTO surveyClassifier = new SurveyClassifierDTO();
+    surveyClassifier.setName("COLLECTION_INSTRUMENT");
+    surveyClassifier.setId(UUID.randomUUID().toString());
+    List<SurveyClassifierDTO> classifierTypeSelectors = Collections.singletonList(surveyClassifier);
+    SurveyClassifierTypeDTO classifierTypeSelector = new SurveyClassifierTypeDTO();
+    classifierTypeSelector.setClassifierTypes(Collections.emptyList());
+
+    when(sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+            any(), any()))
+        .thenReturn(sampleUnits.stream());
+
+    when(surveySvcClient.requestClassifierTypeSelectors(any())).thenReturn(classifierTypeSelectors);
+
+    when(surveySvcClient.requestClassifierTypeSelector(any(), any()))
+        .thenReturn(classifierTypeSelector);
+
+    when(collectionInstrumentSvcClient.requestCollectionInstruments(any()))
+        .thenReturn(collectionInstruments);
+
+    when(partySvcClient.requestParty(any(), any()))
+        .thenThrow(new RuntimeException("Disaster happened"));
+
+    // When
+    validateSampleUnits.validateSampleUnits();
+
+    // Then
+    // ... exception happens, transaction rolled back
+  }
+
+  @Test
+  public void testValidateSampleUnitsCollectionInstrumentNotFound() throws CTPException {
+    // Given
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setSurveyId(UUID.fromString(COLLECTION_EXERCISE_ID_1));
+    collectionExercise.setSampleSize(1);
+    ExerciseSampleUnitGroup sampleUnitGroup = new ExerciseSampleUnitGroup();
+    sampleUnitGroup.setCollectionExercise(collectionExercise);
+    ExerciseSampleUnit sampleUnit = new ExerciseSampleUnit();
+    sampleUnit.setSampleUnitGroup(sampleUnitGroup);
+    sampleUnit.setSampleUnitType(SampleUnitDTO.SampleUnitType.B);
+    List<ExerciseSampleUnit> sampleUnits = Collections.singletonList(sampleUnit);
+    PartyDTO party = new PartyDTO();
+    party.setId(PARTY_ID_1);
+    SurveyClassifierDTO surveyClassifier = new SurveyClassifierDTO();
+    surveyClassifier.setName("COLLECTION_INSTRUMENT");
+    surveyClassifier.setId(UUID.randomUUID().toString());
+    List<SurveyClassifierDTO> classifierTypeSelectors = Collections.singletonList(surveyClassifier);
+    SurveyClassifierTypeDTO classifierTypeSelector = new SurveyClassifierTypeDTO();
+    classifierTypeSelector.setClassifierTypes(Collections.emptyList());
+
+    when(sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+            any(), any()))
+        .thenReturn(sampleUnits.stream());
+
+    when(surveySvcClient.requestClassifierTypeSelectors(any())).thenReturn(classifierTypeSelectors);
+
+    when(surveySvcClient.requestClassifierTypeSelector(any(), any()))
+        .thenReturn(classifierTypeSelector);
+
+    when(collectionInstrumentSvcClient.requestCollectionInstruments(any()))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND, "Bad stuff happened"));
+
+    when(partySvcClient.requestParty(any(), any())).thenReturn(party);
+
+    when(sampleUnitGroupState.transition(any(), any()))
+        .thenReturn(SampleUnitGroupState.FAILEDVALIDATION);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.INIT), any(CollectionExercise.class)))
+        .thenReturn(0L);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.VALIDATED), any(CollectionExercise.class)))
+        .thenReturn(0L);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.FAILEDVALIDATION), any(CollectionExercise.class)))
+        .thenReturn(1L);
+
+    // When
+    validateSampleUnits.validateSampleUnits();
+
+    // Then
+    ArgumentCaptor<ExerciseSampleUnit> exerciseSampleUnitArgCapt =
+        ArgumentCaptor.forClass(ExerciseSampleUnit.class);
+    verify(sampleUnitRepo).save(exerciseSampleUnitArgCapt.capture());
+    assertEquals(
+        SampleUnitGroupState.FAILEDVALIDATION,
+        exerciseSampleUnitArgCapt.getValue().getSampleUnitGroup().getStateFK());
+    assertEquals(PARTY_ID_1, exerciseSampleUnitArgCapt.getValue().getPartyId().toString());
+    assertNull(exerciseSampleUnitArgCapt.getValue().getCollectionInstrumentId());
+    verify(collexService)
+        .transitionCollectionExercise(collectionExercise, CollectionExerciseEvent.INVALIDATE);
+  }
+
+  @Test
+  public void testValidateSampleUnitsPartyNotFound() throws CTPException {
+    // Given
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setSurveyId(UUID.fromString(COLLECTION_EXERCISE_ID_1));
+    collectionExercise.setSampleSize(1);
+    ExerciseSampleUnitGroup sampleUnitGroup = new ExerciseSampleUnitGroup();
+    sampleUnitGroup.setCollectionExercise(collectionExercise);
+    ExerciseSampleUnit sampleUnit = new ExerciseSampleUnit();
+    sampleUnit.setSampleUnitGroup(sampleUnitGroup);
+    sampleUnit.setSampleUnitType(SampleUnitDTO.SampleUnitType.B);
+    List<ExerciseSampleUnit> sampleUnits = Collections.singletonList(sampleUnit);
+    CollectionInstrumentDTO collectionInstrument = new CollectionInstrumentDTO();
+    collectionInstrument.setId(UUID.fromString(COLLECTION_INSTRUMENT_ID_1));
+    List<CollectionInstrumentDTO> collectionInstruments =
+        Collections.singletonList(collectionInstrument);
+    PartyDTO party = new PartyDTO();
+    party.setId(PARTY_ID_1);
+    SurveyClassifierDTO surveyClassifier = new SurveyClassifierDTO();
+    surveyClassifier.setName("COLLECTION_INSTRUMENT");
+    surveyClassifier.setId(UUID.randomUUID().toString());
+    List<SurveyClassifierDTO> classifierTypeSelectors = Collections.singletonList(surveyClassifier);
+    SurveyClassifierTypeDTO classifierTypeSelector = new SurveyClassifierTypeDTO();
+    classifierTypeSelector.setClassifierTypes(Collections.emptyList());
+
+    when(sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+            any(), any()))
+        .thenReturn(sampleUnits.stream());
+
+    when(surveySvcClient.requestClassifierTypeSelectors(any())).thenReturn(classifierTypeSelectors);
+
+    when(surveySvcClient.requestClassifierTypeSelector(any(), any()))
+        .thenReturn(classifierTypeSelector);
+
+    when(collectionInstrumentSvcClient.requestCollectionInstruments(any()))
+        .thenReturn(collectionInstruments);
+
+    when(partySvcClient.requestParty(any(), any()))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND, "Bad stuff happened"));
+
+    when(sampleUnitGroupState.transition(any(), any()))
+        .thenReturn(SampleUnitGroupState.FAILEDVALIDATION);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.INIT), any(CollectionExercise.class)))
+        .thenReturn(0L);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.VALIDATED), any(CollectionExercise.class)))
+        .thenReturn(0L);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.FAILEDVALIDATION), any(CollectionExercise.class)))
+        .thenReturn(1L);
+
+    // When
+    validateSampleUnits.validateSampleUnits();
+
+    // Then
+    ArgumentCaptor<ExerciseSampleUnit> exerciseSampleUnitArgCapt =
+        ArgumentCaptor.forClass(ExerciseSampleUnit.class);
+    verify(sampleUnitRepo).save(exerciseSampleUnitArgCapt.capture());
+    assertEquals(
+        SampleUnitGroupState.FAILEDVALIDATION,
+        exerciseSampleUnitArgCapt.getValue().getSampleUnitGroup().getStateFK());
+    assertNull(exerciseSampleUnitArgCapt.getValue().getPartyId());
+    assertEquals(
+        COLLECTION_INSTRUMENT_ID_1,
+        exerciseSampleUnitArgCapt.getValue().getCollectionInstrumentId().toString());
+    verify(collexService)
+        .transitionCollectionExercise(collectionExercise, CollectionExerciseEvent.INVALIDATE);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testValidateSampleUnitsSurveyTypeSelectorsBlowsUp() throws CTPException {
+    // Given
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setSurveyId(UUID.fromString(COLLECTION_EXERCISE_ID_1));
+    collectionExercise.setSampleSize(1);
+    ExerciseSampleUnitGroup sampleUnitGroup = new ExerciseSampleUnitGroup();
+    sampleUnitGroup.setCollectionExercise(collectionExercise);
+    ExerciseSampleUnit sampleUnit = new ExerciseSampleUnit();
+    sampleUnit.setSampleUnitGroup(sampleUnitGroup);
+    sampleUnit.setSampleUnitType(SampleUnitDTO.SampleUnitType.B);
+    List<ExerciseSampleUnit> sampleUnits = Collections.singletonList(sampleUnit);
+
+    when(sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+            any(), any()))
+        .thenReturn(sampleUnits.stream());
+
+    when(surveySvcClient.requestClassifierTypeSelectors(any()))
+        .thenThrow(new RuntimeException("Kaboom"));
+
+    // When
+    validateSampleUnits.validateSampleUnits();
+
+    // Then
+    // ... exception happens, transaction rolled back
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testValidateSampleUnitsSurveyTypeSelectorBlowsUp() throws CTPException {
+    // Given
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setSurveyId(UUID.fromString(COLLECTION_EXERCISE_ID_1));
+    collectionExercise.setSampleSize(1);
+    ExerciseSampleUnitGroup sampleUnitGroup = new ExerciseSampleUnitGroup();
+    sampleUnitGroup.setCollectionExercise(collectionExercise);
+    ExerciseSampleUnit sampleUnit = new ExerciseSampleUnit();
+    sampleUnit.setSampleUnitGroup(sampleUnitGroup);
+    sampleUnit.setSampleUnitType(SampleUnitDTO.SampleUnitType.B);
+    List<ExerciseSampleUnit> sampleUnits = Collections.singletonList(sampleUnit);
+    SurveyClassifierDTO surveyClassifier = new SurveyClassifierDTO();
+    surveyClassifier.setName("COLLECTION_INSTRUMENT");
+    surveyClassifier.setId(UUID.randomUUID().toString());
+    List<SurveyClassifierDTO> classifierTypeSelectors = Collections.singletonList(surveyClassifier);
+
+    when(sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+            any(), any()))
+        .thenReturn(sampleUnits.stream());
+
+    when(surveySvcClient.requestClassifierTypeSelectors(any())).thenReturn(classifierTypeSelectors);
+
+    when(surveySvcClient.requestClassifierTypeSelector(any(), any()))
+        .thenThrow(new RuntimeException("Kablammo"));
+
+    // When
+    validateSampleUnits.validateSampleUnits();
+
+    // Then
+    // ... exception happens, transaction rolled back
   }
 
   @Test
   public void testTransitionExecutionStartedCollex() throws CTPException {
     CollectionExercise collex = new CollectionExercise();
     collex.setSampleSize(99);
+    List<ExerciseSampleUnit> sampleUnits = Collections.emptyList();
 
     // Given
     when(collexService.findByState(CollectionExerciseState.EXECUTION_STARTED))
         .thenReturn(Collections.singletonList(collex));
     when(sampleUnitRepo.countBySampleUnitGroupCollectionExercise(collex)).thenReturn(99);
+    when(sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+            any(), any()))
+        .thenReturn(sampleUnits.stream());
 
     // When
     validateSampleUnits.validateSampleUnits();
@@ -460,11 +420,15 @@ public class ValidateSampleUnitsTest {
   public void testShouldNotTransitionExecutionStartedUnfinishedCollex() throws CTPException {
     CollectionExercise collex = new CollectionExercise();
     collex.setSampleSize(66);
+    List<ExerciseSampleUnit> sampleUnits = Collections.emptyList();
 
     // Given
     when(collexService.findByState(CollectionExerciseState.EXECUTION_STARTED))
         .thenReturn(Collections.singletonList(collex));
     when(sampleUnitRepo.countBySampleUnitGroupCollectionExercise(collex)).thenReturn(33);
+    when(sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+            any(), any()))
+        .thenReturn(sampleUnits.stream());
 
     // When
     validateSampleUnits.validateSampleUnits();


### PR DESCRIPTION
# Motivation and Context
The 'validation' of the samples was spaghetti code and highly inefficient.

Given the need to load large samples for ASHE etc. it seemed prudent to refactor all the code that the lies on the sample load pipeline, to make it more performant and reliable.

In the course of the refactoring, a number of bugs were spotted, such as inability to recover from momentary connection problems with the Survey, Collection Instrument and Party services - these should retry without manual intervention.

The code was inefficient, badly performant, hard to understand, maintain, and it did not handle errors well.

# What has changed
Major refactoring of the `ValidateSampleUnits` class.

Sadly it's still not quite honouring the single responsibility principle, but the code is a lot less complex and should make future refactoring easier.

Substantial improvement to performance and error handling.

# How to test?
Load a big sample. Make sure the sample validates OK and the collection exercise changes to "Ready for Live" status.

# Links
Trello: https://trello.com/c/eAmhl3iB/729-use-stream-and-multithreading-in-validatesampleunits-to-rapidly-validate-the-samples-13
