### PR TITLE
add changeset to add primary key to supplementary dataset table

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.20
+version: 13.0.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.20
+appVersion: 13.0.21
 

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -66,3 +66,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-20/changelog.yml
+
+  - include:
+      file: database/changes/release-21/changelog.yml

--- a/src/main/resources/database/changes/release-21/add_primary_key_to_supplementary_dataset_table.sql
+++ b/src/main/resources/database/changes/release-21/add_primary_key_to_supplementary_dataset_table.sql
@@ -1,0 +1,3 @@
+Set schema 'collectionexercise';
+
+ALTER TABLE collectionexercise.supplementarydataset ADD PRIMARY KEY (id);

--- a/src/main/resources/database/changes/release-21/changelog.yml
+++ b/src/main/resources/database/changes/release-21/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 21.1
+      author: Jacob Harrison
+      changes:
+        - sqlFile:
+            comment: Add primary key to supplementary table
+            path: add_primary_key_to_supplementary_dataset_table.sql
+            relativeToChangelogFile: true
+            splitStatements: true


### PR DESCRIPTION
# What and why?
The new collectionexercise.supplementarydatset table does not have a primary key.

Add a new Liquibase delta to correct this.

# How to test?
Deploy this PR to env, 
check if constraint has been added to database table supplementarydatset
run the acceptance test should set up a collecton excercise you can use to test supplementary data service 
publish this message to supplementary-data-service-{env}

{
    "survey_id": "139",
    "period_id": "1912",
    "form_types": [
       "0001"
      ],
    "title": "Test dataset for survey id 009 period 220823",
    "sds_published_at": "2023-08-22T14:46:36Z",
    "total_reporting_units": 2,
    "schema_version": "v1.0.0",
    "sds_dataset_version": 4,
    "filename": "373d9a77-2ee5-4c1f-a6dd-8d07b0ea9793.json",
    "dataset_id": "b9a87999-fcc0-4085-979f-06390fb5dddd"
  }

This message should work with the 139 QBS period 1912 created with the acceptance tests. 
you could also create your own collecton exercise, just change the message to add the details from your collection exercise
After confirming this is assigned with the collection exercise in the supplementarydataset table you can complete the survey for completeness. 

# Jira
https://jira.ons.gov.uk/browse/RAS-916
