### PR TITLE
Docker tag latest at the same time as the release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,12 +143,13 @@ jobs:
       - name: Build Release Image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
+          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
       - name: Push Release image
         if: github.ref == 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }}
-      
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
+
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'
         run: |

--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -19,4 +19,4 @@ version: 1.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 11.1.0
+appVersion: 11.1.1


### PR DESCRIPTION
# What and why?
During the release step tag the generated docker image as both the release version and latest. 

# How to test?
Run a release

# Trello
