### PR TITLE
set ddl-auto to none

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,7 +65,7 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQL94Dialect
     defer-datasource-initialization: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
       default_schema: collectionexercise
 
     # Used to suppress warning that appeared after upgrade to spring 2.0. It defaults to true, and we weren't setting


### PR DESCRIPTION
# What and why?

Brand new Cloud SQL environment (e.g. performance) doesn't start due to Hibernate creating sequences. The custom provider doesn't work.

# How to test?

Does this app start in a new Cloud SQL env? Does the `"exercisepkseq" already exists` occur and does the app see zero restarts
