### PR TITLE
Updating property name of changelog schema

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.2
+version: 13.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.2
+appVersion: 13.0.3

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CustomProvider.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/CustomProvider.java
@@ -1,0 +1,51 @@
+package uk.gov.ons.ctp.response.collection.exercise;
+
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.Sequence;
+import org.hibernate.mapping.Table;
+import org.hibernate.tool.schema.spi.SchemaFilter;
+import org.hibernate.tool.schema.spi.SchemaFilterProvider;
+
+public class CustomProvider implements SchemaFilterProvider {
+
+  @Override
+  public SchemaFilter getCreateFilter() {
+    return CustomFilter.INSTANCE;
+  }
+
+  @Override
+  public SchemaFilter getDropFilter() {
+    return CustomFilter.INSTANCE;
+  }
+
+  @Override
+  public SchemaFilter getMigrateFilter() {
+    return CustomFilter.INSTANCE;
+  }
+
+  @Override
+  public SchemaFilter getValidateFilter() {
+    return CustomFilter.INSTANCE;
+  }
+}
+
+class CustomFilter implements SchemaFilter {
+  public static final CustomFilter INSTANCE = new CustomFilter();
+
+  @Override
+  public boolean includeNamespace(Namespace namespace) {
+    return true;
+  }
+
+  @Override
+  public boolean includeTable(Table table) {
+    return true;
+  }
+
+  @Override
+  public boolean includeSequence(Sequence sequence) {
+    // Let Liquibase handle the sequence creation, as its done this in the past
+    // and stripping that out is too messy right now (Spring Boot 2.6.6 upgrade)
+    return false;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,8 @@ spring:
       default_schema: collectionexercise
     properties:
       hibernate:
+        hbm2ddl:
+          schema_filter_provider: uk.gov.ons.ctp.response.collection.exercise.CustomProvider
         id:
           new_generator_mappings: false
     # Used to suppress warning that appeared after upgrade to spring 2.0. It defaults to true, and we weren't setting

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,6 @@ spring:
     liquibase-schema: collectionexercise
     url: jdbc:postgresql://localhost:5432/ras
     change-log: classpath:/database/changelog-master.yml
-    enabled: false
 
   output:
     ansi:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,8 +52,10 @@ spring:
 
   # In spring boot 2.5, schema.sql isn't run on startup anymore.  Because the schema isn't created in the first liquibase
   # patch; we're overriding how it's handled, so it can be created if it's not there.
-  sql.init.mode: always
-  sql.init.continue-on-error: true
+  sql:
+    init:
+      mode: always
+      continue-on-error: true
 
   datasource:
     url: jdbc:postgresql://localhost:5432/ras

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,7 +69,10 @@ spring:
     hibernate:
       ddl-auto: update
       default_schema: collectionexercise
-
+    properties:
+      hibernate:
+        id:
+          new_generator_mappings: false
     # Used to suppress warning that appeared after upgrade to spring 2.0. It defaults to true, and we weren't setting
     # it so nothing changed.  Spring boot shows warnings if you don't explicitly set it.
     open-in-view: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,7 @@ spring:
     user: postgres
     password: postgres
     liquibase-schema: collectionexercise
+    default-schema: collectionexercise
     url: jdbc:postgresql://localhost:5432/ras
     change-log: classpath:/database/changelog-master.yml
     enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,7 @@ spring:
     liquibase-schema: collectionexercise
     url: jdbc:postgresql://localhost:5432/ras
     change-log: classpath:/database/changelog-master.yml
+    enabled: false
 
   output:
     ansi:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,7 +33,7 @@ spring:
   liquibase:
     user: postgres
     password: postgres
-    default-schema: collectionexercise
+    liquibase-schema: collectionexercise
     url: jdbc:postgresql://localhost:5432/ras
     change-log: classpath:/database/changelog-master.yml
     enabled: false


### PR DESCRIPTION
# What and why?
The `collection-exercise` deployment into the performance environment is suffering from a Liquibase error during application startup where the scripts appear to be getting reapplied causing constraint violations.

The issue is that Liquibase doesn't have the correctly named property and is looking in the default (public) schema.

This updates the Liquibase property name that specifies in which schema the delta changelog tables live. 

# How to test?
Deploy into a new and existing development environment (i.e. Docker Postgres), and deploy into a newly build and existing performance environment (i.e. Managed Cloud SQL). In all scenarios the `collection-exercise` should deploy and startup and data should be provisioned (new) or persistent (existing).

# Trello
https://trello.com/c/RpAdmz8R/1908-bug-performance-environment-infrastructure-track-time-2d