### PR TITLE
add missing app label which was failing deployment

### DIFF
--- a/_infra/helm/templates/deployment.yaml
+++ b/_infra/helm/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        app: {{ .Chart.Name }}
     spec:
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
# Motivation and Context
migration work. spinnaker was failing to deploy the service due to missing label.
