### PR TITLE
Added new endpoint to support retrieving collexes for multiple survey…

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,6 +16,63 @@ This page documents the Collection Exercise service API endpoints. Apart from th
 }
 ```
 
+## Get Collection Exercises for Surveys
+* `GET /collectionexercises/surveys?surveyIds=cb8accda-6118-4d3b-85a3-149e28960c54,b447e134-5e5d-46fb-b4fc-15efdcbe5ca7` 
+Will return a dictionary of collection exercises for each survey id in the supplied list of survey ids. In the form of a dictionary with a key of survey id, and value of a list of Collection Exercises.
+* `GET /collectionexercises/survey?surveyIds=cb8accda-6118-4d3b-85a3-149e28960c54,b447e134-5e5d-46fb-b4fc-15efdcbe5ca7&liveOnly=true` 
+As above , but only LIVE collexes returned
+
+### Example JSON Response
+```json
+{
+  "cb8accda-6118-4d3b-85a3-149e28960c54": 
+  [
+      {
+        "id": "c6467711-21eb-4e78-804c-1db8392f93fb",
+        "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
+        "actualExecutionDateTime": null,
+        "scheduledExecutionDateTime": null,
+        "scheduledStartDateTime": null,
+        "actualPublishDateTime": null,
+        "periodStartDateTime": null,
+        "periodEndDateTime": null,
+        "scheduledReturnDateTime": null,
+        "scheduledEndDateTime": null,
+        "executedBy": null,
+        "state": "LIVE",
+        "caseTypes": null,
+        "exerciseRef": "201801",
+        "userDescription": "January 2018",
+        "created": "2018-01-09T12:56:09.652Z",
+        "updated": null,
+        "deleted": null,
+        "validationErrors": []
+      },
+      {
+        "id": "b447e134-5e5d-46fb-b4fc-15efdcbe5ca7",
+        "surveyId": "cb8accda-6118-4d3b-85a3-149e28960c54",
+        "actualExecutionDateTime": null,
+        "scheduledExecutionDateTime": null,
+        "scheduledStartDateTime": null,
+        "actualPublishDateTime": null,
+        "periodStartDateTime": null,
+        "periodEndDateTime": null,
+        "scheduledReturnDateTime": null,
+        "scheduledEndDateTime": null,
+        "executedBy": null,
+        "state": "LIVE",
+        "caseTypes": null,
+        "exerciseRef": "201802",
+        "userDescription": "February 2018",
+        "created": "2018-01-09T12:56:09.709Z",
+        "updated": null,
+        "deleted": null,
+        "validationErrors": []
+      }
+    ]
+}
+```
+
 ## Get Collection Exercises for Survey
 * `GET /collectionexercises/survey/{survey_id}` will return a list of known collection exercises for the survey id.
 * `GET /collectionexercises/survey/{survey_id}?liveOnly=true` will return a list of LIVE collection exercises for the survey id.
@@ -67,8 +124,6 @@ This page documents the Collection Exercise service API endpoints. Apart from th
   }
 ]
 ```
