### PR TITLE
Format timestamp output as GMT to warn on NudgeEmail

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.collection.exercise.service.validator;
 
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -38,14 +39,18 @@ public class NudgeEmailValidator implements EventValidator {
           CTPException.Fault.BAD_REQUEST, "Nudge email cannot be set in the past");
     }
     if (!isEventBetweenGoLiveAndReturnBy(goLive, submittedEvent, returnBy)) {
-      throw new CTPException(
-          CTPException.Fault.BAD_REQUEST,
-          "Nudge email must be set after the Go Live date ("
-              + goLive.getTimestamp()
-              + ") "
-              + "and before Return by date ("
-              + returnBy.getTimestamp()
-              + ")");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+        sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+        Date goLiveDate = new Date(goLive.getTimestamp().getTime());
+        Date returnByDate = new Date(returnBy.getTimestamp().getTime());
+        throw new CTPException(
+            CTPException.Fault.BAD_REQUEST,
+            "Nudge email must be set after the Go Live date ("
+                + sdf.format(goLiveDate)
+                + ") "
+                + "and before Return by date ("
+                + sdf.format(returnByDate)
+                + ")");
     }
     List<Event> existingEvent =
         EventService.Tag.ORDERED_NUDGE_EMAIL

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
@@ -39,18 +39,18 @@ public class NudgeEmailValidator implements EventValidator {
           CTPException.Fault.BAD_REQUEST, "Nudge email cannot be set in the past");
     }
     if (!isEventBetweenGoLiveAndReturnBy(goLive, submittedEvent, returnBy)) {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
-        Date goLiveDate = new Date(goLive.getTimestamp().getTime());
-        Date returnByDate = new Date(returnBy.getTimestamp().getTime());
-        throw new CTPException(
-            CTPException.Fault.BAD_REQUEST,
-            "Nudge email must be set after the Go Live date ("
-                + sdf.format(goLiveDate)
-                + ") "
-                + "and before Return by date ("
-                + sdf.format(returnByDate)
-                + ")");
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+      sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+      Date goLiveDate = new Date(goLive.getTimestamp().getTime());
+      Date returnByDate = new Date(returnBy.getTimestamp().getTime());
+      throw new CTPException(
+          CTPException.Fault.BAD_REQUEST,
+          "Nudge email must be set after the Go Live date ("
+              + sdf.format(goLiveDate)
+              + ") "
+              + "and before Return by date ("
+              + sdf.format(returnByDate)
+              + ")");
     }
     List<Event> existingEvent =
         EventService.Tag.ORDERED_NUDGE_EMAIL

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
@@ -39,8 +39,8 @@ public class NudgeEmailValidator implements EventValidator {
           CTPException.Fault.BAD_REQUEST, "Nudge email cannot be set in the past");
     }
     if (!isEventBetweenGoLiveAndReturnBy(goLive, submittedEvent, returnBy)) {
-      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S zzzz");
-      sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+      sdf.setTimeZone(TimeZone.getTimeZone("Europe/London"));
       Date goLiveDate = new Date(goLive.getTimestamp().getTime());
       Date returnByDate = new Date(returnBy.getTimestamp().getTime());
       throw new CTPException(

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
@@ -39,7 +39,7 @@ public class NudgeEmailValidator implements EventValidator {
           CTPException.Fault.BAD_REQUEST, "Nudge email cannot be set in the past");
     }
     if (!isEventBetweenGoLiveAndReturnBy(goLive, submittedEvent, returnBy)) {
-      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
       sdf.setTimeZone(TimeZone.getTimeZone("Europe/London"));
       Date goLiveDate = new Date(goLive.getTimestamp().getTime());
       Date returnByDate = new Date(returnBy.getTimestamp().getTime());

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidator.java
@@ -39,7 +39,7 @@ public class NudgeEmailValidator implements EventValidator {
           CTPException.Fault.BAD_REQUEST, "Nudge email cannot be set in the past");
     }
     if (!isEventBetweenGoLiveAndReturnBy(goLive, submittedEvent, returnBy)) {
-      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S zzzz");
       sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
       Date goLiveDate = new Date(goLive.getTimestamp().getTime());
       Date returnByDate = new Date(returnBy.getTimestamp().getTime());

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidatorTest.java
@@ -190,6 +190,11 @@ public class NudgeEmailValidatorTest {
     nudgeEvent.setTag(EventService.Tag.nudge_email_0.toString());
     nudgeEvent.setTimestamp(Timestamp.from(Instant.now().plus(1, ChronoUnit.DAYS)));
 
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    sdf.setTimeZone(TimeZone.getTimeZone("Europe/London"));
+    Date goLiveDate = new Date(goLive.getTimestamp().getTime());
+    Date returnByDate = new Date(returnBy.getTimestamp().getTime());
+
     CTPException actualException = null;
     try {
       nudgeEmailValidator.validate(
@@ -200,10 +205,10 @@ public class NudgeEmailValidatorTest {
     assertNotNull(actualException);
     String expectedMessage =
         "Nudge email must be set after the Go Live date ("
-            + goLive.getTimestamp()
+            + sdf.format(goLiveDate)
             + ") "
             + "and before Return by date ("
-            + returnBy.getTimestamp()
+            + sdf.format(returnByDate)
             + ")";
     assertEquals(expectedMessage, actualException.getMessage());
   }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidatorTest.java
@@ -154,7 +154,7 @@ public class NudgeEmailValidatorTest {
     final List<Event> events = Arrays.asList(goLive, returnBy);
     CTPException actualException = null;
 
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     sdf.setTimeZone(TimeZone.getTimeZone("Europe/London"));
     Date goLiveDate = new Date(goLive.getTimestamp().getTime());
     Date returnByDate = new Date(returnBy.getTimestamp().getTime());

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidatorTest.java
@@ -7,12 +7,15 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -150,6 +153,12 @@ public class NudgeEmailValidatorTest {
 
     final List<Event> events = Arrays.asList(goLive, returnBy);
     CTPException actualException = null;
+
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+    sdf.setTimeZone(TimeZone.getTimeZone("Europe/London"));
+    Date goLiveDate = new Date(goLive.getTimestamp().getTime());
+    Date returnByDate = new Date(returnBy.getTimestamp().getTime());
+
     try {
       nudgeEmailValidator.validate(
           events, nudgeEvent, CollectionExerciseDTO.CollectionExerciseState.SCHEDULED);
@@ -159,10 +168,10 @@ public class NudgeEmailValidatorTest {
     assertNotNull(actualException);
     String expectedMessage =
         "Nudge email must be set after the Go Live date ("
-            + goLive.getTimestamp()
+            + sdf.format(returnByDate)
             + ") "
             + "and before Return by date ("
-            + returnBy.getTimestamp()
+            + sdf.format(returnByDate)
             + ")";
     assertEquals(expectedMessage, actualException.getMessage());
   }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/validator/NudgeEmailValidatorTest.java
@@ -168,7 +168,7 @@ public class NudgeEmailValidatorTest {
     assertNotNull(actualException);
     String expectedMessage =
         "Nudge email must be set after the Go Live date ("
-            + sdf.format(returnByDate)
+            + sdf.format(goLiveDate)
             + ") "
             + "and before Return by date ("
             + sdf.format(returnByDate)


### PR DESCRIPTION
# Motivation and Context
bugfix for warning on nudge emails: timestamps show as UTC, not BST
<!--- Why is this change required? What problem does it solve? -->

# What has changed
Converted timestamps to dates (as you can't set a timezone on a timestamp), and in error message printed GoLive and ReturnBy dates in GMT, with same format as timestamps
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
- In sandbox Response Ops, create a new collection exercise, and schedule nudge email for before GoLive or after ReturnBy 
- A red error message will appear asking you to correct the error: check that GoLive and ReturnBy dates are correctly displayed
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
- https://collaborate2.ons.gov.uk/jira/browse/RAS-241
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
