### PR TITLE
RAS-728 Ready for live button not appearing

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.12
+version: 13.0.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.12
+appVersion: 13.0.13

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseInstrumentReceiverEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseInstrumentReceiverEndpoint.java
@@ -31,7 +31,7 @@ public class CollectionExerciseInstrumentReceiverEndpoint {
   public ResponseEntity<?> collectionInstrumentLink(
       final @RequestBody @Valid CollectionInstrumentMessageDTO collectionInstrumentMessageDTO)
       throws CTPException {
-    log.with(collectionInstrumentMessageDTO.getExerciseId()).info("Consumed message");
+    log.with(collectionInstrumentMessageDTO.getExerciseId()).info("Collection instruments updated");
 
     UUID collectionExerciseId = collectionInstrumentMessageDTO.getExerciseId();
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseInstrumentReceiverEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseInstrumentReceiverEndpoint.java
@@ -31,9 +31,8 @@ public class CollectionExerciseInstrumentReceiverEndpoint {
   public ResponseEntity<?> collectionInstrumentLink(
       final @RequestBody @Valid CollectionInstrumentMessageDTO collectionInstrumentMessageDTO)
       throws CTPException {
-    log.with(collectionInstrumentMessageDTO.getInstrumentId())
-        .with(collectionInstrumentMessageDTO.getExerciseId())
-        .info("Consumed message");
+    log.with(collectionInstrumentMessageDTO.getExerciseId())
+        .info("Collection instruments changed for exercise");
 
     UUID collectionExerciseId = collectionInstrumentMessageDTO.getExerciseId();
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseInstrumentReceiverEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseInstrumentReceiverEndpoint.java
@@ -31,8 +31,7 @@ public class CollectionExerciseInstrumentReceiverEndpoint {
   public ResponseEntity<?> collectionInstrumentLink(
       final @RequestBody @Valid CollectionInstrumentMessageDTO collectionInstrumentMessageDTO)
       throws CTPException {
-    log.with(collectionInstrumentMessageDTO.getExerciseId())
-        .info("Consumed message");
+    log.with(collectionInstrumentMessageDTO.getExerciseId()).info("Consumed message");
 
     UUID collectionExerciseId = collectionInstrumentMessageDTO.getExerciseId();
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseInstrumentReceiverEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseInstrumentReceiverEndpoint.java
@@ -32,7 +32,7 @@ public class CollectionExerciseInstrumentReceiverEndpoint {
       final @RequestBody @Valid CollectionInstrumentMessageDTO collectionInstrumentMessageDTO)
       throws CTPException {
     log.with(collectionInstrumentMessageDTO.getExerciseId())
-        .info("Collection instruments changed for exercise");
+        .info("Consumed message");
 
     UUID collectionExerciseId = collectionInstrumentMessageDTO.getExerciseId();
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/ExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/ExceptionHandler.java
@@ -41,7 +41,6 @@ public class ExceptionHandler {
           CollectionInstrumentMessageDTO dto = (CollectionInstrumentMessageDTO) payload;
 
           result.put(ResultKey.collectionExercise, dto.getExerciseId().toString());
-          result.put(ResultKey.collectionInstrument, dto.getInstrumentId().toString());
         }
       }
       Throwable t = e.getCause();

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/CollectionInstrumentMessageDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/CollectionInstrumentMessageDTO.java
@@ -13,7 +13,7 @@ public class CollectionInstrumentMessageDTO {
   @JsonCreator
   public CollectionInstrumentMessageDTO(
       @JsonProperty("action") String action,
-      @JsonProperty("exercise_id") String exerciseId{
+      @JsonProperty("exercise_id") String exerciseId){
     this.action = action;
     this.exerciseId = UUID.fromString(exerciseId);
   }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/CollectionInstrumentMessageDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/CollectionInstrumentMessageDTO.java
@@ -9,15 +9,12 @@ import lombok.Data;
 public class CollectionInstrumentMessageDTO {
   private String action;
   private UUID exerciseId;
-  private UUID instrumentId;
 
   @JsonCreator
   public CollectionInstrumentMessageDTO(
       @JsonProperty("action") String action,
-      @JsonProperty("exercise_id") String exerciseId,
-      @JsonProperty("instrument_id") String instrumentId) {
+      @JsonProperty("exercise_id") String exerciseId{
     this.action = action;
     this.exerciseId = UUID.fromString(exerciseId);
-    this.instrumentId = UUID.fromString(instrumentId);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/CollectionInstrumentMessageDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/CollectionInstrumentMessageDTO.java
@@ -12,8 +12,7 @@ public class CollectionInstrumentMessageDTO {
 
   @JsonCreator
   public CollectionInstrumentMessageDTO(
-      @JsonProperty("action") String action,
-      @JsonProperty("exercise_id") String exerciseId){
+      @JsonProperty("action") String action, @JsonProperty("exercise_id") String exerciseId) {
     this.action = action;
     this.exerciseId = UUID.fromString(exerciseId);
   }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/ExceptionHandlerTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/ExceptionHandlerTests.java
@@ -33,7 +33,7 @@ public class ExceptionHandlerTests {
   public void setUp() {
     this.exceptionHandler = new ExceptionHandler();
     this.ctpException = new CTPException(EXCEPTION_FAULT, EXCEPTION_MESSAGE);
-    this.messageDto = new CollectionInstrumentMessageDTO(COLLECTION_EXERCISE_ID.toString());
+    this.messageDto = new CollectionInstrumentMessageDTO("ADD", COLLECTION_EXERCISE_ID.toString());
   }
 
   /** Given null exception When handleException Then empty response */

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/ExceptionHandlerTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/ExceptionHandlerTests.java
@@ -33,8 +33,7 @@ public class ExceptionHandlerTests {
   public void setUp() {
     this.exceptionHandler = new ExceptionHandler();
     this.ctpException = new CTPException(EXCEPTION_FAULT, EXCEPTION_MESSAGE);
-    this.messageDto =
-        new CollectionInstrumentMessageDTO(COLLECTION_EXERCISE_ID.toString());
+    this.messageDto = new CollectionInstrumentMessageDTO(COLLECTION_EXERCISE_ID.toString());
   }
 
   /** Given null exception When handleException Then empty response */

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/ExceptionHandlerTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/message/ExceptionHandlerTests.java
@@ -15,8 +15,6 @@ import uk.gov.ons.ctp.response.collection.exercise.message.dto.CollectionInstrum
 /** Unit tests for ExceptionHandler class */
 public class ExceptionHandlerTests {
 
-  private static final UUID COLLECTION_INSTRUMENT_ID =
-      UUID.fromString("699632ec-c75b-4454-a0ae-d15c592a6473");
   private static final UUID COLLECTION_EXERCISE_ID =
       UUID.fromString("d42f358c-812c-45f7-a064-39739d0189a6");
 
@@ -36,8 +34,7 @@ public class ExceptionHandlerTests {
     this.exceptionHandler = new ExceptionHandler();
     this.ctpException = new CTPException(EXCEPTION_FAULT, EXCEPTION_MESSAGE);
     this.messageDto =
-        new CollectionInstrumentMessageDTO(
-            null, COLLECTION_EXERCISE_ID.toString(), COLLECTION_INSTRUMENT_ID.toString());
+        new CollectionInstrumentMessageDTO(COLLECTION_EXERCISE_ID.toString());
   }
 
   /** Given null exception When handleException Then empty response */
@@ -57,9 +54,6 @@ public class ExceptionHandlerTests {
     Map<ExceptionHandler.ResultKey, String> result =
         this.exceptionHandler.handleException(exception);
 
-    assertEquals(
-        COLLECTION_INSTRUMENT_ID.toString(),
-        result.get(ExceptionHandler.ResultKey.collectionInstrument));
     assertEquals(
         COLLECTION_EXERCISE_ID.toString(),
         result.get(ExceptionHandler.ResultKey.collectionExercise));
@@ -97,9 +91,6 @@ public class ExceptionHandlerTests {
         this.exceptionHandler.handleException(exception);
 
     assertEquals(
-        COLLECTION_INSTRUMENT_ID.toString(),
-        result.get(ExceptionHandler.ResultKey.collectionInstrument));
-    assertEquals(
         COLLECTION_EXERCISE_ID.toString(),
         result.get(ExceptionHandler.ResultKey.collectionExercise));
     assertNull(result.get(ExceptionHandler.ResultKey.errorType));
@@ -117,9 +108,6 @@ public class ExceptionHandlerTests {
     Map<ExceptionHandler.ResultKey, String> result =
         this.exceptionHandler.handleException(exception);
 
-    assertEquals(
-        COLLECTION_INSTRUMENT_ID.toString(),
-        result.get(ExceptionHandler.ResultKey.collectionInstrument));
     assertEquals(
         COLLECTION_EXERCISE_ID.toString(),
         result.get(ExceptionHandler.ResultKey.collectionExercise));


### PR DESCRIPTION
# What and why?
This PR removes the collection instrument id from the message and logging. 
We now update multiple collection instruments at a time which makes this largely redundant. Calling the endpoint multiple times as we have been doing recently is inefficient as it is forcing it to do state checks each time when it should be done just one

Additionally having the uuid of another services object is a bit unusual, specially as it is only used for the logs, that logging should be captured by the CI service, and this one should log what called it and what it affects in its service

N.B This service needs further work as it receives a call from CI and then makes a call back to CI, it shouldn't be doing that and be provided the details it needs on the first call, however as this is a bug fix for something else, it should be captured on another card 

# How to test?
Test with https://github.com/ONSdigital/response-operations-ui/pull/868 and https://github.com/ONSdigital/ras-collection-instrument/pull/307 (description on collection instrument)
# Trello