-
-
 
 ## Get Collection Exercises for Survey and Exercise
 * `GET /collectionexercises/{exerciseRef}/survey/{survey_id}` will return a list of known collection exercises for the survey id and exerciseRef.

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -11,6 +11,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -152,6 +153,33 @@ public class CollectionExerciseEndpoint {
 
     log.with("survey_id", id).debug("Sucessfully retrieved collection exercises for surveyId");
     return ResponseEntity.ok(collectionExerciseSummaryDTOList);
+  }
+
+  /**
+   * GET to find collection exercises for the surveys in the given list of survey ids.
+   *
+   * @param surveyIds survey Ids for which to get collection exercises
+   * @param liveOnly Boolean , if set only returns live collection exercises
+   * @return json dictionary or collection exercises per survey
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/surveys", method = RequestMethod.GET, produces = "application/json")
+  public ResponseEntity<HashMap> getCollectionExercisesForSurveys(
+    final @RequestParam List<UUID> surveyIds,
+    @RequestParam("liveOnly") Optional<Boolean> liveOnly){
+
+      HashMap<UUID, List<CollectionExercise>> surveyCollexDict = null;
+
+      if (liveOnly.isPresent() && liveOnly.get().booleanValue()) {
+        surveyCollexDict =
+          collectionExerciseService.findCollectionExercisesForSurveysByState(surveyIds,
+            CollectionExerciseState.LIVE);
+      } else {
+        surveyCollexDict = collectionExerciseService.findCollectionExercisesForSurveys(surveyIds);
+      }
+
+    return ResponseEntity.ok(surveyCollexDict);
+
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -192,7 +192,8 @@ public class CollectionExerciseEndpoint {
   }
 
   /**
-   * GET to find collection exercises for the surveys in the given list of survey ids.
+   * Return collection exercises for each of the the surveys
+   * in the given list of survey ids. Return data as a Json dictionary.
    *
    * @param surveyIds survey Ids for which to get collection exercises
    * @param liveOnly Boolean , if set only returns live collection exercises

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -156,33 +156,6 @@ public class CollectionExerciseEndpoint {
   }
 
   /**
-   * GET to find collection exercises for the surveys in the given list of survey ids.
-   *
-   * @param surveyIds survey Ids for which to get collection exercises
-   * @param liveOnly Boolean , if set only returns live collection exercises
-   * @return json dictionary or collection exercises per survey
-   * @throws CTPException on resource not found
-   */
-  @RequestMapping(value = "/surveys", method = RequestMethod.GET, produces = "application/json")
-  public ResponseEntity<HashMap> getCollectionExercisesForSurveys(
-    final @RequestParam List<UUID> surveyIds,
-    @RequestParam("liveOnly") Optional<Boolean> liveOnly){
-
-      HashMap<UUID, List<CollectionExercise>> surveyCollexDict = null;
-
-      if (liveOnly.isPresent() && liveOnly.get().booleanValue()) {
-        surveyCollexDict =
-          collectionExerciseService.findCollectionExercisesForSurveysByState(surveyIds,
-            CollectionExerciseState.LIVE);
-      } else {
-        surveyCollexDict = collectionExerciseService.findCollectionExercisesForSurveys(surveyIds);
-      }
-
-    return ResponseEntity.ok(surveyCollexDict);
-
-  }
-
-  /**
    * Endpoint to get a collection exercise by exercise ref and survey ref
    *
    * @param exerciseRef the exercise ref
@@ -216,6 +189,32 @@ public class CollectionExerciseEndpoint {
           .debug("Successfully retrieved collection exercise using surveyRef and period");
       return ResponseEntity.ok(getCollectionExerciseDTO(collex));
     }
+  }
+
+  /**
+   * GET to find collection exercises for the surveys in the given list of survey ids.
+   *
+   * @param surveyIds survey Ids for which to get collection exercises
+   * @param liveOnly Boolean , if set only returns live collection exercises
+   * @return json dictionary or collection exercises per survey
+   * @throws CTPException on resource not found
+   */
+  @RequestMapping(value = "/surveys", method = RequestMethod.GET, produces = "application/json")
+  public ResponseEntity<HashMap> getCollectionExercisesForSurveys(
+      final @RequestParam List<UUID> surveyIds,
+      @RequestParam("liveOnly") Optional<Boolean> liveOnly) {
+
+    HashMap<UUID, List<CollectionExercise>> surveyCollexDict = null;
+
+    if (liveOnly.isPresent() && liveOnly.get().booleanValue()) {
+      surveyCollexDict =
+          collectionExerciseService.findCollectionExercisesForSurveysByState(
+              surveyIds, CollectionExerciseState.LIVE);
+    } else {
+      surveyCollexDict = collectionExerciseService.findCollectionExercisesForSurveys(surveyIds);
+    }
+
+    return ResponseEntity.ok(surveyCollexDict);
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -192,8 +192,8 @@ public class CollectionExerciseEndpoint {
   }
 
   /**
-   * Return collection exercises for each of the the surveys
-   * in the given list of survey ids. Return data as a Json dictionary.
+   * Return collection exercises for each of the the surveys in the given list of survey ids. Return
+   * data as a Json dictionary.
    *
    * @param surveyIds survey Ids for which to get collection exercises
    * @param liveOnly Boolean , if set only returns live collection exercises
@@ -205,17 +205,17 @@ public class CollectionExerciseEndpoint {
       final @RequestParam List<UUID> surveyIds,
       @RequestParam("liveOnly") Optional<Boolean> liveOnly) {
 
-    HashMap<UUID, List<CollectionExercise>> surveyCollexDict = null;
+    HashMap<UUID, List<CollectionExercise>> surveyCollexMap;
 
     if (liveOnly.isPresent() && liveOnly.get().booleanValue()) {
-      surveyCollexDict =
+      surveyCollexMap =
           collectionExerciseService.findCollectionExercisesForSurveysByState(
               surveyIds, CollectionExerciseState.LIVE);
     } else {
-      surveyCollexDict = collectionExerciseService.findCollectionExercisesForSurveys(surveyIds);
+      surveyCollexMap = collectionExerciseService.findCollectionExercisesForSurveys(surveyIds);
     }
 
-    return ResponseEntity.ok(surveyCollexDict);
+    return ResponseEntity.ok(surveyCollexMap);
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
@@ -29,7 +29,24 @@ public interface CollectionExerciseRepository extends JpaRepository<CollectionEx
 
   List<CollectionExercise> findBySurveyId(UUID surveyUuid);
 
+  /**
+   * Query repository for collection exercises in a list of survey ids
+   *
+   * @param surveyIds the surveys to select by
+   * @return List of collection exercises, ordered by survey id
+   */
+  List<CollectionExercise> findBySurveyIdInOrderBySurveyId(List<UUID> surveyIds);
+
   List<CollectionExercise> findBySurveyIdAndState(UUID surveyUuid, CollectionExerciseState state);
+
+  /**
+   * Query repository for collection exercises in a list of survey ids
+   *
+   * @param surveyIds the surveys to select by
+   * @param state the state of the survey to limit by
+   * @return List of collection exercises, ordered by survey id
+   */
+  List<CollectionExercise> findBySurveyIdInAndStateOrderBySurveyId(List<UUID> surveyIds, CollectionExerciseState state);
 
   /**
    * Query repository for list of collection exercises associated with a certain state.

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/repository/CollectionExerciseRepository.java
@@ -46,7 +46,8 @@ public interface CollectionExerciseRepository extends JpaRepository<CollectionEx
    * @param state the state of the survey to limit by
    * @return List of collection exercises, ordered by survey id
    */
-  List<CollectionExercise> findBySurveyIdInAndStateOrderBySurveyId(List<UUID> surveyIds, CollectionExerciseState state);
+  List<CollectionExercise> findBySurveyIdInAndStateOrderBySurveyId(
+      List<UUID> surveyIds, CollectionExerciseState state);
 
   /**
    * Query repository for list of collection exercises associated with a certain state.

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
@@ -123,7 +123,7 @@ public class CollectionExerciseService {
   }
 
   /**
-   * Walks a list of collection exercises and splits them into a dictionary with key of survey id
+   * Walks a list of collection exercises and splits them into a HashMap with key of survey id
    * and value of list of collection exercises
    *
    * @param collexList list of collection exercises to split
@@ -174,7 +174,7 @@ public class CollectionExerciseService {
    *
    * @param surveyIds the survey UUIDS for which to find collection exercises
    * @param state Only return collection exercises in this state
-   * @return the associated collection exercises as a dictionary , key is survey id , value is List
+   * @return the associated collection exercises as a HashMap, key is survey id , value is List
    *     of collex
    */
   public HashMap<UUID, List<CollectionExercise>> findCollectionExercisesForSurveysByState(

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
@@ -119,29 +119,29 @@ public class CollectionExerciseService {
     List<CollectionExercise> collexList =
         this.collectRepo.findBySurveyIdInOrderBySurveyId(surveyIds);
 
-    return this.collexListToDict(collexList);
+    return this.collexListToMap(collexList);
   }
 
   /**
-   * Walks a list of collection exercises and splits them into a HashMap with key of survey id
-   * and value of list of collection exercises
+   * Walks a list of collection exercises and splits them into a HashMap with key of survey id and
+   * value of list of collection exercises
    *
    * @param collexList list of collection exercises to split
    * @return the associated collection exercises.
    */
-  private HashMap<UUID, List<CollectionExercise>> collexListToDict(
+  private HashMap<UUID, List<CollectionExercise>> collexListToMap(
       List<CollectionExercise> collexList) {
-    HashMap<UUID, List<CollectionExercise>> collexDict = new HashMap<>();
+    HashMap<UUID, List<CollectionExercise>> collexMap = new HashMap<>();
 
     for (CollectionExercise current : collexList) {
       UUID surveyId = current.getSurveyId();
 
-      if (!collexDict.containsKey(surveyId)) {
-        collexDict.put(surveyId, new ArrayList<>());
+      if (!collexMap.containsKey(surveyId)) {
+        collexMap.put(surveyId, new ArrayList<CollectionExercise>());
       }
-      collexDict.get(surveyId).add(current);
+      collexMap.get(surveyId).add(current);
     }
-    return collexDict;
+    return collexMap;
   }
 
   /**
@@ -174,15 +174,15 @@ public class CollectionExerciseService {
    *
    * @param surveyIds the survey UUIDS for which to find collection exercises
    * @param state Only return collection exercises in this state
-   * @return the associated collection exercises as a HashMap, key is survey id , value is List
-   *     of collex
+   * @return the associated collection exercises as a HashMap, key is survey id , value is List of
+   *     collex
    */
   public HashMap<UUID, List<CollectionExercise>> findCollectionExercisesForSurveysByState(
       List<UUID> surveyIds, CollectionExerciseState state) {
     List<CollectionExercise> collexList =
         this.collectRepo.findBySurveyIdInAndStateOrderBySurveyId(surveyIds, state);
 
-    return this.collexListToDict(collexList);
+    return this.collexListToMap(collexList);
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
@@ -107,14 +107,17 @@ public class CollectionExerciseService {
   }
 
   /**
-   * Find a list of collection exercises associated with a list of surveys from the Collection Exercise Service
+   * Find a list of collection exercises associated with a list of surveys from the Collection
+   * Exercise Service
    *
    * @param surveyIds the survey UUIDS for which to find collection exercises
    * @return the associated collection exercises.
    */
-  public HashMap<UUID, List<CollectionExercise>> findCollectionExercisesForSurveys(List<UUID> surveyIds) {
+  public HashMap<UUID, List<CollectionExercise>> findCollectionExercisesForSurveys(
+      List<UUID> surveyIds) {
 
-    List<CollectionExercise> collexList = this.collectRepo.findBySurveyIdInOrderBySurveyId(surveyIds);
+    List<CollectionExercise> collexList =
+        this.collectRepo.findBySurveyIdInOrderBySurveyId(surveyIds);
 
     return this.collexListToDict(collexList);
   }
@@ -122,10 +125,12 @@ public class CollectionExerciseService {
   /**
    * Walks a list of collection exercises and splits them into a dictionary with key of survey id
    * and value of list of collection exercises
+   *
    * @param collexList list of collection exercises to split
    * @return the associated collection exercises.
    */
-  private HashMap<UUID, List<CollectionExercise>> collexListToDict(List<CollectionExercise> collexList) {
+  private HashMap<UUID, List<CollectionExercise>> collexListToDict(
+      List<CollectionExercise> collexList) {
     HashMap<UUID, List<CollectionExercise>> collexDict = new HashMap<>();
 
     for (CollectionExercise current : collexList) {
@@ -163,22 +168,22 @@ public class CollectionExerciseService {
     return collectRepo.findBySurveyIdAndState(surveyId, state);
   }
 
-
   /**
-   * Find a list of collection exercises associated with a list of surveys from the Collection Exercise Service
+   * Find a list of collection exercises associated with a list of surveys from the Collection
+   * Exercise Service
    *
-   * @param surveyIds the survey UUIDS  for which to find collection exercises
+   * @param surveyIds the survey UUIDS for which to find collection exercises
    * @param state Only return collection exercises in this state
-   * @return the associated collection exercises as a dictionary , key is survey id , value is List of collex
+   * @return the associated collection exercises as a dictionary , key is survey id , value is List
+   *     of collex
    */
-  public HashMap<UUID, List<CollectionExercise>> findCollectionExercisesForSurveysByState(List<UUID> surveyIds,
-                                                                           CollectionExerciseState state) {
-    List<CollectionExercise> collexList = this.collectRepo.findBySurveyIdInAndStateOrderBySurveyId(surveyIds, state);
+  public HashMap<UUID, List<CollectionExercise>> findCollectionExercisesForSurveysByState(
+      List<UUID> surveyIds, CollectionExerciseState state) {
+    List<CollectionExercise> collexList =
+        this.collectRepo.findBySurveyIdInAndStateOrderBySurveyId(surveyIds, state);
 
     return this.collexListToDict(collexList);
   }
-
-
 
   /**
    * Find a collection exercise associated to a collection exercise Id from the Collection Exercise

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseService.java
@@ -107,6 +107,39 @@ public class CollectionExerciseService {
   }
 
   /**
+   * Find a list of collection exercises associated with a list of surveys from the Collection Exercise Service
+   *
+   * @param surveyIds the survey UUIDS for which to find collection exercises
+   * @return the associated collection exercises.
+   */
+  public HashMap<UUID, List<CollectionExercise>> findCollectionExercisesForSurveys(List<UUID> surveyIds) {
+
+    List<CollectionExercise> collexList = this.collectRepo.findBySurveyIdInOrderBySurveyId(surveyIds);
+
+    return this.collexListToDict(collexList);
+  }
+
+  /**
+   * Walks a list of collection exercises and splits them into a dictionary with key of survey id
+   * and value of list of collection exercises
+   * @param collexList list of collection exercises to split
+   * @return the associated collection exercises.
+   */
+  private HashMap<UUID, List<CollectionExercise>> collexListToDict(List<CollectionExercise> collexList) {
+    HashMap<UUID, List<CollectionExercise>> collexDict = new HashMap<>();
+
+    for (CollectionExercise current : collexList) {
+      UUID surveyId = current.getSurveyId();
+
+      if (!collexDict.containsKey(surveyId)) {
+        collexDict.put(surveyId, new ArrayList<>());
+      }
+      collexDict.get(surveyId).add(current);
+    }
+    return collexDict;
+  }
+
+  /**
    * find a list of all sample summary linked to a collection exercise
    *
    * @param id the collection exercise Id to find the linked sample summaries for
@@ -129,6 +162,23 @@ public class CollectionExerciseService {
       UUID surveyId, CollectionExerciseState state) {
     return collectRepo.findBySurveyIdAndState(surveyId, state);
   }
+
+
+  /**
+   * Find a list of collection exercises associated with a list of surveys from the Collection Exercise Service
+   *
+   * @param surveyIds the survey UUIDS  for which to find collection exercises
+   * @param state Only return collection exercises in this state
+   * @return the associated collection exercises as a dictionary , key is survey id , value is List of collex
+   */
+  public HashMap<UUID, List<CollectionExercise>> findCollectionExercisesForSurveysByState(List<UUID> surveyIds,
+                                                                           CollectionExerciseState state) {
+    List<CollectionExercise> collexList = this.collectRepo.findBySurveyIdInAndStateOrderBySurveyId(surveyIds, state);
+
+    return this.collexListToDict(collexList);
+  }
+
+
 
   /**
    * Find a collection exercise associated to a collection exercise Id from the Collection Exercise

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -53,10 +53,10 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.CaseType;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CaseTypeDefault;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
+import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.LinkedSampleSummariesDTO;
-import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
@@ -171,34 +171,32 @@ public class CollectionExerciseEndpointUnitTests {
   public void findCollectionExercisesForSurvey() throws Exception {
     when(surveyService.findSurvey(SURVEY_ID_1)).thenReturn(surveyDtoResults.get(0));
     when(collectionExerciseService.findCollectionExercisesForSurvey(surveyDtoResults.get(0)))
-      .thenReturn(collectionExerciseResults);
+        .thenReturn(collectionExerciseResults);
 
     ResultActions actions =
-      mockCollectionExerciseMvc.perform(
-        getJson(String.format("/collectionexercises/survey/%s", SURVEY_ID_1)));
+        mockCollectionExerciseMvc.perform(
+            getJson(String.format("/collectionexercises/survey/%s", SURVEY_ID_1)));
 
     actions
-      .andExpect(status().isOk())
-      .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
-      .andExpect(handler().methodName("getCollectionExercisesForSurvey"))
-      .andExpect(jsonPath("$", hasSize(2)))
-      .andExpect(
-        jsonPath(
-          "$[*].id",
-          containsInAnyOrder(
-            COLLECTIONEXERCISE_ID1.toString(), COLLECTIONEXERCISE_ID2.toString())))
-      .andExpect(
-        jsonPath(
-          "$[*].scheduledExecutionDateTime",
-          containsInAnyOrder(
-            new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT),
-            new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT))));
+        .andExpect(status().isOk())
+        .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
+        .andExpect(handler().methodName("getCollectionExercisesForSurvey"))
+        .andExpect(jsonPath("$", hasSize(2)))
+        .andExpect(
+            jsonPath(
+                "$[*].id",
+                containsInAnyOrder(
+                    COLLECTIONEXERCISE_ID1.toString(), COLLECTIONEXERCISE_ID2.toString())))
+        .andExpect(
+            jsonPath(
+                "$[*].scheduledExecutionDateTime",
+                containsInAnyOrder(
+                    new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT),
+                    new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT))));
   }
 
-
   /**
-   * Tests if collection exercises found for list of surveys.
-   * Returned in a Json dictionary
+   * Tests if collection exercises found for list of surveys. Returned in a Json dictionary
    *
    * @throws Exception
    */
@@ -207,30 +205,34 @@ public class CollectionExerciseEndpointUnitTests {
 
     List<UUID> surveys = Arrays.asList(SURVEY_ID_1, SURVEY_ID_2);
 
-    HashMap<UUID, List<CollectionExercise>> serviceReturn= new HashMap<>();
+    HashMap<UUID, List<CollectionExercise>> serviceReturn = new HashMap<>();
     serviceReturn.put(SURVEY_ID_1, this.collectionExerciseResultsSurvey1);
     serviceReturn.put(SURVEY_ID_2, this.collectionExerciseResultsSurvey2);
 
-
     when(collectionExerciseService.findCollectionExercisesForSurveys(surveys))
-      .thenReturn(serviceReturn);
+        .thenReturn(serviceReturn);
 
     ResultActions actions =
-      mockCollectionExerciseMvc.perform(
-        getJson(String.format("/collectionexercises/surveys?surveyIds=%s,%s", SURVEY_ID_1, SURVEY_ID_2)));
+        mockCollectionExerciseMvc.perform(
+            getJson(
+                String.format(
+                    "/collectionexercises/surveys?surveyIds=%s,%s", SURVEY_ID_1, SURVEY_ID_2)));
 
     actions
-      .andExpect(status().isOk())
-      .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
-      .andExpect(handler().methodName("getCollectionExercisesForSurveys"))
-      .andExpect(jsonPath(String.format("$.%s", SURVEY_ID_1.toString()), hasSize(1)))
-      .andExpect(jsonPath(String.format("$.%s.[0].id", SURVEY_ID_1.toString()),
-                          containsString(COLLECTIONEXERCISE_ID1.toString())))
-      .andExpect(jsonPath(String.format("$.%s", SURVEY_ID_2.toString()), hasSize(1)))
-      .andExpect(jsonPath(String.format("$.%s.[0].id", SURVEY_ID_2.toString()),
-        containsString(COLLECTIONEXERCISE_ID2.toString())));
+        .andExpect(status().isOk())
+        .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
+        .andExpect(handler().methodName("getCollectionExercisesForSurveys"))
+        .andExpect(jsonPath(String.format("$.%s", SURVEY_ID_1.toString()), hasSize(1)))
+        .andExpect(
+            jsonPath(
+                String.format("$.%s.[0].id", SURVEY_ID_1.toString()),
+                containsString(COLLECTIONEXERCISE_ID1.toString())))
+        .andExpect(jsonPath(String.format("$.%s", SURVEY_ID_2.toString()), hasSize(1)))
+        .andExpect(
+            jsonPath(
+                String.format("$.%s.[0].id", SURVEY_ID_2.toString()),
+                containsString(COLLECTIONEXERCISE_ID2.toString())));
   }
-
 
   @Test
   public void findCollectionExercisesForSurveyOnlyLive() throws Exception {

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointUnitTests.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.response.collection.exercise.endpoint;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -55,6 +56,7 @@ import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.LinkedSampleSummariesDTO;
+import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
 import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
 import uk.gov.ons.ctp.response.collection.exercise.service.EventService;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleService;
@@ -101,6 +103,8 @@ public class CollectionExerciseEndpointUnitTests {
 
   @Mock private PartySvcClient partySvcClient;
 
+  @Mock private CollectionExerciseRepository collectionExerciseRepository;
+
   @Mock private CollectionExerciseService collectionExerciseService;
 
   @Mock private SurveySvcClient surveyService;
@@ -113,6 +117,8 @@ public class CollectionExerciseEndpointUnitTests {
   private MockMvc textPlainMock;
   private List<SurveyDTO> surveyDtoResults;
   private List<CollectionExercise> collectionExerciseResults;
+  private List<CollectionExercise> collectionExerciseResultsSurvey1;
+  private List<CollectionExercise> collectionExerciseResultsSurvey2;
   private List<SampleUnitsRequestDTO> sampleUnitsRequestDTOResults;
   private Collection<CaseType> caseTypeDefaultResults;
   private List<LinkedSampleSummariesDTO> linkedSampleSummaries;
@@ -140,6 +146,11 @@ public class CollectionExerciseEndpointUnitTests {
 
     this.surveyDtoResults = FixtureHelper.loadClassFixtures(SurveyDTO[].class);
     this.collectionExerciseResults = FixtureHelper.loadClassFixtures(CollectionExercise[].class);
+    this.collectionExerciseResultsSurvey1 = new ArrayList<CollectionExercise>();
+    this.collectionExerciseResultsSurvey2 = new ArrayList<CollectionExercise>();
+
+    this.collectionExerciseResultsSurvey1.add(this.collectionExerciseResults.get(0));
+    this.collectionExerciseResultsSurvey2.add(this.collectionExerciseResults.get(1));
     this.sampleUnitsRequestDTOResults =
         FixtureHelper.loadClassFixtures(SampleUnitsRequestDTO[].class);
     this.linkedSampleSummaries = FixtureHelper.loadClassFixtures(LinkedSampleSummariesDTO[].class);
@@ -160,29 +171,66 @@ public class CollectionExerciseEndpointUnitTests {
   public void findCollectionExercisesForSurvey() throws Exception {
     when(surveyService.findSurvey(SURVEY_ID_1)).thenReturn(surveyDtoResults.get(0));
     when(collectionExerciseService.findCollectionExercisesForSurvey(surveyDtoResults.get(0)))
-        .thenReturn(collectionExerciseResults);
+      .thenReturn(collectionExerciseResults);
 
     ResultActions actions =
-        mockCollectionExerciseMvc.perform(
-            getJson(String.format("/collectionexercises/survey/%s", SURVEY_ID_1)));
+      mockCollectionExerciseMvc.perform(
+        getJson(String.format("/collectionexercises/survey/%s", SURVEY_ID_1)));
 
     actions
-        .andExpect(status().isOk())
-        .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
-        .andExpect(handler().methodName("getCollectionExercisesForSurvey"))
-        .andExpect(jsonPath("$", hasSize(2)))
-        .andExpect(
-            jsonPath(
-                "$[*].id",
-                containsInAnyOrder(
-                    COLLECTIONEXERCISE_ID1.toString(), COLLECTIONEXERCISE_ID2.toString())))
-        .andExpect(
-            jsonPath(
-                "$[*].scheduledExecutionDateTime",
-                containsInAnyOrder(
-                    new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT),
-                    new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT))));
+      .andExpect(status().isOk())
+      .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
+      .andExpect(handler().methodName("getCollectionExercisesForSurvey"))
+      .andExpect(jsonPath("$", hasSize(2)))
+      .andExpect(
+        jsonPath(
+          "$[*].id",
+          containsInAnyOrder(
+            COLLECTIONEXERCISE_ID1.toString(), COLLECTIONEXERCISE_ID2.toString())))
+      .andExpect(
+        jsonPath(
+          "$[*].scheduledExecutionDateTime",
+          containsInAnyOrder(
+            new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT),
+            new DateMatcher(COLLECTIONEXERCISE_DATE_OUTPUT))));
   }
+
+
+  /**
+   * Tests if collection exercises found for list of surveys.
+   * Returned in a Json dictionary
+   *
+   * @throws Exception
+   */
+  @Test
+  public void findCollectionExercisesForSurveys() throws Exception {
+
+    List<UUID> surveys = Arrays.asList(SURVEY_ID_1, SURVEY_ID_2);
+
+    HashMap<UUID, List<CollectionExercise>> serviceReturn= new HashMap<>();
+    serviceReturn.put(SURVEY_ID_1, this.collectionExerciseResultsSurvey1);
+    serviceReturn.put(SURVEY_ID_2, this.collectionExerciseResultsSurvey2);
+
+
+    when(collectionExerciseService.findCollectionExercisesForSurveys(surveys))
+      .thenReturn(serviceReturn);
+
+    ResultActions actions =
+      mockCollectionExerciseMvc.perform(
+        getJson(String.format("/collectionexercises/surveys?surveyIds=%s,%s", SURVEY_ID_1, SURVEY_ID_2)));
+
+    actions
+      .andExpect(status().isOk())
+      .andExpect(handler().handlerType(CollectionExerciseEndpoint.class))
+      .andExpect(handler().methodName("getCollectionExercisesForSurveys"))
+      .andExpect(jsonPath(String.format("$.%s", SURVEY_ID_1.toString()), hasSize(1)))
+      .andExpect(jsonPath(String.format("$.%s.[0].id", SURVEY_ID_1.toString()),
+                          containsString(COLLECTIONEXERCISE_ID1.toString())))
+      .andExpect(jsonPath(String.format("$.%s", SURVEY_ID_2.toString()), hasSize(1)))
+      .andExpect(jsonPath(String.format("$.%s.[0].id", SURVEY_ID_2.toString()),
+        containsString(COLLECTIONEXERCISE_ID2.toString())));
+  }
+
 
   @Test
   public void findCollectionExercisesForSurveyOnlyLive() throws Exception {

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseServiceTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_DELETED;
-
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -751,6 +751,49 @@ public class CollectionExerciseServiceTest {
             CollectionExerciseDTO.CollectionExerciseState.CREATED,
             CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_ADDED);
   }
+
+  @Test
+  public void testFindCollectionExercisesForSurveys() throws Exception {
+    final UUID SURVEY_ID_1 = UUID.fromString("31ec898e-f370-429a-bca4-eab1045aff4e");
+
+    List<UUID> surveys = Arrays.asList(SURVEY_ID_1);
+
+    List<CollectionExercise> existing = FixtureHelper
+      .loadClassFixtures(CollectionExercise[].class);
+
+    given(collexRepo.findBySurveyIdInOrderBySurveyId(surveys)).willReturn(existing);
+
+    HashMap<UUID, List<CollectionExercise>> result =
+      this.collectionExerciseService.findCollectionExercisesForSurveys(surveys);
+
+    assertEquals(result.get(SURVEY_ID_1).size(), 2);
+
+  }
+
+  /**
+   * Tests that returns collexes in a dictionary (key of survey) when repo returns a list of
+   * specific collexes.
+   */
+  @Test
+  public void testFindCollectionExercisesForSurveysByState() throws Exception {
+    final UUID SURVEY_ID_1 = UUID.fromString("31ec898e-f370-429a-bca4-eab1045aff4e");
+
+    List<UUID> surveys = Arrays.asList(SURVEY_ID_1);
+
+    List<CollectionExercise> existing = FixtureHelper
+      .loadClassFixtures(CollectionExercise[].class);
+
+    given(collexRepo.findBySurveyIdInAndStateOrderBySurveyId(
+      surveys, CollectionExerciseDTO.CollectionExerciseState.LIVE)).willReturn(existing);
+
+    HashMap<UUID, List<CollectionExercise>> result =
+      this.collectionExerciseService.findCollectionExercisesForSurveysByState(surveys,
+        CollectionExerciseDTO.CollectionExerciseState.LIVE );
+
+    assertEquals(result.get(SURVEY_ID_1).size(), 2);
+
+  }
+
 
   public void testRemoveSampleSummaryLink() throws Exception {
     // Given

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/CollectionExerciseServiceTest.java
@@ -12,8 +12,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent.CI_SAMPLE_DELETED;
-import java.util.Arrays;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -758,16 +759,14 @@ public class CollectionExerciseServiceTest {
 
     List<UUID> surveys = Arrays.asList(SURVEY_ID_1);
 
-    List<CollectionExercise> existing = FixtureHelper
-      .loadClassFixtures(CollectionExercise[].class);
+    List<CollectionExercise> existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class);
 
     given(collexRepo.findBySurveyIdInOrderBySurveyId(surveys)).willReturn(existing);
 
     HashMap<UUID, List<CollectionExercise>> result =
-      this.collectionExerciseService.findCollectionExercisesForSurveys(surveys);
+        this.collectionExerciseService.findCollectionExercisesForSurveys(surveys);
 
     assertEquals(result.get(SURVEY_ID_1).size(), 2);
-
   }
 
   /**
@@ -780,20 +779,19 @@ public class CollectionExerciseServiceTest {
 
     List<UUID> surveys = Arrays.asList(SURVEY_ID_1);
 
-    List<CollectionExercise> existing = FixtureHelper
-      .loadClassFixtures(CollectionExercise[].class);
+    List<CollectionExercise> existing = FixtureHelper.loadClassFixtures(CollectionExercise[].class);
 
-    given(collexRepo.findBySurveyIdInAndStateOrderBySurveyId(
-      surveys, CollectionExerciseDTO.CollectionExerciseState.LIVE)).willReturn(existing);
+    given(
+            collexRepo.findBySurveyIdInAndStateOrderBySurveyId(
+                surveys, CollectionExerciseDTO.CollectionExerciseState.LIVE))
+        .willReturn(existing);
 
     HashMap<UUID, List<CollectionExercise>> result =
-      this.collectionExerciseService.findCollectionExercisesForSurveysByState(surveys,
-        CollectionExerciseDTO.CollectionExerciseState.LIVE );
+        this.collectionExerciseService.findCollectionExercisesForSurveysByState(
+            surveys, CollectionExerciseDTO.CollectionExerciseState.LIVE);
 
     assertEquals(result.get(SURVEY_ID_1).size(), 2);
-
   }
-
 
   public void testRemoveSampleSummaryLink() throws Exception {
     // Given


### PR DESCRIPTION


# Motivation and Context
Some of the front ends retrieve collection exercises once per survey. This new end point is to enable the front end to change so as to make fewer calls 

# What has changed
New endpoint created that accepts a list of survey ids and an optional state .
This then returns all the collexes for all the surveys in the form of a Json dictionary .
With a key of the survey ID , and a list of collection exercises as the value

# How to test?
Since this is ahead of the uI changes , run the new tests . 

# Links
 https://trello.com/c/tyGZ9sD9