### PR TITLE
created database migration for deleting tables and procedures

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -139,8 +139,6 @@
    Holds association between collection exercise and action plan id
    #### `samplelink`
    Holds collection-exercise and sample summary id
-   #### `messagelog`
-   Holds job id and message information.
    
    
    ## improvements
@@ -150,7 +148,6 @@
    but it does interact with multiple services to carry out its function.
    This service can be simplified by improving existing service, a rewrite might not be necessary.
    * DB structure need to be improved to provide more viable link and relationship between tables.
-   * Remove `report` and `reporttype` table. I haven't seen its usage.
    * Remove `sampleunittype` as it can easily be removed by a static value. 
    * Remove the use of XML/XSD and replace with JSON.
    * Improving service to propagate the changes to action for any changes. Few of the function does not seem to propagate

--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.0.22
+appVersion: 11.0.23

--- a/src/main/resources/database/changes/release-12/changelog.yml
+++ b/src/main/resources/database/changes/release-12/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 12.1
+      author: Adam Wilkie
+      changes:
+        - sqlFile:
+            comment: Remove report table and procedures
+            path: remove_report_table_and_procedures.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/main/resources/database/changes/release-12/remove_report_table_and_procedures.sql
+++ b/src/main/resources/database/changes/release-12/remove_report_table_and_procedures.sql
@@ -1,0 +1,7 @@
+DROP TABLE [IF EXISTS]
+    collectionexercise.messagelog,
+    collectionexercise.report,
+    collectionexercise.reporttype;
+DROP FUNCTION [IF EXISTS]
+    collectionexercise.generate_collectionexercise_mi,
+    collectionexercise.logmessage;


### PR DESCRIPTION
# Motivation and Context
The MI reporting system isn't used in RASRM, so there is no need for it and any related tables/ procedures. From what I could tell, there was no Java code relating to these tables/procedures on the service itself.

# What has changed
* Created database migration to drop three tables (`report`, `reporttype` and `messagelog`) and two procedures (`generate_collectionexercise_mi` and `logmessage`).
* Removed a line from the `improvements.md` about removing the `report` and `reporttype` tables, as that will be done here. Also removed a mention of the `messagelog` table.

# Links
[Trello card](https://trello.com/c/ZE7RDTVg)
