### PR TITLE
BUG: Setting CE to live with wrong CI causes errors

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.6
+version: 13.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.6
+appVersion: 13.0.7

--- a/diagrams/collection-exercise-new-states.puml
+++ b/diagrams/collection-exercise-new-states.puml
@@ -1,5 +1,4 @@
 @startuml
-
 [*] --> CREATED
 CREATED --> CREATED : ci_sample_added
 CREATED --> CREATED : ci_sample_deleted
@@ -15,12 +14,11 @@ READY_FOR_REVIEW --> CREATED : events_deleted
 READY_FOR_REVIEW --> EXECUTION_STARTED : execute
 EXECUTION_STARTED --> EXECUTION_STARTED : execute
 EXECUTION_STARTED --> EXECUTED : execution_complete
-FAILEDVALIDATION --> EXECUTION_STARTED : execute
+FAILEDVALIDATION --> SCHEDULED : ci_sample_deleted
 EXECUTED --> VALIDATED : validate
 EXECUTED --> FAILEDVALIDATION : invalidate
 VALIDATED --> READY_FOR_LIVE : publish
 VALIDATED --> LIVE : go_live
 READY_FOR_LIVE --> LIVE : go_live
 LIVE --> ENDED : end_exercise
-
 @enduml

--- a/diagrams/collection-exercise-new-states.puml
+++ b/diagrams/collection-exercise-new-states.puml
@@ -1,4 +1,5 @@
 @startuml
+
 [*] --> CREATED
 CREATED --> CREATED : ci_sample_added
 CREATED --> CREATED : ci_sample_deleted
@@ -21,4 +22,5 @@ VALIDATED --> READY_FOR_LIVE : publish
 VALIDATED --> LIVE : go_live
 READY_FOR_LIVE --> LIVE : go_live
 LIVE --> ENDED : end_exercise
+
 @enduml

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
@@ -102,7 +102,7 @@ public class CollectionExerciseStateTransitionManagerFactory
     Map<CollectionExerciseEvent, CollectionExerciseState> transitionForFailedvalidation =
         new HashMap<>();
     transitionForFailedvalidation.put(
-        CollectionExerciseEvent.EXECUTE, CollectionExerciseState.EXECUTION_STARTED);
+        CollectionExerciseEvent.CI_SAMPLE_DELETED, CollectionExerciseState.SCHEDULED);
     transitions.put(CollectionExerciseState.FAILEDVALIDATION, transitionForFailedvalidation);
 
     // READY_FOR_LIVE


### PR DESCRIPTION
# What and why?
It was found that when uploading a SEFT CI and a sample, with different form types, they failed validation (as expected). However, when trying to correct the issue by uploading the correct files, an error was thrown. It was being caused by the state of the CE being set to failed validation and needs to be changed to a state of scheduled.

I have changed the code, so that the failed validation state of the CE reverts back to a scheduled event. This will allow editing of the uploads without any exceptions/errors.

# How to test?

1. Set up a CE with correct outlined times and dates
2. Uploaded SEFT form type 0001
3. Uploaded sample looking for form type 0002
4. Hit the “set ready for live” button or if didn’t appear, hit the "edit date" MPS date and press “Save” the button should now be visible 
5. I pressed “Set as ready for live” and selected “OK” on the popup confirmation window.
6. Went into “Replace sample file”  and pressed “replace sample file”
7. Sample should have loaded with no issues

# Trello
https://trello.com/c/G1zMQCAB/1964-bug-setting-ce-to-live-with-wrong-ci-causes-errors-track-time