### PR TITLE
Add DNS entries

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/_infra/helm/collection-exercise/templates/deployment.yaml
+++ b/_infra/helm/collection-exercise/templates/deployment.yaml
@@ -184,41 +184,81 @@ spec:
           - name: DATA_GRID_ADDRESS
             value: "$(REDIS_HOST):$(REDIS_PORT)"
           - name: ACTION_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "action.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(ACTION_SERVICE_HOST)"
+            {{- end }}
           - name: ACTION_SVC_CONNECTION_CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(ACTION_SERVICE_PORT)"
+            {{- end }}
           - name: ACTION_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: ACTION_SVC_CONNECTION_CONFIG_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: SAMPLE_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "sample.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(SAMPLE_SERVICE_HOST)"
+            {{- end }}
           - name: SAMPLE_SVC_CONNECTION_CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(SAMPLE_SERVICE_PORT)"
+            {{- end }}
           - name: SAMPLE_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: SAMPLE_SVC_CONNECTION_CONFIG_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: SURVEY_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "survey.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(SURVEY_SERVICE_HOST)"
+            {{- end }}
+          - name: SURVEY_SVC_CONNECTION_CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
+            value: "$(SURVEY_SERVICE_PORT)"
+            {{- end }}
           - name: SURVEY_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: SURVEY_SVC_CONNECTION_CONFIG_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
-          - name: SURVEY_SVC_CONNECTION_CONFIG_PORT
-            value: "$(SURVEY_SERVICE_PORT)"
           - name: PARTY_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "party.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(PARTY_SERVICE_HOST)"
+            {{- end }}
           - name: PARTY_SVC_CONNECTION_CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(PARTY_SERVICE_PORT)"
+            {{- end }}
           - name: PARTY_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: PARTY_SVC_CONNECTION_CONFIG_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: COLLECTION_INSTRUMENT_SVC_CONNECTION_CONFIG_HOST
+            {{- if .Values.dns.enabled }}
+            value: "collection-instrument.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(COLLECTION_INSTRUMENT_SERVICE_HOST)"
+            {{- end }}
           - name: COLLECTION_INSTRUMENT_SVC_CONNECTION_CONFIG_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(COLLECTION_INSTRUMENT_SERVICE_PORT)"
+            {{- end }}
           - name: COLLECTION_INSTRUMENT_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: COLLECTION_INSTRUMENT_SVC_CONNECTION_CONFIG_PASSWORD

--- a/_infra/helm/collection-exercise/values.yaml
+++ b/_infra/helm/collection-exercise/values.yaml
@@ -39,3 +39,7 @@ tomcat:
   maxActive: 10
   maxIdle: 5
   minIdle: 3
+
+dns:
+  enabled: false
+  wellKnownPort: 8080


### PR DESCRIPTION
# Motivation and Context
Adds kube_dns addresses for all connecting services to allow us to have circular references