### PR TITLE
Fix for event update for nudge email fails for the same event with th…

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.0.7
+appVersion: 11.0.8

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
@@ -118,6 +118,7 @@ public class NudgeEmailValidator implements EventValidator {
   }
 
   private boolean isEventSameAsExisting(Event nudgeEvent, Event submittedEvent) {
-    return nudgeEvent.getTimestamp().equals(submittedEvent.getTimestamp());
+    return !(nudgeEvent.equals(submittedEvent))
+        && nudgeEvent.getTimestamp().equals(submittedEvent.getTimestamp());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidatorTest.java
@@ -233,4 +233,36 @@ public class NudgeEmailValidatorTest {
         "A nudge email has already been scheduled for this date and time. Choose a different date or time.",
         actualException.getMessage());
   }
+
+  @Test
+  public void testNudgeWithSameDateAndTimeEventCreationNotValidForTheSameEvent() {
+    final Instant now = Instant.now();
+    final Long nudgeTime = now.plus(2, ChronoUnit.DAYS).toEpochMilli();
+    final Event goLive = new Event();
+    goLive.setTag((EventService.Tag.go_live.toString()));
+    goLive.setTimestamp(Timestamp.from(now));
+
+    final Event nudge = new Event();
+    nudge.setTag((EventService.Tag.nudge_email_0.toString()));
+    nudge.setTimestamp(new Timestamp(nudgeTime));
+
+    final Event returnBy = new Event();
+    returnBy.setTag((EventService.Tag.return_by.toString()));
+    returnBy.setTimestamp(Timestamp.from(now.plus(4, ChronoUnit.DAYS)));
+
+    final List<Event> events = Arrays.asList(goLive, returnBy, nudge);
+
+    final Event submittedEvent = new Event();
+    submittedEvent.setTag((EventService.Tag.nudge_email_0.toString()));
+    submittedEvent.setTimestamp(new Timestamp(nudgeTime));
+
+    CTPException actualException = null;
+    try {
+      nudgeEmailValidator.validate(
+          events, submittedEvent, CollectionExerciseDTO.CollectionExerciseState.CREATED);
+    } catch (CTPException expectedException) {
+      actualException = expectedException;
+    }
+    assertNull(actualException);
+  }
 }


### PR DESCRIPTION
Fix for event update for nudge email fails for the same event with the validation error

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
