### PR TITLE
Remove excess logging events that are not ready to be excuted

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.1.11
+version: 12.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.1.11
+appVersion: 12.1.12

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/EventService.java
@@ -449,10 +449,6 @@ public class EventService {
                   .info(
                       "Number of cases does not match the sample size.  Case may still be processing messages from sample");
             }
-          } else {
-            log.with("id", event.getId())
-                .with("tag", event.getTag())
-                .debug("Event not ready to be processed");
           }
         });
     log.info("Found [" + counter + "] events in the SCHEDULED state");


### PR DESCRIPTION
# What and why?

The logging for an event not being ready was fine in dev when you had like 10 lines, but in production environments it spams 1000s of lines every minute that aren't very helpful.

# How to test?

# Trello
