### PR TITLE
Manually bump version to 13.0.4

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.13
+version: 13.0.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.13
+appVersion: 13.0.14


### PR DESCRIPTION
# What and why?
A conflict wan't picked up merge and the action fired
# How to test?
Make sure 13.0.4 is the next version
# Trello
