### PR TITLE
RAS-720 update Cronjob to v1

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.11
+version: 13.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.11
+appVersion: 13.0.12

--- a/_infra/helm/collection-exercise/templates/process-events-cronjob.yaml
+++ b/_infra/helm/collection-exercise/templates/process-events-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Values.crons.processEvents.name }}


### PR DESCRIPTION
# What and why?
This PR updates the CronJob version from v1beta to v1
# How to test?
Deploying to case via helm, ```helm install collection-exercse ./_infra/helm/collection-exercse``` The change from v1beta to v1 was tested here aswell https://github.com/ONSdigital/ras-party/pull/390
# Trello
