### PR TITLE
Change party url to business url

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -19,4 +19,4 @@ version: 1.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 11.1.6
+appVersion: 11.1.7

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/PartySvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/PartySvcClient.java
@@ -17,7 +17,6 @@ import uk.gov.ons.ctp.response.collection.exercise.lib.common.rest.RestUtility;
 import uk.gov.ons.ctp.response.collection.exercise.lib.party.definition.SampleLinkCreationRequestDTO;
 import uk.gov.ons.ctp.response.collection.exercise.lib.party.representation.PartyDTO;
 import uk.gov.ons.ctp.response.collection.exercise.lib.party.representation.SampleLinkDTO;
-import uk.gov.ons.ctp.response.collection.exercise.lib.sample.representation.SampleUnitDTO;
 
 /** HTTP RestClient implementation for calls to the Party service */
 @Component
@@ -40,7 +39,6 @@ public class PartySvcClient {
   /**
    * Request party from the Party Service
    *
-   * @param sampleUnitType the sample unit type for which to request party
    * @param sampleUnitRef the sample unit ref for which to request party
    * @return the party object
    */
@@ -48,13 +46,11 @@ public class PartySvcClient {
       value = {RestClientException.class},
       maxAttemptsExpression = "#{${retries.maxAttempts}}",
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
-  public PartyDTO requestParty(SampleUnitDTO.SampleUnitType sampleUnitType, String sampleUnitRef) {
-    log.with("sample_unit_type", sampleUnitType)
-        .with("sample_unit_ref", sampleUnitRef)
-        .debug("Retrieving party");
+  public PartyDTO requestParty(String sampleUnitRef) {
+    log.with("sample_unit_ref", sampleUnitRef).debug("Retrieving party");
     UriComponents uriComponents =
         restUtility.createUriComponents(
-            appConfig.getPartySvc().getRequestPartyPath(), null, sampleUnitType, sampleUnitRef);
+            appConfig.getPartySvc().getRequestPartyPath(), null, sampleUnitRef);
     HttpEntity<PartyDTO> httpEntity = restUtility.createHttpEntityWithAuthHeader();
     ResponseEntity<PartyDTO> responseEntity =
         restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity, PartyDTO.class);

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributor.java
@@ -212,8 +212,7 @@ public class SampleUnitDistributor {
    * @return True if a respondent is enrolled, false otherwise
    */
   private boolean hasActiveEnrolment(ExerciseSampleUnit sampleUnit, CollectionExercise exercise) {
-    PartyDTO businessParty =
-        partySvcClient.requestParty(sampleUnit.getSampleUnitType(), sampleUnit.getSampleUnitRef());
+    PartyDTO businessParty = partySvcClient.requestParty(sampleUnit.getSampleUnitRef());
     return surveyHasEnrolledRespondent(businessParty, exercise.getSurveyId().toString());
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnits.java
@@ -136,9 +136,7 @@ public class ValidateSampleUnits {
 
             if (sampleUnit.getSampleUnitType() == SampleUnitDTO.SampleUnitType.B) {
               try {
-                PartyDTO party =
-                    partySvcClient.requestParty(
-                        sampleUnit.getSampleUnitType(), sampleUnit.getSampleUnitRef());
+                PartyDTO party = partySvcClient.requestParty(sampleUnit.getSampleUnitRef());
                 sampleUnit.setPartyId(UUID.fromString(party.getId()));
               } catch (HttpClientErrorException e) {
                 if (e.getStatusCode() != HttpStatus.NOT_FOUND) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -128,7 +128,7 @@ collection-instrument-svc:
     read-timeout-milli-seconds: 5000
 
 party-svc:
-  request-party-path: /party-api/v1/parties/type/{sampleUnitType}/ref/{sampleUnitRef}
+  request-party-path: /party-api/v1/businesses/ref/{sampleUnitRef}
   sample-link-path: /party-api/v1/businesses/sample/link/{sampleSummaryId}
   connection-config:
     scheme: http

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/PartySvcClientTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/PartySvcClientTest.java
@@ -27,7 +27,6 @@ import uk.gov.ons.ctp.response.collection.exercise.lib.common.rest.RestUtility;
 import uk.gov.ons.ctp.response.collection.exercise.lib.common.rest.RestUtilityConfig;
 import uk.gov.ons.ctp.response.collection.exercise.lib.party.representation.PartyDTO;
 import uk.gov.ons.ctp.response.collection.exercise.lib.party.representation.SampleLinkDTO;
-import uk.gov.ons.ctp.response.collection.exercise.lib.sample.representation.SampleUnitDTO;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PartySvcClientTest {
@@ -59,7 +58,7 @@ public class PartySvcClientTest {
         .thenReturn(new ResponseEntity<>(HttpStatus.CREATED));
 
     // When
-    partySvcClient.requestParty(SampleUnitDTO.SampleUnitType.B, SAMPLE_UNIT_REF);
+    partySvcClient.requestParty(SAMPLE_UNIT_REF);
 
     // Then
     verify(restTemplate, times(1))
@@ -74,7 +73,7 @@ public class PartySvcClientTest {
         .thenThrow(new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
 
     // When
-    partySvcClient.requestParty(SampleUnitDTO.SampleUnitType.B, SAMPLE_UNIT_REF);
+    partySvcClient.requestParty(SAMPLE_UNIT_REF);
 
     // Then
     verify(restTemplate, times(1))

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/distribution/SampleUnitDistributorTest.java
@@ -153,7 +153,7 @@ public class SampleUnitDistributorTest {
 
     when(sampleUnitRepo.findBySampleUnitGroup(any())).thenReturn(sampleUnitParentOnly);
 
-    when(partySvcClient.requestParty(any(), any())).thenReturn(parties.get(0));
+    when(partySvcClient.requestParty(any())).thenReturn(parties.get(0));
 
     when(sampleUnitGroupRepo.countByStateFKAndCollectionExercise(
             eq(SampleUnitGroupDTO.SampleUnitGroupState.PUBLISHED), any()))

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpointIT.java
@@ -412,7 +412,7 @@ public class CollectionExerciseEndpointIT {
             CollectionExerciseEndpointIT.class,
             "CollectionExerciseEndpointIT.PartyDTO.with-associations.json");
     this.wireMockRule.stubFor(
-        get(urlPathMatching("/party-api/v1/parties/type/(.*)/ref/(.*)"))
+        get(urlPathMatching("/party-api/v1/businesses/ref/(.*)"))
             .willReturn(aResponse().withHeader("Content-Type", "application/json").withBody(json)));
   }
 
@@ -422,7 +422,7 @@ public class CollectionExerciseEndpointIT {
             CollectionExerciseEndpointIT.class,
             "CollectionExerciseEndpointIT.PartyDTO.no-associations.json");
     this.wireMockRule.stubFor(
-        get(urlPathMatching("/party-api/v1/parties/type/B/ref/(.*)"))
+        get(urlPathMatching("/party-api/v1/businesses/ref/(.*)"))
             .willReturn(aResponse().withHeader("Content-Type", "application/json").withBody(json)));
   }
 
@@ -432,7 +432,7 @@ public class CollectionExerciseEndpointIT {
             CollectionExerciseEndpointIT.class,
             "CollectionExerciseEndpointIT.PartyDTO.with-associations.json");
     this.wireMockRule.stubFor(
-        get(urlPathMatching("/party-api/v1/parties/type/B/ref/(.*)"))
+        get(urlPathMatching("/party-api/v1/businesses/ref/(.*)"))
             .willReturn(aResponse().withHeader("Content-Type", "application/json").withBody(json)));
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/validation/ValidateSampleUnitsTest.java
@@ -105,7 +105,7 @@ public class ValidateSampleUnitsTest {
     when(collectionInstrumentSvcClient.requestCollectionInstruments(any()))
         .thenReturn(collectionInstruments);
 
-    when(partySvcClient.requestParty(any(), any())).thenReturn(party);
+    when(partySvcClient.requestParty(any())).thenReturn(party);
 
     when(sampleUnitGroupState.transition(any(), any())).thenReturn(SampleUnitGroupState.VALIDATED);
 
@@ -207,7 +207,7 @@ public class ValidateSampleUnitsTest {
             eq("{\"SURVEY_ID\":\"d943344b-1ef4-4c24-b59b-23e3a0350158\",\"FORM_TYPE\":\"0666\"}")))
         .thenReturn(collectionInstrumentsTwo);
 
-    when(partySvcClient.requestParty(any(), any())).thenReturn(party);
+    when(partySvcClient.requestParty(any())).thenReturn(party);
 
     when(sampleUnitGroupState.transition(any(), any())).thenReturn(SampleUnitGroupState.VALIDATED);
 
@@ -292,7 +292,7 @@ public class ValidateSampleUnitsTest {
     when(collectionInstrumentSvcClient.requestCollectionInstruments(any()))
         .thenReturn(collectionInstruments);
 
-    when(partySvcClient.requestParty(any(), any()))
+    when(partySvcClient.requestParty(any()))
         .thenThrow(new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Error"));
 
     // When
@@ -335,7 +335,7 @@ public class ValidateSampleUnitsTest {
     when(collectionInstrumentSvcClient.requestCollectionInstruments(any()))
         .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND, "Bad stuff happened"));
 
-    when(partySvcClient.requestParty(any(), any())).thenReturn(party);
+    when(partySvcClient.requestParty(any())).thenReturn(party);
 
     when(sampleUnitGroupState.transition(any(), any()))
         .thenReturn(SampleUnitGroupState.FAILEDVALIDATION);
@@ -445,7 +445,7 @@ public class ValidateSampleUnitsTest {
     when(collectionInstrumentSvcClient.requestCollectionInstruments(any()))
         .thenReturn(collectionInstruments);
 
-    when(partySvcClient.requestParty(any(), any()))
+    when(partySvcClient.requestParty(any()))
         .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND, "Bad stuff happened"));
 
     when(sampleUnitGroupState.transition(any(), any()))


### PR DESCRIPTION
# What and why?

The `/parties/type/{type}/ref/{ref}` endpoint in party is being removed in favour  of `/businesses/ref/{ref}`.  This PR changes over to it.  Functionally there should be no change as those 2 endpoints have been mapped to the same function in party for months now.

# How to test?

# Trello
