### PR TITLE
update API location in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There are two ways of running this service
     ```
 
 # API
-See [API.md](https://github.com/ONSdigital/rm-collection-exercise-service/blob/main/API.md) for API documentation.
+See [openapi.yml](https://github.com/ONSdigital/rm-collection-exercise-service/blob/main/openapi.yml) for API documentation.
 
 # Swagger Specification
 To view the swagger Specification for the Collection Exercise service, run the service and navigate to http://localhost:8145/swagger-ui.html.

--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.1.9
+version: 12.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.1.9
+appVersion: 12.1.10


### PR DESCRIPTION
# What and why?
change the location of the api file in the read me to the correct one

# How to test?

# Trello
https://trello.com/c/nYqgmTOz/925-s48-update-rm-collecion-exercise-service-high-level-documentation
