### PR TITLE
BUG: same collection instrument was being used for every sample in a collex

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
@@ -50,6 +50,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
@@ -83,6 +84,7 @@ import uk.gov.ons.tools.rabbit.SimpleMessageSender;
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class CollectionExerciseEndpointIT {
   private static final Logger log = LoggerFactory.getLogger(CollectionExerciseEndpointIT.class);
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
@@ -139,6 +139,13 @@ public class ValidateSampleUnitsTest {
         .transitionCollectionExercise(collectionExercise, CollectionExerciseEvent.VALIDATE);
   }
 
+  /*
+   * This test covers the scenario where a collection exercise has multiple collection instruments associated
+   * with it. Usually (virtually 100% of the time) a single sample will be uploaded and processed in isolation
+   * (i.e. it would be very rare to have 2 or more samples validating at the same time) and we are mainly interested
+   * in the collection instruments which relate to the form types contained in the sample which was uploaded.
+   * An MBS sample, for example, may contain as many as 20 different collection instruments.
+   */
   @Test
   public void testValidateSampleUnitsMultipleCollectionInstruments() throws CTPException {
     // Given

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
@@ -1,7 +1,11 @@
 package uk.gov.ons.ctp.response.collection.exercise.validation;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -61,6 +65,8 @@ public class ValidateSampleUnitsTest {
   private static final String COLLECTION_EXERCISE_ID_1 = "14fb3e68-4dca-46db-bf49-04b84e07e77c";
   private static final String PARTY_ID_1 = "628ed030-19f3-406d-8c1c-b3dc2f4793a0";
   private static final String COLLECTION_INSTRUMENT_ID_1 = "2a6edbe3-0849-48ae-95de-091eb5a08587";
+  private static final String COLLECTION_INSTRUMENT_ID_2 = "e9679672-1680-4bd7-bf38-ee9ce44ffdf0";
+  private static final String SURVEY_ID = "d943344b-1ef4-4c24-b59b-23e3a0350158";
 
   @Test
   public void testValidateSampleUnits() throws CTPException {
@@ -131,6 +137,100 @@ public class ValidateSampleUnitsTest {
         exerciseSampleUnitArgCapt.getValue().getCollectionInstrumentId().toString());
     verify(collexService)
         .transitionCollectionExercise(collectionExercise, CollectionExerciseEvent.VALIDATE);
+  }
+
+  @Test
+  public void testValidateSampleUnitsMultipleCollectionInstruments() throws CTPException {
+    // Given
+    CollectionExercise collectionExercise = new CollectionExercise();
+    collectionExercise.setSurveyId(UUID.fromString(SURVEY_ID));
+    collectionExercise.setSampleSize(2);
+
+    List<ExerciseSampleUnit> sampleUnits = new LinkedList<>();
+
+    ExerciseSampleUnitGroup sampleUnitGroup = new ExerciseSampleUnitGroup();
+    sampleUnitGroup.setCollectionExercise(collectionExercise);
+    sampleUnitGroup.setFormType("0101");
+    ExerciseSampleUnit sampleUnit = new ExerciseSampleUnit();
+    sampleUnit.setSampleUnitGroup(sampleUnitGroup);
+    sampleUnit.setSampleUnitType(SampleUnitDTO.SampleUnitType.B);
+    sampleUnits.add(sampleUnit); // Add the first sample
+
+    sampleUnitGroup = new ExerciseSampleUnitGroup();
+    sampleUnitGroup.setCollectionExercise(collectionExercise);
+    sampleUnitGroup.setFormType("0666");
+    sampleUnit = new ExerciseSampleUnit();
+    sampleUnit.setSampleUnitGroup(sampleUnitGroup);
+    sampleUnit.setSampleUnitType(SampleUnitDTO.SampleUnitType.B);
+    sampleUnits.add(sampleUnit); // Add the second sample
+
+    CollectionInstrumentDTO collectionInstrument = new CollectionInstrumentDTO();
+    collectionInstrument.setId(UUID.fromString(COLLECTION_INSTRUMENT_ID_1));
+    List<CollectionInstrumentDTO> collectionInstrumentsOne =
+        Collections.singletonList(collectionInstrument);
+
+    collectionInstrument = new CollectionInstrumentDTO();
+    collectionInstrument.setId(UUID.fromString(COLLECTION_INSTRUMENT_ID_2));
+    List<CollectionInstrumentDTO> collectionInstrumentsTwo =
+        Collections.singletonList(collectionInstrument);
+
+    PartyDTO party = new PartyDTO();
+    party.setId(PARTY_ID_1);
+    SurveyClassifierDTO surveyClassifier = new SurveyClassifierDTO();
+    surveyClassifier.setName("COLLECTION_INSTRUMENT");
+    surveyClassifier.setId(UUID.randomUUID().toString());
+    List<SurveyClassifierDTO> classifierTypeSelectors = Collections.singletonList(surveyClassifier);
+    SurveyClassifierTypeDTO classifierTypeSelector = new SurveyClassifierTypeDTO();
+    classifierTypeSelector.setClassifierTypes(Collections.singletonList("FORM_TYPE"));
+
+    when(sampleUnitRepo.findBySampleUnitGroupCollectionExerciseStateAndSampleUnitGroupStateFK(
+            any(), any()))
+        .thenReturn(sampleUnits.stream());
+
+    when(surveySvcClient.requestClassifierTypeSelectors(any())).thenReturn(classifierTypeSelectors);
+
+    when(surveySvcClient.requestClassifierTypeSelector(any(), any()))
+        .thenReturn(classifierTypeSelector);
+
+    when(collectionInstrumentSvcClient.requestCollectionInstruments(
+            eq("{\"SURVEY_ID\":\"d943344b-1ef4-4c24-b59b-23e3a0350158\",\"FORM_TYPE\":\"0101\"}")))
+        .thenReturn(collectionInstrumentsOne);
+
+    when(collectionInstrumentSvcClient.requestCollectionInstruments(
+            eq("{\"SURVEY_ID\":\"d943344b-1ef4-4c24-b59b-23e3a0350158\",\"FORM_TYPE\":\"0666\"}")))
+        .thenReturn(collectionInstrumentsTwo);
+
+    when(partySvcClient.requestParty(any(), any())).thenReturn(party);
+
+    when(sampleUnitGroupState.transition(any(), any())).thenReturn(SampleUnitGroupState.VALIDATED);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.INIT), any(CollectionExercise.class)))
+        .thenReturn(0L);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.VALIDATED), any(CollectionExercise.class)))
+        .thenReturn(1L);
+
+    when(sampleUnitGroupSvc.countByStateFKAndCollectionExercise(
+            eq(SampleUnitGroupState.FAILEDVALIDATION), any(CollectionExercise.class)))
+        .thenReturn(0L);
+
+    // When
+    validateSampleUnits.validateSampleUnits();
+
+    // Then
+    ArgumentCaptor<ExerciseSampleUnit> exerciseSampleUnitArgCapt =
+        ArgumentCaptor.forClass(ExerciseSampleUnit.class);
+    verify(sampleUnitRepo, times(2)).save(exerciseSampleUnitArgCapt.capture());
+    List<ExerciseSampleUnit> exerciseSampleUnits = exerciseSampleUnitArgCapt.getAllValues();
+
+    assertThat(
+        exerciseSampleUnits,
+        containsInAnyOrder(
+            hasProperty("collectionInstrumentId", is(UUID.fromString(COLLECTION_INSTRUMENT_ID_1))),
+            hasProperty(
+                "collectionInstrumentId", is(UUID.fromString(COLLECTION_INSTRUMENT_ID_2)))));
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
A bug had been introduced as part of performance improvement work, intended to speed up the amount of time it takes to validate a sample. The bug was putting the same collection instrument onto every sample, regardless of form type.

# What has changed
The cache has been enhanced so that it caches collection instruments down to a form type granularity.

# How to test?
Load a sample with multiple form types. Check that the resulting cases have the correct collection instruments associated against them.

# Links
Trello: https://trello.com/c/sySrEfGS
Root cause of bug: https://github.com/ONSdigital/rm-collection-exercise-service/pull/142