### PR TITLE
RAS-638 Investigate how "Ready for live" button works, when replacing sample file (track time)

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.18
+version: 13.0.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.18
+appVersion: 13.0.19
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -706,6 +706,29 @@ paths:
                 type: object
         400:
           description: Bad Request
+  /sample/summary-readiness:
+    post:
+      tags:
+        - sample-service-endpoint
+      summary: POST request to update collection exercise state to READY_FOR_REVIEW
+      operationId: sampleSummaryReadiness
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SampleSummaryReadinessDTO"
+        required: true
+      responses:
+        401:
+          description: Unauthorized
+        201:
+          description: Successfully attempted to updated collection exercise state
+          content:
+            application/json:
+              schema:
+                type: object
+        404:
+          description: Resource not found
 components:
   schemas:
     SampleUnitsRequestDTO:
@@ -943,3 +966,9 @@ components:
           type: string
         collectionExerciseId:
           type: string
+    SampleSummaryReadinessDTO:
+      type: object
+      properties:
+        sampleSummaryId:
+          type: string
+          format: uuid

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/SampleSvcEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/SampleSvcEndpoint.java
@@ -43,6 +43,13 @@ public class SampleSvcEndpoint {
             .get(0)
             .getCollectionExerciseId();
 
+    if (collectionExerciseId == null) {
+      throw new CTPException(
+          CTPException.Fault.RESOURCE_NOT_FOUND,
+          String.format(
+              "No collection exercise id linked with sample summary %s", sampleSummaryId));
+    }
+
     collectionExerciseService.transitionScheduleCollectionExerciseToReadyToReview(
         collectionExerciseId);
     return ResponseEntity.ok().build();

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/SampleSvcEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/SampleSvcEndpoint.java
@@ -1,0 +1,40 @@
+package uk.gov.ons.ctp.response.collection.exercise.endpoint;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import java.util.UUID;
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.ons.ctp.response.collection.exercise.lib.common.error.CTPException;
+import uk.gov.ons.ctp.response.collection.exercise.message.dto.SampleSummaryReadinessDTO;
+import uk.gov.ons.ctp.response.collection.exercise.service.CollectionExerciseService;
+
+@RestController
+@RequestMapping(value = "/sample", produces = "application/json")
+public class SampleSvcEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(SampleSvcEndpoint.class);
+  private CollectionExerciseService collectionExerciseService;
+
+  @Autowired
+  public SampleSvcEndpoint(CollectionExerciseService collectionExerciseService) {
+    this.collectionExerciseService = collectionExerciseService;
+  }
+
+  @RequestMapping(value = "/summary-readiness", method = RequestMethod.POST)
+  public ResponseEntity<?> sampleSummaryReadiness(
+      final @RequestBody @Valid SampleSummaryReadinessDTO sampleSummaryReadinessDTO)
+      throws CTPException {
+    log.with(sampleSummaryReadinessDTO.getSampleSummaryId()).info("Sample summary status updated");
+
+    UUID collectionExerciseId = sampleSummaryReadinessDTO.getCollectionExerciseId();
+
+    collectionExerciseService.transitionScheduleCollectionExerciseToReadyToReview(
+        collectionExerciseId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/SampleSummaryReadinessDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/SampleSummaryReadinessDTO.java
@@ -11,5 +11,4 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class SampleSummaryReadinessDTO {
   private UUID sampleSummaryId;
-  private UUID collectionExerciseId;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/SampleSummaryReadinessDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/dto/SampleSummaryReadinessDTO.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.response.collection.exercise.message.dto;
+
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class SampleSummaryReadinessDTO {
+  private UUID sampleSummaryId;
+  private UUID collectionExerciseId;
+}

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
@@ -280,4 +280,31 @@ public class CollectionExerciseClient {
               event.getCollectionExerciseId(), event.getTag(), response.getStatus()));
     }
   }
+
+  void sampleSummaryReadiness(final UUID sampleSummaryId) throws CTPException {
+    sampleSummaryReady(sampleSummaryId);
+  }
+
+  private int sampleSummaryReady(final UUID sampleSummaryId) throws CTPException {
+    try {
+      JSONObject jsonPayload = new JSONObject();
+      JSONArray jsonSampleSummaryId = new JSONArray();
+      jsonSampleSummaryId.put(sampleSummaryId);
+      jsonPayload.put("sampleSummaryId", jsonSampleSummaryId);
+
+      HttpResponse<JsonNode> linkResponse =
+          Unirest.put("http://localhost:" + this.port + "/sample/summary-readiness")
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/json")
+              .header("Content-Type", "application/json")
+              .body(jsonPayload)
+              .asJson();
+
+      return linkResponse.getStatus();
+    } catch (JSONException e) {
+      throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to create payload: %s", e);
+    } catch (UnirestException e) {
+      throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to serialize payload: %s", e);
+    }
+  }
 }


### PR DESCRIPTION
# What and why?
This PR adds the the endpoint that the sample service uses to notify when the sample is ready and loaded so that when a sample is loaded in response operations, and all other values are loaded, the `Set Ready for live` button appears.
# How to test?
- Deploy this PR to your environment
- Deploy https://github.com/ONSdigital/rm-sample-service/pull/248 to your environment
   - Must be deployed last
- Deploy https://github.com/ONSdigital/response-operations-ui/pull/888 to your environment
- Set up a collection exercise in this order
   - Required event dates
   - A collection instrument
   - A sample file
- Ensure the sample has loaded
 - There is no `Refresh` link at the top of the page
- The `Set ready for live` button appears and the collection exercise
# Jira
[RAS-638](https://jira.ons.gov.uk/browse/RAS-638)