### PR TITLE
Moving sample v2 communication to pubsub

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.1.9
+version: 11.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 11.1.9
+appVersion: 11.1.10

--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.1.10
+version: 12.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 11.1.10
+appVersion: 12.0.1

--- a/_infra/helm/collection-exercise/templates/deployment.yaml
+++ b/_infra/helm/collection-exercise/templates/deployment.yaml
@@ -271,12 +271,18 @@ spec:
             value: "{{ .Values.tomcat.maxIdle }}"
           - name: SPRING_DATASOURCE_TOMCAT_MIN_IDLE
             value: "{{ .Values.tomcat.minIdle }}"
+          - name: SPRING_CLOUD_GCP_PROJECT-ID
+            value: "{{ .Values.gcp.project }}"
           - name: GCP_PROJECT
             value: "{{ .Values.gcp.project }}"
           - name: GCP_CASENOTIFICATIONTOPIC
             value: "{{ .Values.gcp.caseNotificationTopic }}"
           - name: GCP_SAMPLEUNITRECEIVERSUBSCRIPTION
             value: "{{ .Values.gcp.sampleUnitReceiverSubscription }}"
+          - name: GCP_SAMPLESUMMARYSTATUSSUBSCRIPTION
+            value: "{{ .Values.gcp.sampleSummaryStatusSubscription }}"
+          - name: GCP_SAMPLESUMMARYACTIVATIONTOPIC
+            value: "{{ .Values.gcp.sampleSummaryActivationTopic }}"
           - name: SAMPLE_V2_ENABLED
             value: "{{ .Values.sampleV2.enabled }}"
           resources:

--- a/_infra/helm/collection-exercise/templates/deployment.yaml
+++ b/_infra/helm/collection-exercise/templates/deployment.yaml
@@ -279,8 +279,8 @@ spec:
             value: "{{ .Values.gcp.caseNotificationTopic }}"
           - name: GCP_SAMPLEUNITRECEIVERSUBSCRIPTION
             value: "{{ .Values.gcp.sampleUnitReceiverSubscription }}"
-          - name: GCP_SAMPLESUMMARYSTATUSSUBSCRIPTION
-            value: "{{ .Values.gcp.sampleSummaryStatusSubscription }}"
+          - name: GCP_SAMPLESUMMARYACTIVATIONSTATUSSUBSCRIPTION
+            value: "{{ .Values.gcp.sampleSummaryActivationStatusSubscription }}"
           - name: GCP_SAMPLESUMMARYACTIVATIONTOPIC
             value: "{{ .Values.gcp.sampleSummaryActivationTopic }}"
           - name: SAMPLE_V2_ENABLED

--- a/_infra/helm/collection-exercise/values.yaml
+++ b/_infra/helm/collection-exercise/values.yaml
@@ -76,8 +76,8 @@ gcp:
   project: ras-rm-sandbox
   caseNotificationTopic: "case-notification-topic"
   sampleUnitReceiverSubscription: "test_subscription"
-  sampleSummaryStatusSubscription: "sample-summary-status-subscription"
-  sampleSummaryActivationTopic: "sample-summary-activation-topic"
+  sampleSummaryActivationStatusSubscription: sample-summary-activation-status
+  sampleSummaryActivationTopic: sample-summary-activation
 
 sampleV2:
   enabled: false

--- a/_infra/helm/collection-exercise/values.yaml
+++ b/_infra/helm/collection-exercise/values.yaml
@@ -76,6 +76,8 @@ gcp:
   project: ras-rm-sandbox
   caseNotificationTopic: "case-notification-topic"
   sampleUnitReceiverSubscription: "test_subscription"
+  sampleSummaryStatusSubscription: "sample-summary-status-subscription"
+  sampleSummaryActivationTopic: "sample-summary-activation-topic"
 
 sampleV2:
   enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
     <properties>
         <springboot.version>2.4.4</springboot.version>
+        <spring.cloud.gcp.version>1.2.8.RELEASE</spring.cloud.gcp.version>
         <jackson.version>2.12.2</jackson.version>
         <java.version>11</java.version>
         <orika.version>1.5.4</orika.version>
