### PR TITLE
Update endpoint that is used to get cases

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.9
+version: 12.0.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 
-appVersion: 12.0.9
+appVersion: 12.0.10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -119,7 +119,7 @@ action-svc:
     password: secret
 
 case-svc:
-  number-of-cases-path: /casegroups/cases/{collectionExerciseId}
+  number-of-cases-path: /casegroups/cases/{collectionExerciseId}/all
   connection-config:
     scheme: http
     host: localhost


### PR DESCRIPTION
# What and why?

The endpoint that gives casegroups for a given collection exercise id will only give you the ones in IN_PROGRESS and NOT_STARTED. Collection exercise needed one where it would return them all regardless of state. This PR uses the new (temporary) endpoint added in case to get the full count

# How to test?

# Trello