@@ -24,6 +25,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${springboot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-gcp-dependencies</artifactId>
+                <version>${spring.cloud.gcp.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -118,6 +126,15 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
             <version>5.0.19.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-core</artifactId>
         </dependency>
 
         <!-- SPRING END -->

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
@@ -246,7 +246,7 @@ public class CollectionExerciseApplication {
       PubSubTemplate pubSubTemplate) {
     PubSubInboundChannelAdapter adapter =
         new PubSubInboundChannelAdapter(
-            pubSubTemplate, appConfig.getGcp().getSampleSummaryStatusSubscription());
+            pubSubTemplate, appConfig.getGcp().getSampleSummaryActivationStatusSubscription());
     adapter.setOutputChannel(messageChannel);
     adapter.setAckMode(AckMode.MANUAL);
     adapter.setPayloadType(SampleSummaryStatusDTO.class);

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CollectionExerciseApplication.java
@@ -41,7 +41,6 @@ import uk.gov.ons.ctp.response.collection.exercise.lib.common.jackson.CustomObje
 import uk.gov.ons.ctp.response.collection.exercise.lib.common.rest.RestUtility;
 import uk.gov.ons.ctp.response.collection.exercise.lib.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.collection.exercise.lib.common.state.StateTransitionManagerFactory;
-import uk.gov.ons.ctp.response.collection.exercise.message.dto.SampleSummaryStatusDTO;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseEvent;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO.CollectionExerciseState;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleUnitGroupDTO.SampleUnitGroupEvent;
@@ -249,7 +248,6 @@ public class CollectionExerciseApplication {
             pubSubTemplate, appConfig.getGcp().getSampleSummaryActivationStatusSubscription());
     adapter.setOutputChannel(messageChannel);
     adapter.setAckMode(AckMode.MANUAL);
-    adapter.setPayloadType(SampleSummaryStatusDTO.class);
     return adapter;
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
@@ -132,41 +132,4 @@ public class SampleSvcClient {
 
     return responseEntity.getBody();
   }
-
-  public boolean enrichSampleSummary(
-      final UUID surveyId, final UUID collectionExerciseId, final UUID sampleSummaryId) {
-    log.with("surveyId", surveyId)
-        .with("collectionExerciseId", collectionExerciseId)
-        .with("sampleSummaryId", sampleSummaryId)
-        .debug("Enriching sample summary");
-
-    UriComponents uri =
-        restUtility.createUriComponents(
-            appConfig.getSampleSvc().getEnrichSampleSummary(),
-            null,
-            surveyId,
-            collectionExerciseId,
-            sampleSummaryId);
-    HttpEntity<UriComponents> httpEntity = restUtility.createHttpEntity(uri);
-
-    // GET should change to POST but the sample service needs to change
-    ResponseEntity<String> response =
-        restTemplate.exchange(uri.toUri(), HttpMethod.GET, httpEntity, String.class);
-
-    return response.getStatusCode().is2xxSuccessful();
-  }
-
-  public boolean distributeSampleSummary(final UUID sampleSummaryId) {
-    log.with("sampleSummaryId", sampleSummaryId).debug("distribute sample summary");
-    UriComponents uri =
-        restUtility.createUriComponents(
-            appConfig.getSampleSvc().getDistributeSampleSummary(), null, sampleSummaryId);
-    HttpEntity<UriComponents> httpEntity = restUtility.createHttpEntity(uri);
-
-    // as above
-    ResponseEntity<String> response =
-        restTemplate.exchange(uri.toUri(), HttpMethod.GET, httpEntity, String.class);
-
-    return response.getStatusCode().is2xxSuccessful();
-  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/GCP.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/GCP.java
@@ -8,4 +8,6 @@ public class GCP {
   String project;
   String caseNotificationTopic;
   String sampleUnitReceiverSubscription;
+  String sampleSummaryStatusSubscription;
+  String sampleSummaryActivationTopic;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/GCP.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/config/GCP.java
@@ -8,6 +8,6 @@ public class GCP {
   String project;
   String caseNotificationTopic;
   String sampleUnitReceiverSubscription;
-  String sampleSummaryStatusSubscription;
+  String sampleSummaryActivationStatusSubscription;
   String sampleSummaryActivationTopic;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryActivationPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryActivationPublisher.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.response.collection.exercise.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +19,13 @@ public class SampleSummaryActivationPublisher {
 
   @Autowired private CollectionExerciseApplication.PubsubOutboundGateway messagingGateway;
 
-  public void sendSampleSummaryActivation(SampleSummaryActivationDTO sampleSummaryActivationDTO) {
+  public void sendSampleSummaryActivation(
+      UUID collectionExerciseId, UUID sampleSummaryId, UUID surveyId) {
+    SampleSummaryActivationDTO sampleSummaryActivationDTO = new SampleSummaryActivationDTO();
+    sampleSummaryActivationDTO.setCollectionExerciseId(collectionExerciseId);
+    sampleSummaryActivationDTO.setSampleSummaryId(sampleSummaryId);
+    sampleSummaryActivationDTO.setSurveyId(surveyId);
+
     try {
       String payload = objectMapper.writeValueAsString(sampleSummaryActivationDTO);
       messagingGateway.sendToPubsub(payload);

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryActivationPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryActivationPublisher.java
@@ -1,0 +1,29 @@
+package uk.gov.ons.ctp.response.collection.exercise.message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.response.collection.exercise.CollectionExerciseApplication;
+import uk.gov.ons.ctp.response.collection.exercise.representation.SampleSummaryActivationDTO;
+
+@Component
+public class SampleSummaryActivationPublisher {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SampleSummaryActivationDTO.class);
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private CollectionExerciseApplication.PubsubOutboundGateway messagingGateway;
+
+  public void sendSampleSummaryActivation(SampleSummaryActivationDTO sampleSummaryActivationDTO) {
+    try {
+      String payload = objectMapper.writeValueAsString(sampleSummaryActivationDTO);
+      messagingGateway.sendToPubsub(payload);
+    } catch (JsonProcessingException e) {
+      LOGGER.error("Failed to serialise sample summary activation", e);
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiver.java
@@ -1,0 +1,63 @@
+package uk.gov.ons.ctp.response.collection.exercise.message;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gcp.pubsub.support.BasicAcknowledgeablePubsubMessage;
+import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.response.collection.exercise.message.dto.SampleSummaryStatusDTO;
+import uk.gov.ons.ctp.response.collection.exercise.service.SampleSummaryService;
+
+@Component
+public class SampleSummaryStateReceiver {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SampleSummaryStateReceiver.class);
+
+  @Autowired private SampleSummaryService sampleSummaryService;
+
+  @ServiceActivator(inputChannel = "sampleSummaryStatusChannel")
+  public void messageReceiver(
+      SampleSummaryStatusDTO sampleSummaryStatusDTO,
+      @Header(GcpPubSubHeaders.ORIGINAL_MESSAGE) BasicAcknowledgeablePubsubMessage message) {
+
+    if (SampleSummaryStatusDTO.Event.ENRICHED.equals(sampleSummaryStatusDTO.getEvent())) {
+      boolean enrich =
+          sampleSummaryService.validSample(
+              sampleSummaryStatusDTO.isSuccessful(),
+              sampleSummaryStatusDTO.getCollectionExerciseId());
+      if (enrich) {
+        LOGGER
+            .with("collectionExerciseId", sampleSummaryStatusDTO.getCollectionExerciseId())
+            .info("collection exercise transition to valid successful");
+        message.ack();
+      } else {
+        LOGGER
+            .with("collectionExerciseId", sampleSummaryStatusDTO.getCollectionExerciseId())
+            .info("collection exercise transition to valid failed");
+        message.nack();
+      }
+    } else if (SampleSummaryStatusDTO.Event.DISTRIBUTED.equals(sampleSummaryStatusDTO.getEvent())) {
+      boolean distributed =
+          sampleSummaryService.sampleSummaryDistributed(
+              sampleSummaryStatusDTO.isSuccessful(),
+              sampleSummaryStatusDTO.getCollectionExerciseId());
+      if (distributed) {
+        LOGGER
+            .with("collectionExerciseId", sampleSummaryStatusDTO.getCollectionExerciseId())
+            .info("collection exercise transition successful");
+        message.ack();
+      } else {
+        LOGGER
+            .with("collectionExerciseId", sampleSummaryStatusDTO.getCollectionExerciseId())
+            .info("collection exercise transition failed");
+        message.nack();
+      }
+    } else {
+      LOGGER.error("unsupported message type");
+      message.nack();
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiver.java
@@ -38,7 +38,7 @@ public class SampleSummaryStateReceiver {
           objectMapper.readValue(payload, SampleSummaryStatusDTO.class);
       collectionExerciseId = sampleSummaryStatusDTO.getCollectionExerciseId();
       if (SampleSummaryStatusDTO.Event.ENRICHED.equals(sampleSummaryStatusDTO.getEvent())) {
-        sampleSummaryService.validSample(
+        sampleSummaryService.sampleSummaryValidated(
             sampleSummaryStatusDTO.isSuccessful(), collectionExerciseId);
         pubSubMsg.ack();
       } else if (SampleSummaryStatusDTO.Event.DISTRIBUTED.equals(

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiver.java
@@ -40,31 +40,17 @@ public class SampleSummaryStateReceiver {
       if (SampleSummaryStatusDTO.Event.ENRICHED.equals(sampleSummaryStatusDTO.getEvent())) {
         sampleSummaryService.validSample(
             sampleSummaryStatusDTO.isSuccessful(), collectionExerciseId);
-        LOGGER
-            .with("collectionExerciseId", collectionExerciseId)
-            .info("collection exercise transition to valid successful");
         pubSubMsg.ack();
       } else if (SampleSummaryStatusDTO.Event.DISTRIBUTED.equals(
           sampleSummaryStatusDTO.getEvent())) {
         sampleSummaryService.sampleSummaryDistributed(
             sampleSummaryStatusDTO.isSuccessful(), collectionExerciseId);
-        LOGGER
-            .with("collectionExerciseId", collectionExerciseId)
-            .info("collection exercise transition successful");
         pubSubMsg.ack();
       } else {
         LOGGER.error("unsupported message type");
         pubSubMsg.nack();
       }
-    } catch (SampleSummaryValidationException e) {
-      LOGGER
-          .with("collectionExerciseId", collectionExerciseId)
-          .error("collection exercise transition to valid failed");
-      pubSubMsg.nack();
-    } catch (SampleSummaryDistributionException e) {
-      LOGGER
-          .with("collectionExerciseId", collectionExerciseId)
-          .error("collection exercise transition failed");
+    } catch (SampleSummaryValidationException | SampleSummaryDistributionException e) {
       pubSubMsg.nack();
     } catch (JsonProcessingException e) {
       LOGGER.error("failed to deserialize message type", e);

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiver.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gcp.pubsub.support.BasicAcknowledgeablePubsubMessage;
 import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
@@ -13,6 +14,8 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.response.collection.exercise.message.dto.SampleSummaryStatusDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleSummaryService;
+import uk.gov.ons.ctp.response.collection.exercise.service.SampleSummaryValidationException;
+import uk.gov.ons.ctp.response.collection.exercise.service.change.SampleSummaryDistributionException;
 
 @Component
 public class SampleSummaryStateReceiver {
@@ -26,52 +29,47 @@ public class SampleSummaryStateReceiver {
   @ServiceActivator(inputChannel = "sampleSummaryStatusChannel")
   public void messageReceiver(
       Message message,
-      @Header(GcpPubSubHeaders.ORIGINAL_MESSAGE) BasicAcknowledgeablePubsubMessage gcpMessage) {
+      @Header(GcpPubSubHeaders.ORIGINAL_MESSAGE) BasicAcknowledgeablePubsubMessage pubSubMsg) {
 
-    String payload = new String((byte[]) message.getPayload());
-    SampleSummaryStatusDTO sampleSummaryStatusDTO = null;
+    UUID collectionExerciseId = null;
     try {
-      sampleSummaryStatusDTO = objectMapper.readValue(payload, SampleSummaryStatusDTO.class);
+      String payload = new String((byte[]) message.getPayload());
+      SampleSummaryStatusDTO sampleSummaryStatusDTO =
+          objectMapper.readValue(payload, SampleSummaryStatusDTO.class);
+      collectionExerciseId = sampleSummaryStatusDTO.getCollectionExerciseId();
+      if (SampleSummaryStatusDTO.Event.ENRICHED.equals(sampleSummaryStatusDTO.getEvent())) {
+        sampleSummaryService.validSample(
+            sampleSummaryStatusDTO.isSuccessful(), collectionExerciseId);
+        LOGGER
+            .with("collectionExerciseId", collectionExerciseId)
+            .info("collection exercise transition to valid successful");
+        pubSubMsg.ack();
+      } else if (SampleSummaryStatusDTO.Event.DISTRIBUTED.equals(
+          sampleSummaryStatusDTO.getEvent())) {
+        sampleSummaryService.sampleSummaryDistributed(
+            sampleSummaryStatusDTO.isSuccessful(), collectionExerciseId);
+        LOGGER
+            .with("collectionExerciseId", collectionExerciseId)
+            .info("collection exercise transition successful");
+        pubSubMsg.ack();
+      } else {
+        LOGGER.error("unsupported message type");
+        pubSubMsg.nack();
+      }
+    } catch (SampleSummaryValidationException e) {
+      LOGGER
+          .with("collectionExerciseId", collectionExerciseId)
+          .error("collection exercise transition to valid failed");
+      pubSubMsg.nack();
+    } catch (SampleSummaryDistributionException e) {
+      LOGGER
+          .with("collectionExerciseId", collectionExerciseId)
+          .error("collection exercise transition failed");
+      pubSubMsg.nack();
     } catch (JsonProcessingException e) {
       LOGGER.error("failed to deserialize message type", e);
-      gcpMessage.nack();
-    }
-
-    if (SampleSummaryStatusDTO.Event.ENRICHED.equals(sampleSummaryStatusDTO.getEvent())) {
-      boolean enrich =
-          sampleSummaryService.validSample(
-              sampleSummaryStatusDTO.isSuccessful(),
-              sampleSummaryStatusDTO.getCollectionExerciseId());
-      if (enrich) {
-        LOGGER
-            .with("collectionExerciseId", sampleSummaryStatusDTO.getCollectionExerciseId())
-            .info("collection exercise transition to valid successful");
-        gcpMessage.ack();
-      } else {
-        LOGGER
-            .with("collectionExerciseId", sampleSummaryStatusDTO.getCollectionExerciseId())
-            .info("collection exercise transition to valid failed");
-        gcpMessage.nack();
-      }
-    } else if (SampleSummaryStatusDTO.Event.DISTRIBUTED.equals(sampleSummaryStatusDTO.getEvent())) {
-      boolean distributed =
-          sampleSummaryService.sampleSummaryDistributed(
-              sampleSummaryStatusDTO.isSuccessful(),
-              sampleSummaryStatusDTO.getCollectionExerciseId());
-      if (distributed) {
-        LOGGER
-            .with("collectionExerciseId", sampleSummaryStatusDTO.getCollectionExerciseId())
-            .info("collection exercise transition successful");
-        gcpMessage.ack();
-      } else {
-        LOGGER
-            .with("collectionExerciseId", sampleSummaryStatusDTO.getCollectionExerciseId())
-            .info("collection exercise transition failed");
-        gcpMessage.nack();
-      }
-    } else {
-      LOGGER.error("unsupported message type");
-      gcpMessage.nack();
+      pubSubMsg.nack();
+      return;
     }
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/SampleSummaryStatusDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/SampleSummaryStatusDTO.java
@@ -1,0 +1,24 @@
+package uk.gov.ons.ctp.response.collection.exercise.message.dto;
+
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Domain model object */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class SampleSummaryStatusDTO {
+  private UUID collectionExerciseId;
+
+  private boolean successful;
+
+  public enum Event {
+    DISTRIBUTED,
+    ENRICHED
+  }
+
+  private Event event;
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/SampleSummaryActivationDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/SampleSummaryActivationDTO.java
@@ -1,0 +1,17 @@
+package uk.gov.ons.ctp.response.collection.exercise.representation;
+
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Domain model object */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class SampleSummaryActivationDTO {
+  private UUID collectionExerciseId;
+  private UUID sampleSummaryId;
+  private UUID surveyId;
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryService.java
@@ -89,12 +89,11 @@ public class SampleSummaryService {
   /**
    * Transitions the state of a collection exercise depending on the outcome of the validation of
    * the sample summary
-   *
-   * @param valid true if sample summary valid and enriched, false otherwise
+   *  @param valid true if sample summary valid and enriched, false otherwise
    * @param collectionExerciseId the id of the collection exercise
    */
   @Transactional(propagation = Propagation.REQUIRED)
-  public void validSample(boolean valid, UUID collectionExerciseId)
+  public void sampleSummaryValidated(boolean valid, UUID collectionExerciseId)
       throws SampleSummaryValidationException {
     CollectionExercise collectionExercise =
         collectionExerciseRepository.findOneById(collectionExerciseId);

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryService.java
@@ -9,14 +9,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.ons.ctp.response.collection.exercise.client.SampleSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
 import uk.gov.ons.ctp.response.collection.exercise.lib.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.message.SampleSummaryActivationPublisher;
 import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.EventRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.SampleSummaryActivationDTO;
 
 @Service
 public class SampleSummaryService {
@@ -27,14 +28,14 @@ public class SampleSummaryService {
 
   @Autowired private CollectionExerciseRepository collectionExerciseRepository;
 
-  @Autowired private SampleSvcClient sampleSvcClient;
+  @Autowired private SampleSummaryActivationPublisher sampleSummaryActivationPublisher;
 
   @Autowired private CollectionExerciseService collectionExerciseService;
 
   @Autowired private EventRepository eventRepository;
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public boolean activateSamples(UUID collectionExerciseId) {
+  public void activateSamples(UUID collectionExerciseId) {
 
     CollectionExercise collectionExercise =
         collectionExerciseRepository.findOneById(collectionExerciseId);
@@ -55,24 +56,16 @@ public class SampleSummaryService {
     }
     // in rasrm business there can only ever be one sample summary per collection exercise
     UUID sampleSummaryId = sampleSummaryIdList.get(0);
-    boolean successfulEnrichment =
-        sampleSvcClient.enrichSampleSummary(surveyId, collectionExerciseId, sampleSummaryId);
 
-    LOG.with("successfulEnrichment", successfulEnrichment)
-        .with("sampleSummaryId", sampleSummaryId)
-        .info("Enrichment complete");
+    SampleSummaryActivationDTO sampleSummaryActivationDTO = new SampleSummaryActivationDTO();
+    sampleSummaryActivationDTO.setCollectionExerciseId(collectionExerciseId);
+    sampleSummaryActivationDTO.setSampleSummaryId(sampleSummaryId);
+    sampleSummaryActivationDTO.setSurveyId(surveyId);
+
+    sampleSummaryActivationPublisher.sendSampleSummaryActivation(sampleSummaryActivationDTO);
 
     // now transition to executed complete
     executionCompleted(collectionExercise);
-
-    // TODO change this to be pubsub
-    validSample(successfulEnrichment, collectionExerciseId);
-    if (successfulEnrichment) {
-      LOG.info("request distribution of sample");
-      return distributeSample(collectionExerciseId);
-    } else {
-      return false;
-    }
   }
 
   private void executionStarted(CollectionExercise collectionExercise) {
@@ -97,28 +90,6 @@ public class SampleSummaryService {
     }
   }
 
-  public boolean distributeSample(UUID collectionExerciseId) {
-    List<SampleLink> sampleLinks =
-        sampleLinkRepository.findByCollectionExerciseId(collectionExerciseId);
-    List<UUID> sampleSummaryIdList =
-        sampleLinks.stream().map(SampleLink::getSampleSummaryId).collect(Collectors.toList());
-
-    if (sampleSummaryIdList.size() > 1) {
-      LOG.with("numberOfSampleSummaries", sampleSummaryIdList.size())
-          .with("collectionExerciseId", collectionExerciseId)
-          .error("Multiple sample summaries detected during distribution phase");
-    }
-    // in rasrm business there can only ever be one sample summary per collection exercise
-    UUID sampleSummaryId = sampleSummaryIdList.get(0);
-    boolean successfulDistribution = sampleSvcClient.distributeSampleSummary(sampleSummaryId);
-    // TODO change this to be pubsub
-    boolean stateChange = sampleSummaryDistributed(successfulDistribution, collectionExerciseId);
-    LOG.with("successfulDistribution", successfulDistribution)
-        .with("sampleSummaryId", sampleSummaryId)
-        .info("Distribution complete");
-    return stateChange;
-  }
-
   /**
    * Transitions the state of a collection exercise depending on the outcome of the validation of
    * the sample summary
@@ -126,7 +97,8 @@ public class SampleSummaryService {
    * @param valid true if sample summary valid and enriched, false otherwise
    * @param collectionExerciseId the id of the collection exercise
    */
-  public void validSample(boolean valid, UUID collectionExerciseId) {
+  @Transactional(propagation = Propagation.REQUIRED)
+  public boolean validSample(boolean valid, UUID collectionExerciseId) {
     CollectionExercise collectionExercise =
         collectionExerciseRepository.findOneById(collectionExerciseId);
     CollectionExerciseDTO.CollectionExerciseEvent event;
@@ -140,8 +112,10 @@ public class SampleSummaryService {
     try {
       LOG.with("collectionExerciseId", collectionExerciseId).info("transitioning state");
       collectionExerciseService.transitionCollectionExercise(collectionExercise, event);
+      return true;
     } catch (CTPException e) {
       LOG.error("unable to transition collection exercise", e);
+      return false;
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryService.java
@@ -89,7 +89,8 @@ public class SampleSummaryService {
   /**
    * Transitions the state of a collection exercise depending on the outcome of the validation of
    * the sample summary
-   *  @param valid true if sample summary valid and enriched, false otherwise
+   *
+   * @param valid true if sample summary valid and enriched, false otherwise
    * @param collectionExerciseId the id of the collection exercise
    */
   @Transactional(propagation = Propagation.REQUIRED)

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryService.java
@@ -17,7 +17,6 @@ import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExercise
 import uk.gov.ons.ctp.response.collection.exercise.repository.EventRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
-import uk.gov.ons.ctp.response.collection.exercise.representation.SampleSummaryActivationDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.change.SampleSummaryDistributionException;
 
 @Service
@@ -58,12 +57,8 @@ public class SampleSummaryService {
     // in rasrm business there can only ever be one sample summary per collection exercise
     UUID sampleSummaryId = sampleSummaryIdList.get(0);
 
-    SampleSummaryActivationDTO sampleSummaryActivationDTO = new SampleSummaryActivationDTO();
-    sampleSummaryActivationDTO.setCollectionExerciseId(collectionExerciseId);
-    sampleSummaryActivationDTO.setSampleSummaryId(sampleSummaryId);
-    sampleSummaryActivationDTO.setSurveyId(surveyId);
-
-    sampleSummaryActivationPublisher.sendSampleSummaryActivation(sampleSummaryActivationDTO);
+    sampleSummaryActivationPublisher.sendSampleSummaryActivation(
+        collectionExerciseId, sampleSummaryId, surveyId);
 
     // now transition to executed complete
     executionCompleted(collectionExercise);

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryService.java
@@ -114,6 +114,9 @@ public class SampleSummaryService {
     try {
       LOG.with("collectionExerciseId", collectionExerciseId).info("transitioning state");
       collectionExerciseService.transitionCollectionExercise(collectionExercise, event);
+      LOG.with("collectionExerciseId", collectionExerciseId)
+          .with("valid", valid)
+          .info("collection exercise transition successful");
     } catch (CTPException e) {
       LOG.error("unable to transition collection exercise", e);
       throw new SampleSummaryValidationException(e);
@@ -155,6 +158,9 @@ public class SampleSummaryService {
       try {
         LOG.with("collectionExerciseId", collectionExerciseId).info("transitioning state");
         collectionExerciseService.transitionCollectionExercise(collectionExercise, event);
+        LOG.with("collectionExerciseId", collectionExerciseId)
+            .with("distributed", distributed)
+            .info("collection exercise transition successful");
       } catch (CTPException e) {
         LOG.error("unable to transition collection exercise", e);
         throw new SampleSummaryDistributionException(e);

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryValidationException.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryValidationException.java
@@ -1,0 +1,7 @@
+package uk.gov.ons.ctp.response.collection.exercise.service;
+
+public class SampleSummaryValidationException extends Exception {
+  public SampleSummaryValidationException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/change/SampleSummaryDistributionException.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/change/SampleSummaryDistributionException.java
@@ -1,0 +1,7 @@
+package uk.gov.ons.ctp.response.collection.exercise.service.change;
+
+public class SampleSummaryDistributionException extends Exception {
+  public SampleSummaryDistributionException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -5,6 +5,12 @@ spring:
   liquibase:
     url: jdbc:postgresql://localhost:15432/postgres
 
+  cloud:
+    gcp:
+      project-id: test
+      pubsub:
+        emulator-host: localhost:18681
+
 survey-svc:
   connection-config:
     port: 18002

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,8 +69,6 @@ spring:
 sample-svc:
   request-sample-units-path: /samples/sampleunitrequests
   request-sample-unit-count-path: /samples/count
-  enrich-sample-summary: /enrich/survey/{surveyId}/collection-exercise/{collectionExerciseId}/samplesummary/{sampleSummaryId}
-  distribute-sample-summary: /distribute/{sampleSummaryId}
   connection-config:
     scheme: http
     host: localhost
@@ -186,6 +184,8 @@ gcp:
   project: ras-rm-sandbox
   caseNotificationTopic: "test_topic"
   sampleUnitReceiverSubscription: "test_subscription"
+  sampleSummaryStatusSubscription: "sample-summary-status-subscription"
+  sampleSummaryActivationTopic: "sample-summary-activation-topic"
 
 sampleV2:
   enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -188,8 +188,8 @@ gcp:
   project: ras-rm-sandbox
   caseNotificationTopic: "test_topic"
   sampleUnitReceiverSubscription: "test_subscription"
-  sampleSummaryStatusSubscription: "sample-summary-status-subscription"
-  sampleSummaryActivationTopic: "sample-summary-activation-topic"
+  sampleSummaryActivationStatusSubscription: "sample-summary-activation-status"
+  sampleSummaryActivationTopic: "sample-summary-activation"
 
 sampleV2:
   enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,10 @@ spring:
     # it so nothing changed.  Spring boot shows warnings if you don't explicitly set it.
     open-in-view: true
 
+  cloud:
+    gcp:
+      project-id: ras-rm-dev
+
 sample-svc:
   request-sample-units-path: /samples/sampleunitrequests
   request-sample-unit-count-path: /samples/count

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClientTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClientTest.java
@@ -17,7 +17,6 @@ import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -107,106 +106,5 @@ public class SampleSvcClientTest {
 
     // Then
     assertEquals(666, actualResponse.getSampleUnitsTotal().intValue());
-  }
-
-  @Test
-  public void testEnrich() {
-    String response = "ok";
-    SampleSvc sampleSvc = Mockito.mock(SampleSvc.class);
-    ResponseEntity<String> responseEntity = Mockito.mock(ResponseEntity.class);
-
-    UUID surveyId = UUID.randomUUID();
-    UUID collectionExerciseId = UUID.randomUUID();
-    UUID sampleSummaryId = UUID.randomUUID();
-
-    // Given
-    given(appConfig.getSampleSvc()).willReturn(sampleSvc);
-    given(sampleSvc.getEnrichSampleSummary()).willReturn("test/path");
-    given(responseEntity.getStatusCode()).willReturn(HttpStatus.OK);
-    given(
-            restTemplate.exchange(
-                any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
-        .willReturn(responseEntity);
-
-    // When
-    boolean actualResponse =
-        sampleSvcRestClient.enrichSampleSummary(surveyId, collectionExerciseId, sampleSummaryId);
-
-    // Then
-    assertTrue("enrich request successful", actualResponse);
-  }
-
-  @Test
-  public void testEnrichFails() {
-    SampleSvc sampleSvc = Mockito.mock(SampleSvc.class);
-    ResponseEntity<String> responseEntity = Mockito.mock(ResponseEntity.class);
-
-    UUID surveyId = UUID.randomUUID();
-    UUID collectionExerciseId = UUID.randomUUID();
-    UUID sampleSummaryId = UUID.randomUUID();
-
-    // Given
-    given(appConfig.getSampleSvc()).willReturn(sampleSvc);
-    given(sampleSvc.getEnrichSampleSummary()).willReturn("test/path");
-    given(responseEntity.getStatusCode()).willReturn(HttpStatus.INTERNAL_SERVER_ERROR);
-    given(
-            restTemplate.exchange(
-                any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
-        .willReturn(responseEntity);
-
-    // When
-    boolean actualResponse =
-        sampleSvcRestClient.enrichSampleSummary(surveyId, collectionExerciseId, sampleSummaryId);
-
-    // Then
-    assertFalse("enrich request unsuccessful", actualResponse);
-  }
-
-  @Test
-  public void testDistribute() {
-    SampleSvc sampleSvc = Mockito.mock(SampleSvc.class);
-    ResponseEntity<String> responseEntity = Mockito.mock(ResponseEntity.class);
-
-    UUID surveyId = UUID.randomUUID();
-    UUID collectionExerciseId = UUID.randomUUID();
-    UUID sampleSummaryId = UUID.randomUUID();
-
-    // Given
-    given(appConfig.getSampleSvc()).willReturn(sampleSvc);
-    given(sampleSvc.getDistributeSampleSummary()).willReturn("test/path");
-    given(responseEntity.getStatusCode()).willReturn(HttpStatus.OK);
-    given(
-            restTemplate.exchange(
-                any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
-        .willReturn(responseEntity);
-
-    // When
-    boolean actualResponse = sampleSvcRestClient.distributeSampleSummary(sampleSummaryId);
-
-    // Then
-    assertTrue("distribute request successful", actualResponse);
-  }
-
-  @Test
-  public void testDistributeFails() {
-    SampleSvc sampleSvc = Mockito.mock(SampleSvc.class);
-    ResponseEntity<String> responseEntity = Mockito.mock(ResponseEntity.class);
-
-    UUID sampleSummaryId = UUID.randomUUID();
-
-    // Given
-    given(appConfig.getSampleSvc()).willReturn(sampleSvc);
-    given(sampleSvc.getDistributeSampleSummary()).willReturn("test/path");
-    given(responseEntity.getStatusCode()).willReturn(HttpStatus.INTERNAL_SERVER_ERROR);
-    given(
-            restTemplate.exchange(
-                any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
-        .willReturn(responseEntity);
-
-    // When
-    boolean actualResponse = sampleSvcRestClient.distributeSampleSummary(sampleSummaryId);
-
-    // Then
-    assertFalse("distribute request unsuccessful", actualResponse);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryActivationPublisherTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryActivationPublisherTest.java
@@ -1,0 +1,43 @@
+package uk.gov.ons.ctp.response.collection.exercise.message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ons.ctp.response.collection.exercise.CollectionExerciseApplication;
+import uk.gov.ons.ctp.response.collection.exercise.representation.SampleSummaryActivationDTO;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SampleSummaryActivationPublisherTest {
+
+  @Mock
+  private CollectionExerciseApplication.PubsubOutboundGateway messagingGateway;
+
+  @Mock private ObjectMapper objectMapper;
+
+  @InjectMocks SampleSummaryActivationPublisher sampleSummaryActivationPublisher;
+
+
+  @Test
+  public void testSendSampleSummaryActivation() throws Exception{
+    UUID collectionExerciseId = UUID.randomUUID();
+    UUID sampleSummaryId = UUID.randomUUID();
+    UUID surveyId = UUID.randomUUID();
+
+    ObjectMapper mapper = new ObjectMapper();
+    String payload = mapper.writeValueAsString(new SampleSummaryActivationDTO(collectionExerciseId, sampleSummaryId, surveyId));
+    when(objectMapper.writeValueAsString(any(SampleSummaryActivationDTO.class))).thenReturn(payload);
+
+    sampleSummaryActivationPublisher.sendSampleSummaryActivation(collectionExerciseId, sampleSummaryId, surveyId);
+
+    verify(objectMapper, times(1)).writeValueAsString(any(SampleSummaryActivationDTO.class));
+    verify(messagingGateway, times(1)).sendToPubsub(payload);
+  }
+
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryActivationPublisherTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryActivationPublisherTest.java
@@ -1,6 +1,9 @@
 package uk.gov.ons.ctp.response.collection.exercise.message;
 
+import static org.mockito.Mockito.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -9,35 +12,32 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ons.ctp.response.collection.exercise.CollectionExerciseApplication;
 import uk.gov.ons.ctp.response.collection.exercise.representation.SampleSummaryActivationDTO;
 
-import java.util.UUID;
-
-import static org.mockito.Mockito.*;
-
 @RunWith(MockitoJUnitRunner.class)
 public class SampleSummaryActivationPublisherTest {
 
-  @Mock
-  private CollectionExerciseApplication.PubsubOutboundGateway messagingGateway;
+  @Mock private CollectionExerciseApplication.PubsubOutboundGateway messagingGateway;
 
   @Mock private ObjectMapper objectMapper;
 
   @InjectMocks SampleSummaryActivationPublisher sampleSummaryActivationPublisher;
 
-
   @Test
-  public void testSendSampleSummaryActivation() throws Exception{
+  public void testSendSampleSummaryActivation() throws Exception {
     UUID collectionExerciseId = UUID.randomUUID();
     UUID sampleSummaryId = UUID.randomUUID();
     UUID surveyId = UUID.randomUUID();
 
     ObjectMapper mapper = new ObjectMapper();
-    String payload = mapper.writeValueAsString(new SampleSummaryActivationDTO(collectionExerciseId, sampleSummaryId, surveyId));
-    when(objectMapper.writeValueAsString(any(SampleSummaryActivationDTO.class))).thenReturn(payload);
+    String payload =
+        mapper.writeValueAsString(
+            new SampleSummaryActivationDTO(collectionExerciseId, sampleSummaryId, surveyId));
+    when(objectMapper.writeValueAsString(any(SampleSummaryActivationDTO.class)))
+        .thenReturn(payload);
 
-    sampleSummaryActivationPublisher.sendSampleSummaryActivation(collectionExerciseId, sampleSummaryId, surveyId);
+    sampleSummaryActivationPublisher.sendSampleSummaryActivation(
+        collectionExerciseId, sampleSummaryId, surveyId);
 
     verify(objectMapper, times(1)).writeValueAsString(any(SampleSummaryActivationDTO.class));
     verify(messagingGateway, times(1)).sendToPubsub(payload);
   }
-
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiverTest.java
@@ -1,6 +1,9 @@
 package uk.gov.ons.ctp.response.collection.exercise.message;
 
+import static org.mockito.Mockito.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -12,18 +15,12 @@ import org.springframework.messaging.Message;
 import uk.gov.ons.ctp.response.collection.exercise.message.dto.SampleSummaryStatusDTO;
 import uk.gov.ons.ctp.response.collection.exercise.service.SampleSummaryService;
 
-import java.util.UUID;
-
-import static org.mockito.Mockito.*;
-
 @RunWith(MockitoJUnitRunner.class)
 public class SampleSummaryStateReceiverTest {
 
-  @Mock
-  private ObjectMapper objectMapper;
+  @Mock private ObjectMapper objectMapper;
 
-  @Mock
-  private SampleSummaryService sampleSummaryService;
+  @Mock private SampleSummaryService sampleSummaryService;
 
   @InjectMocks private SampleSummaryStateReceiver sampleSummaryStateReceiver;
 
@@ -41,11 +38,13 @@ public class SampleSummaryStateReceiverTest {
 
     Message message = Mockito.mock(Message.class);
     when(message.getPayload()).thenReturn(payload.getBytes());
-    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class)).thenReturn(sampleSummaryStatusDTO);
+    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class))
+        .thenReturn(sampleSummaryStatusDTO);
 
-    BasicAcknowledgeablePubsubMessage pubSubMsg = Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
+    BasicAcknowledgeablePubsubMessage pubSubMsg =
+        Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
 
-    sampleSummaryStateReceiver.messageReceiver(message,  pubSubMsg);
+    sampleSummaryStateReceiver.messageReceiver(message, pubSubMsg);
 
     verify(sampleSummaryService, times(1)).sampleSummaryValidated(true, collectionExerciseId);
     verify(pubSubMsg, times(1)).ack();
@@ -65,11 +64,13 @@ public class SampleSummaryStateReceiverTest {
 
     Message message = Mockito.mock(Message.class);
     when(message.getPayload()).thenReturn(payload.getBytes());
-    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class)).thenReturn(sampleSummaryStatusDTO);
+    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class))
+        .thenReturn(sampleSummaryStatusDTO);
 
-    BasicAcknowledgeablePubsubMessage pubSubMsg = Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
+    BasicAcknowledgeablePubsubMessage pubSubMsg =
+        Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
 
-    sampleSummaryStateReceiver.messageReceiver(message,  pubSubMsg);
+    sampleSummaryStateReceiver.messageReceiver(message, pubSubMsg);
 
     verify(sampleSummaryService, times(1)).sampleSummaryValidated(false, collectionExerciseId);
     verify(pubSubMsg, times(1)).ack();
@@ -89,11 +90,13 @@ public class SampleSummaryStateReceiverTest {
 
     Message message = Mockito.mock(Message.class);
     when(message.getPayload()).thenReturn(payload.getBytes());
-    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class)).thenReturn(sampleSummaryStatusDTO);
+    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class))
+        .thenReturn(sampleSummaryStatusDTO);
 
-    BasicAcknowledgeablePubsubMessage pubSubMsg = Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
+    BasicAcknowledgeablePubsubMessage pubSubMsg =
+        Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
 
-    sampleSummaryStateReceiver.messageReceiver(message,  pubSubMsg);
+    sampleSummaryStateReceiver.messageReceiver(message, pubSubMsg);
 
     verify(sampleSummaryService, times(1)).sampleSummaryDistributed(true, collectionExerciseId);
     verify(pubSubMsg, times(1)).ack();
@@ -113,17 +116,15 @@ public class SampleSummaryStateReceiverTest {
 
     Message message = Mockito.mock(Message.class);
     when(message.getPayload()).thenReturn(payload.getBytes());
-    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class)).thenReturn(sampleSummaryStatusDTO);
+    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class))
+        .thenReturn(sampleSummaryStatusDTO);
 
-    BasicAcknowledgeablePubsubMessage pubSubMsg = Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
+    BasicAcknowledgeablePubsubMessage pubSubMsg =
+        Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
 
-    sampleSummaryStateReceiver.messageReceiver(message,  pubSubMsg);
+    sampleSummaryStateReceiver.messageReceiver(message, pubSubMsg);
 
     verify(sampleSummaryService, times(1)).sampleSummaryDistributed(false, collectionExerciseId);
     verify(pubSubMsg, times(1)).ack();
   }
-
-
-
-
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/SampleSummaryStateReceiverTest.java
@@ -1,0 +1,129 @@
+package uk.gov.ons.ctp.response.collection.exercise.message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.cloud.gcp.pubsub.support.BasicAcknowledgeablePubsubMessage;
+import org.springframework.messaging.Message;
+import uk.gov.ons.ctp.response.collection.exercise.message.dto.SampleSummaryStatusDTO;
+import uk.gov.ons.ctp.response.collection.exercise.service.SampleSummaryService;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SampleSummaryStateReceiverTest {
+
+  @Mock
+  private ObjectMapper objectMapper;
+
+  @Mock
+  private SampleSummaryService sampleSummaryService;
+
+  @InjectMocks private SampleSummaryStateReceiver sampleSummaryStateReceiver;
+
+  @Test
+  public void messageReceiverEnrich() throws Exception {
+    UUID collectionExerciseId = UUID.randomUUID();
+
+    SampleSummaryStatusDTO sampleSummaryStatusDTO = new SampleSummaryStatusDTO();
+    sampleSummaryStatusDTO.setCollectionExerciseId(collectionExerciseId);
+    sampleSummaryStatusDTO.setEvent(SampleSummaryStatusDTO.Event.ENRICHED);
+    sampleSummaryStatusDTO.setSuccessful(true);
+
+    ObjectMapper mapper = new ObjectMapper();
+    String payload = mapper.writeValueAsString(sampleSummaryStatusDTO);
+
+    Message message = Mockito.mock(Message.class);
+    when(message.getPayload()).thenReturn(payload.getBytes());
+    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class)).thenReturn(sampleSummaryStatusDTO);
+
+    BasicAcknowledgeablePubsubMessage pubSubMsg = Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
+
+    sampleSummaryStateReceiver.messageReceiver(message,  pubSubMsg);
+
+    verify(sampleSummaryService, times(1)).sampleSummaryValidated(true, collectionExerciseId);
+    verify(pubSubMsg, times(1)).ack();
+  }
+
+  @Test
+  public void messageReceiverEnrichFails() throws Exception {
+    UUID collectionExerciseId = UUID.randomUUID();
+
+    SampleSummaryStatusDTO sampleSummaryStatusDTO = new SampleSummaryStatusDTO();
+    sampleSummaryStatusDTO.setCollectionExerciseId(collectionExerciseId);
+    sampleSummaryStatusDTO.setEvent(SampleSummaryStatusDTO.Event.ENRICHED);
+    sampleSummaryStatusDTO.setSuccessful(false);
+
+    ObjectMapper mapper = new ObjectMapper();
+    String payload = mapper.writeValueAsString(sampleSummaryStatusDTO);
+
+    Message message = Mockito.mock(Message.class);
+    when(message.getPayload()).thenReturn(payload.getBytes());
+    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class)).thenReturn(sampleSummaryStatusDTO);
+
+    BasicAcknowledgeablePubsubMessage pubSubMsg = Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
+
+    sampleSummaryStateReceiver.messageReceiver(message,  pubSubMsg);
+
+    verify(sampleSummaryService, times(1)).sampleSummaryValidated(false, collectionExerciseId);
+    verify(pubSubMsg, times(1)).ack();
+  }
+
+  @Test
+  public void messageReceiverDistributed() throws Exception {
+    UUID collectionExerciseId = UUID.randomUUID();
+
+    SampleSummaryStatusDTO sampleSummaryStatusDTO = new SampleSummaryStatusDTO();
+    sampleSummaryStatusDTO.setCollectionExerciseId(collectionExerciseId);
+    sampleSummaryStatusDTO.setEvent(SampleSummaryStatusDTO.Event.DISTRIBUTED);
+    sampleSummaryStatusDTO.setSuccessful(true);
+
+    ObjectMapper mapper = new ObjectMapper();
+    String payload = mapper.writeValueAsString(sampleSummaryStatusDTO);
+
+    Message message = Mockito.mock(Message.class);
+    when(message.getPayload()).thenReturn(payload.getBytes());
+    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class)).thenReturn(sampleSummaryStatusDTO);
+
+    BasicAcknowledgeablePubsubMessage pubSubMsg = Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
+
+    sampleSummaryStateReceiver.messageReceiver(message,  pubSubMsg);
+
+    verify(sampleSummaryService, times(1)).sampleSummaryDistributed(true, collectionExerciseId);
+    verify(pubSubMsg, times(1)).ack();
+  }
+
+  @Test
+  public void messageReceiverDistributedFails() throws Exception {
+    UUID collectionExerciseId = UUID.randomUUID();
+
+    SampleSummaryStatusDTO sampleSummaryStatusDTO = new SampleSummaryStatusDTO();
+    sampleSummaryStatusDTO.setCollectionExerciseId(collectionExerciseId);
+    sampleSummaryStatusDTO.setEvent(SampleSummaryStatusDTO.Event.DISTRIBUTED);
+    sampleSummaryStatusDTO.setSuccessful(false);
+
+    ObjectMapper mapper = new ObjectMapper();
+    String payload = mapper.writeValueAsString(sampleSummaryStatusDTO);
+
+    Message message = Mockito.mock(Message.class);
+    when(message.getPayload()).thenReturn(payload.getBytes());
+    when(objectMapper.readValue(payload, SampleSummaryStatusDTO.class)).thenReturn(sampleSummaryStatusDTO);
+
+    BasicAcknowledgeablePubsubMessage pubSubMsg = Mockito.mock(BasicAcknowledgeablePubsubMessage.class);
+
+    sampleSummaryStateReceiver.messageReceiver(message,  pubSubMsg);
+
+    verify(sampleSummaryService, times(1)).sampleSummaryDistributed(false, collectionExerciseId);
+    verify(pubSubMsg, times(1)).ack();
+  }
+
+
+
+
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.ctp.response.collection.exercise.service;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.sql.Timestamp;
@@ -68,7 +67,7 @@ public class SampleSummaryServiceTest {
     // first activate
     sampleSummaryService.activateSamples(collectionExerciseId);
     // then simulate successful enrich
-    sampleSummaryService.validSample(true, collectionExerciseId);
+    sampleSummaryService.sampleSummaryValidated(true, collectionExerciseId);
     // then simulate successful distribution
     sampleSummaryService.sampleSummaryDistributed(true, collectionExerciseId);
 
@@ -117,7 +116,7 @@ public class SampleSummaryServiceTest {
     // first activate
     sampleSummaryService.activateSamples(collectionExerciseId);
     // then simulate failed enrich
-    sampleSummaryService.validSample(false, collectionExerciseId);
+    sampleSummaryService.sampleSummaryValidated(false, collectionExerciseId);
 
     verify(collectionExerciseRepository, times(2)).findOneById(collectionExerciseId);
     verify(sampleSummaryActivationPublisher, times(1))
@@ -164,7 +163,7 @@ public class SampleSummaryServiceTest {
     // first activate
     sampleSummaryService.activateSamples(collectionExerciseId);
     // then simulate successful enrich
-    sampleSummaryService.validSample(true, collectionExerciseId);
+    sampleSummaryService.sampleSummaryValidated(true, collectionExerciseId);
     // then simulate failed distribution
     sampleSummaryService.sampleSummaryDistributed(false, collectionExerciseId);
 

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryServiceTest.java
@@ -12,14 +12,15 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.ons.ctp.response.collection.exercise.client.SampleSvcClient;
 import uk.gov.ons.ctp.response.collection.exercise.domain.CollectionExercise;
 import uk.gov.ons.ctp.response.collection.exercise.domain.Event;
 import uk.gov.ons.ctp.response.collection.exercise.domain.SampleLink;
+import uk.gov.ons.ctp.response.collection.exercise.message.SampleSummaryActivationPublisher;
 import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExerciseRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.EventRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
+import uk.gov.ons.ctp.response.collection.exercise.representation.SampleSummaryActivationDTO;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SampleSummaryServiceTest {
@@ -28,7 +29,7 @@ public class SampleSummaryServiceTest {
 
   @Mock private CollectionExerciseRepository collectionExerciseRepository;
 
-  @Mock private SampleSvcClient sampleSvcClient;
+  @Mock private SampleSummaryActivationPublisher sampleSummaryActivationPublisher;
 
   @Mock private CollectionExerciseService collectionExerciseService;
 
@@ -60,18 +61,21 @@ public class SampleSummaryServiceTest {
         .thenReturn(collectionExercise);
     when(sampleLinkRepository.findByCollectionExerciseId(collectionExerciseId))
         .thenReturn(sampleLinks);
-    when(sampleSvcClient.enrichSampleSummary(surveyId, collectionExerciseId, sampleSummaryId))
-        .thenReturn(true);
-    when(sampleSvcClient.distributeSampleSummary(sampleSummaryId)).thenReturn(true);
+
     when(eventRepository.findOneByCollectionExerciseAndTag(
             collectionExercise, EventService.Tag.go_live.name()))
         .thenReturn(event);
 
-    assertTrue(
-        "samples processed successfully",
-        sampleSummaryService.activateSamples(collectionExerciseId));
+    // first activate
+    sampleSummaryService.activateSamples(collectionExerciseId);
+    // then simulate successful enrich
+    sampleSummaryService.validSample(true, collectionExerciseId);
+    // then simulate successful distribution
+    sampleSummaryService.sampleSummaryDistributed(true, collectionExerciseId);
 
     verify(collectionExerciseRepository, times(3)).findOneById(collectionExerciseId);
+    verify(sampleSummaryActivationPublisher, times(1))
+        .sendSampleSummaryActivation(any(SampleSummaryActivationDTO.class));
     verify(collectionExerciseService, times(1))
         .transitionCollectionExercise(
             collectionExercise, CollectionExerciseDTO.CollectionExerciseEvent.EXECUTE);
@@ -110,12 +114,15 @@ public class SampleSummaryServiceTest {
         .thenReturn(collectionExercise);
     when(sampleLinkRepository.findByCollectionExerciseId(collectionExerciseId))
         .thenReturn(sampleLinks);
-    when(sampleSvcClient.enrichSampleSummary(surveyId, collectionExerciseId, sampleSummaryId))
-        .thenReturn(false);
 
-    assertFalse(sampleSummaryService.activateSamples(collectionExerciseId));
+    // first activate
+    sampleSummaryService.activateSamples(collectionExerciseId);
+    // then simulate failed enrich
+    sampleSummaryService.validSample(false, collectionExerciseId);
 
     verify(collectionExerciseRepository, times(2)).findOneById(collectionExerciseId);
+    verify(sampleSummaryActivationPublisher, times(1))
+        .sendSampleSummaryActivation(any(SampleSummaryActivationDTO.class));
     verify(collectionExerciseService, times(1))
         .transitionCollectionExercise(
             collectionExercise, CollectionExerciseDTO.CollectionExerciseEvent.EXECUTE);
@@ -154,13 +161,17 @@ public class SampleSummaryServiceTest {
         .thenReturn(collectionExercise);
     when(sampleLinkRepository.findByCollectionExerciseId(collectionExerciseId))
         .thenReturn(sampleLinks);
-    when(sampleSvcClient.enrichSampleSummary(surveyId, collectionExerciseId, sampleSummaryId))
-        .thenReturn(true);
-    when(sampleSvcClient.distributeSampleSummary(sampleSummaryId)).thenReturn(false);
 
-    assertFalse(sampleSummaryService.activateSamples(collectionExerciseId));
+    // first activate
+    sampleSummaryService.activateSamples(collectionExerciseId);
+    // then simulate successful enrich
+    sampleSummaryService.validSample(true, collectionExerciseId);
+    // then simulate failed distribution
+    sampleSummaryService.sampleSummaryDistributed(false, collectionExerciseId);
 
     verify(collectionExerciseRepository, times(3)).findOneById(collectionExerciseId);
+    verify(sampleSummaryActivationPublisher, times(1))
+        .sendSampleSummaryActivation(any(SampleSummaryActivationDTO.class));
     verify(collectionExerciseService, times(1))
         .transitionCollectionExercise(
             collectionExercise, CollectionExerciseDTO.CollectionExerciseEvent.EXECUTE);

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/SampleSummaryServiceTest.java
@@ -20,7 +20,6 @@ import uk.gov.ons.ctp.response.collection.exercise.repository.CollectionExercise
 import uk.gov.ons.ctp.response.collection.exercise.repository.EventRepository;
 import uk.gov.ons.ctp.response.collection.exercise.repository.SampleLinkRepository;
 import uk.gov.ons.ctp.response.collection.exercise.representation.CollectionExerciseDTO;
-import uk.gov.ons.ctp.response.collection.exercise.representation.SampleSummaryActivationDTO;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SampleSummaryServiceTest {
@@ -75,7 +74,7 @@ public class SampleSummaryServiceTest {
 
     verify(collectionExerciseRepository, times(3)).findOneById(collectionExerciseId);
     verify(sampleSummaryActivationPublisher, times(1))
-        .sendSampleSummaryActivation(any(SampleSummaryActivationDTO.class));
+        .sendSampleSummaryActivation(collectionExerciseId, sampleSummaryId, surveyId);
     verify(collectionExerciseService, times(1))
         .transitionCollectionExercise(
             collectionExercise, CollectionExerciseDTO.CollectionExerciseEvent.EXECUTE);
@@ -122,7 +121,7 @@ public class SampleSummaryServiceTest {
 
     verify(collectionExerciseRepository, times(2)).findOneById(collectionExerciseId);
     verify(sampleSummaryActivationPublisher, times(1))
-        .sendSampleSummaryActivation(any(SampleSummaryActivationDTO.class));
+        .sendSampleSummaryActivation(collectionExerciseId, sampleSummaryId, surveyId);
     verify(collectionExerciseService, times(1))
         .transitionCollectionExercise(
             collectionExercise, CollectionExerciseDTO.CollectionExerciseEvent.EXECUTE);
@@ -171,7 +170,7 @@ public class SampleSummaryServiceTest {
 
     verify(collectionExerciseRepository, times(3)).findOneById(collectionExerciseId);
     verify(sampleSummaryActivationPublisher, times(1))
-        .sendSampleSummaryActivation(any(SampleSummaryActivationDTO.class));
+        .sendSampleSummaryActivation(collectionExerciseId, sampleSummaryId, surveyId);
     verify(collectionExerciseService, times(1))
         .transitionCollectionExercise(
             collectionExercise, CollectionExerciseDTO.CollectionExerciseEvent.EXECUTE);


### PR DESCRIPTION
# What and why?
Move the communication between sample and collection exercise to pub sub

# How to test?
1. Deploy and configure the sample v2 enabled flag to true
1. Run acceptance tests


# Trello
https://trello.com/c/8dkkqOpl/605-ce-sample-convert-communication-to-pubsub