### PR TITLE
Replace org.json with jackson.json due to vulnerabilities

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.25
+version: 13.0.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.25
+appVersion: 13.0.26
 

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <version>1.1.5</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.24</version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,12 @@
         <!-- third party libraries -->
 
         <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>2.1.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.24</version>

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
@@ -6,6 +6,7 @@ import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import jakarta.json.Json;
+import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import java.time.OffsetDateTime;
@@ -37,10 +38,10 @@ public class CollectionExerciseClient {
   /**
    * Constructor for client - accepts API connection information
    *
-   * @param aPort collection exercise API port
+   * @param aPort     collection exercise API port
    * @param aUsername collection exercise API username
    * @param aPassword collection exercise API password
-   * @param aMapper an object mapper
+   * @param aMapper   an object mapper
    */
   public CollectionExerciseClient(
       final int aPort, final String aUsername, final String aPassword, final ObjectMapper aMapper) {
@@ -71,21 +72,20 @@ public class CollectionExerciseClient {
   }
 
   public HttpResponse updateEvent(final EventDTO event) {
-    final OffsetDateTime offsetDateTime =
-        OffsetDateTime.ofInstant(event.getTimestamp().toInstant(), ZoneOffset.systemDefault());
+    final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(event.getTimestamp().toInstant(),
+        ZoneOffset.systemDefault());
     final String date = DateTimeFormatter.ISO_DATE_TIME.format(offsetDateTime);
 
     HttpResponse response = null;
     try {
-      response =
-          Unirest.put("http://localhost:" + this.port + "/collectionexercises/{id}/events/{tag}")
-              .routeParam("id", event.getCollectionExerciseId().toString())
-              .routeParam("tag", event.getTag())
-              .basicAuth(this.username, this.password)
-              .header("accept", "application/json")
-              .header("Content-Type", "text/plain")
-              .body(date)
-              .asObject(ResponseEventDTO.class);
+      response = Unirest.put("http://localhost:" + this.port + "/collectionexercises/{id}/events/{tag}")
+          .routeParam("id", event.getCollectionExerciseId().toString())
+          .routeParam("tag", event.getTag())
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/json")
+          .header("Content-Type", "text/plain")
+          .body(date)
+          .asObject(ResponseEventDTO.class);
     } catch (UnirestException e) {
       throw new RuntimeException(
           String.format(
@@ -105,12 +105,14 @@ public class CollectionExerciseClient {
   /**
    * Calls the API to create a collection exercise
    *
-   * @param surveyId survey to create collection exercise for
-   * @param exerciseRef the period of the collection exercise
+   * @param surveyId        survey to create collection exercise for
+   * @param exerciseRef     the period of the collection exercise
    * @param userDescription the description of the collection exercise
-   * @return a Pair of the status code of the operation and the location at which the new resource
-   *     has been created
-   * @throws CTPException thrown if an error occurred creating the collection exercise
+   * @return a Pair of the status code of the operation and the location at which
+   *         the new resource
+   *         has been created
+   * @throws CTPException thrown if an error occurred creating the collection
+   *                      exercise
    */
   public Pair<Integer, String> createCollectionExercise(
       final UUID surveyId, final String exerciseRef, final String userDescription)
@@ -123,13 +125,12 @@ public class CollectionExerciseClient {
     inputDto.setSupplementaryDatasetEntity(null);
 
     try {
-      HttpResponse<String> createCollexResponse =
-          Unirest.post("http://localhost:" + this.port + "/collectionexercises")
-              .basicAuth(this.username, this.password)
-              .header("accept", "application/json")
-              .header("Content-Type", "application/json")
-              .body(inputDto)
-              .asString();
+      HttpResponse<String> createCollexResponse = Unirest.post("http://localhost:" + this.port + "/collectionexercises")
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/json")
+          .header("Content-Type", "application/json")
+          .body(inputDto)
+          .asString();
       int statusCode = createCollexResponse.getStatus();
       List<String> locations = createCollexResponse.getHeaders().get("Location");
       String location = locations != null && locations.size() > 0 ? locations.get(0) : null;
@@ -146,7 +147,8 @@ public class CollectionExerciseClient {
    *
    * @param collexId the uuid of the collection exercise
    * @return the full details of the collection exercise
-   * @throws CTPException thrown if an error occurred retrieving the collection exercise details
+   * @throws CTPException thrown if an error occurred retrieving the collection
+   *                      exercise details
    */
   CollectionExerciseDTO getCollectionExercise(final UUID collexId) throws CTPException {
     try {
@@ -165,11 +167,13 @@ public class CollectionExerciseClient {
   }
 
   /**
-   * Gets a collection exercise given the whole URI (e.g. as returned in a Location header)
+   * Gets a collection exercise given the whole URI (e.g. as returned in a
+   * Location header)
    *
    * @param uriStr the full URI of the collection exercise resource
    * @return a representation of the collection exercise
-   * @throws CTPException thrown if there was an error retrieving the collection exercise
+   * @throws CTPException thrown if there was an error retrieving the collection
+   *                      exercise
    */
   public CollectionExerciseDTO getCollectionExercise(final String uriStr) throws CTPException {
     try {
@@ -187,11 +191,12 @@ public class CollectionExerciseClient {
   /**
    * Calls the API to link a list of sample summaries to a collection exercise
    *
-   * @param collexId the uuid of the collection exercise to link
+   * @param collexId         the uuid of the collection exercise to link
    * @param sampleSummaryIds a list of the uuids of the sample summaries to link
    * @return the http status code of the operation
-   * @throws CTPException thrown if there was an error linking the sample summaries to the
-   *     collection exercise
+   * @throws CTPException thrown if there was an error linking the sample
+   *                      summaries to the
+   *                      collection exercise
    */
   private int linkSampleSummaries(final UUID collexId, final List<UUID> sampleSummaryIds)
       throws CTPException {
@@ -200,17 +205,17 @@ public class CollectionExerciseClient {
       for (UUID ssi : sampleSummaryIds) {
         arrayBuilder.add(ssi.toString());
       }
-      JsonObject jsonPayload =
-          Json.createObjectBuilder().add("sampleSummaryIds", arrayBuilder).build();
+      JsonArray sampleSummaryArray = arrayBuilder.build();
+      JsonObject jsonPayload = Json.createObjectBuilder().add("sampleSummaryIds", sampleSummaryArray).build();
 
-      HttpResponse<JsonNode> linkResponse =
-          Unirest.put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
-              .routeParam("id", collexId.toString())
-              .basicAuth(this.username, this.password)
-              .header("accept", "application/json")
-              .header("Content-Type", "application/json")
-              .body(jsonPayload)
-              .asJson();
+      HttpResponse<JsonNode> linkResponse = Unirest
+          .put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+          .routeParam("id", collexId.toString())
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/json")
+          .header("Content-Type", "application/json")
+          .body(jsonPayload)
+          .asJson();
 
       return linkResponse.getStatus();
     } catch (UnirestException e) {
@@ -221,10 +226,11 @@ public class CollectionExerciseClient {
   /**
    * Links a sample summary to a collection exercise
    *
-   * @param collexId the uuid of the collection exercise to link
+   * @param collexId        the uuid of the collection exercise to link
    * @param sampleSummaryId the uuid of the sample summary to link
-   * @throws CTPException thrown if there was an error linking the sample summary to the collection
-   *     exercise
+   * @throws CTPException thrown if there was an error linking the sample summary
+   *                      to the collection
+   *                      exercise
    * @see CollectionExerciseClient#linkSampleSummaries
    */
   void linkSampleSummary(final UUID collexId, final UUID sampleSummaryId) throws CTPException {
@@ -240,13 +246,12 @@ public class CollectionExerciseClient {
    */
   List<SampleLinkDTO> getSampleLinks(final UUID collexId) throws CTPException {
     try {
-      SampleLinkDTO[] linkArray =
-          Unirest.get("http://localhost:" + this.port + "/collectionexercises/link/{id}")
-              .routeParam("id", collexId.toString())
-              .basicAuth(this.username, this.password)
-              .header("accept", "application/vnd.ons.sdc.samplelink.v1+json")
-              .asObject(SampleLinkDTO[].class)
-              .getBody();
+      SampleLinkDTO[] linkArray = Unirest.get("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+          .routeParam("id", collexId.toString())
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/vnd.ons.sdc.samplelink.v1+json")
+          .asObject(SampleLinkDTO[].class)
+          .getBody();
 
       return Arrays.asList(linkArray);
     } catch (UnirestException e) {
@@ -258,14 +263,13 @@ public class CollectionExerciseClient {
   public void createCollectionExerciseEvent(EventDTO event) {
     HttpResponse<String> response = null;
     try {
-      response =
-          Unirest.post("http://localhost:" + this.port + "/collectionexercises/{id}/events")
-              .routeParam("id", event.getCollectionExerciseId().toString())
-              .basicAuth(this.username, this.password)
-              .header("accept", "application/json")
-              .header("Content-Type", "application/json")
-              .body(event)
-              .asString();
+      response = Unirest.post("http://localhost:" + this.port + "/collectionexercises/{id}/events")
+          .routeParam("id", event.getCollectionExerciseId().toString())
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/json")
+          .header("Content-Type", "application/json")
+          .body(event)
+          .asString();
     } catch (UnirestException e) {
       throw new RuntimeException(
           String.format(
@@ -289,8 +293,8 @@ public class CollectionExerciseClient {
     try {
       JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
       arrayBuilder.add(sampleSummaryId.toString());
-      JsonObject jsonPayload =
-          Json.createObjectBuilder().add("sampleSummaryIds", arrayBuilder).build();
+      JsonArray sampleSummaryArray = arrayBuilder.build();
+      JsonObject jsonPayload = Json.createObjectBuilder().add("sampleSummaryIds", sampleSummaryArray).build();
 
       Unirest.put("http://localhost:" + this.port + "/sample/summary-readiness")
           .basicAuth(this.username, this.password)

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
@@ -6,7 +6,6 @@ import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import jakarta.json.Json;
-import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import java.time.OffsetDateTime;
@@ -38,10 +37,10 @@ public class CollectionExerciseClient {
   /**
    * Constructor for client - accepts API connection information
    *
-   * @param aPort collection exercise API port
+   * @param aPort     collection exercise API port
    * @param aUsername collection exercise API username
    * @param aPassword collection exercise API password
-   * @param aMapper an object mapper
+   * @param aMapper   an object mapper
    */
   public CollectionExerciseClient(
       final int aPort, final String aUsername, final String aPassword, final ObjectMapper aMapper) {
@@ -72,21 +71,20 @@ public class CollectionExerciseClient {
   }
 
   public HttpResponse updateEvent(final EventDTO event) {
-    final OffsetDateTime offsetDateTime =
-        OffsetDateTime.ofInstant(event.getTimestamp().toInstant(), ZoneOffset.systemDefault());
+    final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(event.getTimestamp().toInstant(),
+        ZoneOffset.systemDefault());
     final String date = DateTimeFormatter.ISO_DATE_TIME.format(offsetDateTime);
 
     HttpResponse response = null;
     try {
-      response =
-          Unirest.put("http://localhost:" + this.port + "/collectionexercises/{id}/events/{tag}")
-              .routeParam("id", event.getCollectionExerciseId().toString())
-              .routeParam("tag", event.getTag())
-              .basicAuth(this.username, this.password)
-              .header("accept", "application/json")
-              .header("Content-Type", "text/plain")
-              .body(date)
-              .asObject(ResponseEventDTO.class);
+      response = Unirest.put("http://localhost:" + this.port + "/collectionexercises/{id}/events/{tag}")
+          .routeParam("id", event.getCollectionExerciseId().toString())
+          .routeParam("tag", event.getTag())
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/json")
+          .header("Content-Type", "text/plain")
+          .body(date)
+          .asObject(ResponseEventDTO.class);
     } catch (UnirestException e) {
       throw new RuntimeException(
           String.format(
@@ -106,12 +104,14 @@ public class CollectionExerciseClient {
   /**
    * Calls the API to create a collection exercise
    *
-   * @param surveyId survey to create collection exercise for
-   * @param exerciseRef the period of the collection exercise
+   * @param surveyId        survey to create collection exercise for
+   * @param exerciseRef     the period of the collection exercise
    * @param userDescription the description of the collection exercise
-   * @return a Pair of the status code of the operation and the location at which the new resource
-   *     has been created
-   * @throws CTPException thrown if an error occurred creating the collection exercise
+   * @return a Pair of the status code of the operation and the location at which
+   *         the new resource
+   *         has been created
+   * @throws CTPException thrown if an error occurred creating the collection
+   *                      exercise
    */
   public Pair<Integer, String> createCollectionExercise(
       final UUID surveyId, final String exerciseRef, final String userDescription)
@@ -124,13 +124,12 @@ public class CollectionExerciseClient {
     inputDto.setSupplementaryDatasetEntity(null);
 
     try {
-      HttpResponse<String> createCollexResponse =
-          Unirest.post("http://localhost:" + this.port + "/collectionexercises")
-              .basicAuth(this.username, this.password)
-              .header("accept", "application/json")
-              .header("Content-Type", "application/json")
-              .body(inputDto)
-              .asString();
+      HttpResponse<String> createCollexResponse = Unirest.post("http://localhost:" + this.port + "/collectionexercises")
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/json")
+          .header("Content-Type", "application/json")
+          .body(inputDto)
+          .asString();
       int statusCode = createCollexResponse.getStatus();
       List<String> locations = createCollexResponse.getHeaders().get("Location");
       String location = locations != null && locations.size() > 0 ? locations.get(0) : null;
@@ -147,7 +146,8 @@ public class CollectionExerciseClient {
    *
    * @param collexId the uuid of the collection exercise
    * @return the full details of the collection exercise
-   * @throws CTPException thrown if an error occurred retrieving the collection exercise details
+   * @throws CTPException thrown if an error occurred retrieving the collection
+   *                      exercise details
    */
   CollectionExerciseDTO getCollectionExercise(final UUID collexId) throws CTPException {
     try {
@@ -166,11 +166,13 @@ public class CollectionExerciseClient {
   }
 
   /**
-   * Gets a collection exercise given the whole URI (e.g. as returned in a Location header)
+   * Gets a collection exercise given the whole URI (e.g. as returned in a
+   * Location header)
    *
    * @param uriStr the full URI of the collection exercise resource
    * @return a representation of the collection exercise
-   * @throws CTPException thrown if there was an error retrieving the collection exercise
+   * @throws CTPException thrown if there was an error retrieving the collection
+   *                      exercise
    */
   public CollectionExerciseDTO getCollectionExercise(final String uriStr) throws CTPException {
     try {
@@ -188,11 +190,12 @@ public class CollectionExerciseClient {
   /**
    * Calls the API to link a list of sample summaries to a collection exercise
    *
-   * @param collexId the uuid of the collection exercise to link
+   * @param collexId         the uuid of the collection exercise to link
    * @param sampleSummaryIds a list of the uuids of the sample summaries to link
    * @return the http status code of the operation
-   * @throws CTPException thrown if there was an error linking the sample summaries to the
-   *     collection exercise
+   * @throws CTPException thrown if there was an error linking the sample
+   *                      summaries to the
+   *                      collection exercise
    */
   private int linkSampleSummaries(final UUID collexId, final List<UUID> sampleSummaryIds)
       throws CTPException {
@@ -201,18 +204,16 @@ public class CollectionExerciseClient {
       for (UUID ssi : sampleSummaryIds) {
         arrayBuilder.add(ssi.toString());
       }
-      JsonArray sampleSummaryArray = arrayBuilder.build();
-      JsonObject jsonPayload =
-          Json.createObjectBuilder().add("sampleSummaryIds", sampleSummaryArray).build();
+      JsonObject jsonPayload = Json.createObjectBuilder().add("sampleSummaryIds", arrayBuilder).build();
 
-      HttpResponse<JsonNode> linkResponse =
-          Unirest.put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
-              .routeParam("id", collexId.toString())
-              .basicAuth(this.username, this.password)
-              .header("accept", "application/json")
-              .header("Content-Type", "application/json")
-              .body(jsonPayload)
-              .asJson();
+      HttpResponse<JsonNode> linkResponse = Unirest
+          .put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+          .routeParam("id", collexId.toString())
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/json")
+          .header("Content-Type", "application/json")
+          .body(jsonPayload.toString())
+          .asJson();
 
       return linkResponse.getStatus();
     } catch (UnirestException e) {
@@ -223,10 +224,11 @@ public class CollectionExerciseClient {
   /**
    * Links a sample summary to a collection exercise
    *
-   * @param collexId the uuid of the collection exercise to link
+   * @param collexId        the uuid of the collection exercise to link
    * @param sampleSummaryId the uuid of the sample summary to link
-   * @throws CTPException thrown if there was an error linking the sample summary to the collection
-   *     exercise
+   * @throws CTPException thrown if there was an error linking the sample summary
+   *                      to the collection
+   *                      exercise
    * @see CollectionExerciseClient#linkSampleSummaries
    */
   void linkSampleSummary(final UUID collexId, final UUID sampleSummaryId) throws CTPException {
@@ -242,13 +244,12 @@ public class CollectionExerciseClient {
    */
   List<SampleLinkDTO> getSampleLinks(final UUID collexId) throws CTPException {
     try {
-      SampleLinkDTO[] linkArray =
-          Unirest.get("http://localhost:" + this.port + "/collectionexercises/link/{id}")
-              .routeParam("id", collexId.toString())
-              .basicAuth(this.username, this.password)
-              .header("accept", "application/vnd.ons.sdc.samplelink.v1+json")
-              .asObject(SampleLinkDTO[].class)
-              .getBody();
+      SampleLinkDTO[] linkArray = Unirest.get("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+          .routeParam("id", collexId.toString())
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/vnd.ons.sdc.samplelink.v1+json")
+          .asObject(SampleLinkDTO[].class)
+          .getBody();
 
       return Arrays.asList(linkArray);
     } catch (UnirestException e) {
@@ -260,14 +261,13 @@ public class CollectionExerciseClient {
   public void createCollectionExerciseEvent(EventDTO event) {
     HttpResponse<String> response = null;
     try {
-      response =
-          Unirest.post("http://localhost:" + this.port + "/collectionexercises/{id}/events")
-              .routeParam("id", event.getCollectionExerciseId().toString())
-              .basicAuth(this.username, this.password)
-              .header("accept", "application/json")
-              .header("Content-Type", "application/json")
-              .body(event)
-              .asString();
+      response = Unirest.post("http://localhost:" + this.port + "/collectionexercises/{id}/events")
+          .routeParam("id", event.getCollectionExerciseId().toString())
+          .basicAuth(this.username, this.password)
+          .header("accept", "application/json")
+          .header("Content-Type", "application/json")
+          .body(event)
+          .asString();
     } catch (UnirestException e) {
       throw new RuntimeException(
           String.format(
@@ -291,15 +291,13 @@ public class CollectionExerciseClient {
     try {
       JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
       arrayBuilder.add(sampleSummaryId.toString());
-      JsonArray sampleSummaryArray = arrayBuilder.build();
-      JsonObject jsonPayload =
-          Json.createObjectBuilder().add("sampleSummaryIds", sampleSummaryArray).build();
+      JsonObject jsonPayload = Json.createObjectBuilder().add("sampleSummaryIds", arrayBuilder).build();
 
       Unirest.put("http://localhost:" + this.port + "/sample/summary-readiness")
           .basicAuth(this.username, this.password)
           .header("accept", "application/json")
           .header("Content-Type", "application/json")
-          .body(jsonPayload)
+          .body(jsonPayload.toString())
           .asJson();
 
     } catch (UnirestException e) {

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
@@ -38,10 +38,10 @@ public class CollectionExerciseClient {
   /**
    * Constructor for client - accepts API connection information
    *
-   * @param aPort     collection exercise API port
+   * @param aPort collection exercise API port
    * @param aUsername collection exercise API username
    * @param aPassword collection exercise API password
-   * @param aMapper   an object mapper
+   * @param aMapper an object mapper
    */
   public CollectionExerciseClient(
       final int aPort, final String aUsername, final String aPassword, final ObjectMapper aMapper) {
@@ -72,20 +72,21 @@ public class CollectionExerciseClient {
   }
 
   public HttpResponse updateEvent(final EventDTO event) {
-    final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(event.getTimestamp().toInstant(),
-        ZoneOffset.systemDefault());
+    final OffsetDateTime offsetDateTime =
+        OffsetDateTime.ofInstant(event.getTimestamp().toInstant(), ZoneOffset.systemDefault());
     final String date = DateTimeFormatter.ISO_DATE_TIME.format(offsetDateTime);
 
     HttpResponse response = null;
     try {
-      response = Unirest.put("http://localhost:" + this.port + "/collectionexercises/{id}/events/{tag}")
-          .routeParam("id", event.getCollectionExerciseId().toString())
-          .routeParam("tag", event.getTag())
-          .basicAuth(this.username, this.password)
-          .header("accept", "application/json")
-          .header("Content-Type", "text/plain")
-          .body(date)
-          .asObject(ResponseEventDTO.class);
+      response =
+          Unirest.put("http://localhost:" + this.port + "/collectionexercises/{id}/events/{tag}")
+              .routeParam("id", event.getCollectionExerciseId().toString())
+              .routeParam("tag", event.getTag())
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/json")
+              .header("Content-Type", "text/plain")
+              .body(date)
+              .asObject(ResponseEventDTO.class);
     } catch (UnirestException e) {
       throw new RuntimeException(
           String.format(
@@ -105,14 +106,12 @@ public class CollectionExerciseClient {
   /**
    * Calls the API to create a collection exercise
    *
-   * @param surveyId        survey to create collection exercise for
-   * @param exerciseRef     the period of the collection exercise
+   * @param surveyId survey to create collection exercise for
+   * @param exerciseRef the period of the collection exercise
    * @param userDescription the description of the collection exercise
-   * @return a Pair of the status code of the operation and the location at which
-   *         the new resource
-   *         has been created
-   * @throws CTPException thrown if an error occurred creating the collection
-   *                      exercise
+   * @return a Pair of the status code of the operation and the location at which the new resource
+   *     has been created
+   * @throws CTPException thrown if an error occurred creating the collection exercise
    */
   public Pair<Integer, String> createCollectionExercise(
       final UUID surveyId, final String exerciseRef, final String userDescription)
@@ -125,12 +124,13 @@ public class CollectionExerciseClient {
     inputDto.setSupplementaryDatasetEntity(null);
 
     try {
-      HttpResponse<String> createCollexResponse = Unirest.post("http://localhost:" + this.port + "/collectionexercises")
-          .basicAuth(this.username, this.password)
-          .header("accept", "application/json")
-          .header("Content-Type", "application/json")
-          .body(inputDto)
-          .asString();
+      HttpResponse<String> createCollexResponse =
+          Unirest.post("http://localhost:" + this.port + "/collectionexercises")
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/json")
+              .header("Content-Type", "application/json")
+              .body(inputDto)
+              .asString();
       int statusCode = createCollexResponse.getStatus();
       List<String> locations = createCollexResponse.getHeaders().get("Location");
       String location = locations != null && locations.size() > 0 ? locations.get(0) : null;
@@ -147,8 +147,7 @@ public class CollectionExerciseClient {
    *
    * @param collexId the uuid of the collection exercise
    * @return the full details of the collection exercise
-   * @throws CTPException thrown if an error occurred retrieving the collection
-   *                      exercise details
+   * @throws CTPException thrown if an error occurred retrieving the collection exercise details
    */
   CollectionExerciseDTO getCollectionExercise(final UUID collexId) throws CTPException {
     try {
@@ -167,13 +166,11 @@ public class CollectionExerciseClient {
   }
 
   /**
-   * Gets a collection exercise given the whole URI (e.g. as returned in a
-   * Location header)
+   * Gets a collection exercise given the whole URI (e.g. as returned in a Location header)
    *
    * @param uriStr the full URI of the collection exercise resource
    * @return a representation of the collection exercise
-   * @throws CTPException thrown if there was an error retrieving the collection
-   *                      exercise
+   * @throws CTPException thrown if there was an error retrieving the collection exercise
    */
   public CollectionExerciseDTO getCollectionExercise(final String uriStr) throws CTPException {
     try {
@@ -191,12 +188,11 @@ public class CollectionExerciseClient {
   /**
    * Calls the API to link a list of sample summaries to a collection exercise
    *
-   * @param collexId         the uuid of the collection exercise to link
+   * @param collexId the uuid of the collection exercise to link
    * @param sampleSummaryIds a list of the uuids of the sample summaries to link
    * @return the http status code of the operation
-   * @throws CTPException thrown if there was an error linking the sample
-   *                      summaries to the
-   *                      collection exercise
+   * @throws CTPException thrown if there was an error linking the sample summaries to the
+   *     collection exercise
    */
   private int linkSampleSummaries(final UUID collexId, final List<UUID> sampleSummaryIds)
       throws CTPException {
@@ -206,16 +202,17 @@ public class CollectionExerciseClient {
         arrayBuilder.add(ssi.toString());
       }
       JsonArray sampleSummaryArray = arrayBuilder.build();
-      JsonObject jsonPayload = Json.createObjectBuilder().add("sampleSummaryIds", sampleSummaryArray).build();
+      JsonObject jsonPayload =
+          Json.createObjectBuilder().add("sampleSummaryIds", sampleSummaryArray).build();
 
-      HttpResponse<JsonNode> linkResponse = Unirest
-          .put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
-          .routeParam("id", collexId.toString())
-          .basicAuth(this.username, this.password)
-          .header("accept", "application/json")
-          .header("Content-Type", "application/json")
-          .body(jsonPayload)
-          .asJson();
+      HttpResponse<JsonNode> linkResponse =
+          Unirest.put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+              .routeParam("id", collexId.toString())
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/json")
+              .header("Content-Type", "application/json")
+              .body(jsonPayload)
+              .asJson();
 
       return linkResponse.getStatus();
     } catch (UnirestException e) {
@@ -226,11 +223,10 @@ public class CollectionExerciseClient {
   /**
    * Links a sample summary to a collection exercise
    *
-   * @param collexId        the uuid of the collection exercise to link
+   * @param collexId the uuid of the collection exercise to link
    * @param sampleSummaryId the uuid of the sample summary to link
-   * @throws CTPException thrown if there was an error linking the sample summary
-   *                      to the collection
-   *                      exercise
+   * @throws CTPException thrown if there was an error linking the sample summary to the collection
+   *     exercise
    * @see CollectionExerciseClient#linkSampleSummaries
    */
   void linkSampleSummary(final UUID collexId, final UUID sampleSummaryId) throws CTPException {
@@ -246,12 +242,13 @@ public class CollectionExerciseClient {
    */
   List<SampleLinkDTO> getSampleLinks(final UUID collexId) throws CTPException {
     try {
-      SampleLinkDTO[] linkArray = Unirest.get("http://localhost:" + this.port + "/collectionexercises/link/{id}")
-          .routeParam("id", collexId.toString())
-          .basicAuth(this.username, this.password)
-          .header("accept", "application/vnd.ons.sdc.samplelink.v1+json")
-          .asObject(SampleLinkDTO[].class)
-          .getBody();
+      SampleLinkDTO[] linkArray =
+          Unirest.get("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+              .routeParam("id", collexId.toString())
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/vnd.ons.sdc.samplelink.v1+json")
+              .asObject(SampleLinkDTO[].class)
+              .getBody();
 
       return Arrays.asList(linkArray);
     } catch (UnirestException e) {
@@ -263,13 +260,14 @@ public class CollectionExerciseClient {
   public void createCollectionExerciseEvent(EventDTO event) {
     HttpResponse<String> response = null;
     try {
-      response = Unirest.post("http://localhost:" + this.port + "/collectionexercises/{id}/events")
-          .routeParam("id", event.getCollectionExerciseId().toString())
-          .basicAuth(this.username, this.password)
-          .header("accept", "application/json")
-          .header("Content-Type", "application/json")
-          .body(event)
-          .asString();
+      response =
+          Unirest.post("http://localhost:" + this.port + "/collectionexercises/{id}/events")
+              .routeParam("id", event.getCollectionExerciseId().toString())
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/json")
+              .header("Content-Type", "application/json")
+              .body(event)
+              .asString();
     } catch (UnirestException e) {
       throw new RuntimeException(
           String.format(
@@ -294,7 +292,8 @@ public class CollectionExerciseClient {
       JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
       arrayBuilder.add(sampleSummaryId.toString());
       JsonArray sampleSummaryArray = arrayBuilder.build();
-      JsonObject jsonPayload = Json.createObjectBuilder().add("sampleSummaryIds", sampleSummaryArray).build();
+      JsonObject jsonPayload =
+          Json.createObjectBuilder().add("sampleSummaryIds", sampleSummaryArray).build();
 
       Unirest.put("http://localhost:" + this.port + "/sample/summary-readiness")
           .basicAuth(this.username, this.password)

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
@@ -37,10 +37,10 @@ public class CollectionExerciseClient {
   /**
    * Constructor for client - accepts API connection information
    *
-   * @param aPort     collection exercise API port
+   * @param aPort collection exercise API port
    * @param aUsername collection exercise API username
    * @param aPassword collection exercise API password
-   * @param aMapper   an object mapper
+   * @param aMapper an object mapper
    */
   public CollectionExerciseClient(
       final int aPort, final String aUsername, final String aPassword, final ObjectMapper aMapper) {
@@ -71,20 +71,21 @@ public class CollectionExerciseClient {
   }
 
   public HttpResponse updateEvent(final EventDTO event) {
-    final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(event.getTimestamp().toInstant(),
-        ZoneOffset.systemDefault());
+    final OffsetDateTime offsetDateTime =
+        OffsetDateTime.ofInstant(event.getTimestamp().toInstant(), ZoneOffset.systemDefault());
     final String date = DateTimeFormatter.ISO_DATE_TIME.format(offsetDateTime);
 
     HttpResponse response = null;
     try {
-      response = Unirest.put("http://localhost:" + this.port + "/collectionexercises/{id}/events/{tag}")
-          .routeParam("id", event.getCollectionExerciseId().toString())
-          .routeParam("tag", event.getTag())
-          .basicAuth(this.username, this.password)
-          .header("accept", "application/json")
-          .header("Content-Type", "text/plain")
-          .body(date)
-          .asObject(ResponseEventDTO.class);
+      response =
+          Unirest.put("http://localhost:" + this.port + "/collectionexercises/{id}/events/{tag}")
+              .routeParam("id", event.getCollectionExerciseId().toString())
+              .routeParam("tag", event.getTag())
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/json")
+              .header("Content-Type", "text/plain")
+              .body(date)
+              .asObject(ResponseEventDTO.class);
     } catch (UnirestException e) {
       throw new RuntimeException(
           String.format(
@@ -104,14 +105,12 @@ public class CollectionExerciseClient {
   /**
    * Calls the API to create a collection exercise
    *
-   * @param surveyId        survey to create collection exercise for
-   * @param exerciseRef     the period of the collection exercise
+   * @param surveyId survey to create collection exercise for
+   * @param exerciseRef the period of the collection exercise
    * @param userDescription the description of the collection exercise
-   * @return a Pair of the status code of the operation and the location at which
-   *         the new resource
-   *         has been created
-   * @throws CTPException thrown if an error occurred creating the collection
-   *                      exercise
+   * @return a Pair of the status code of the operation and the location at which the new resource
+   *     has been created
+   * @throws CTPException thrown if an error occurred creating the collection exercise
    */
   public Pair<Integer, String> createCollectionExercise(
       final UUID surveyId, final String exerciseRef, final String userDescription)
@@ -124,12 +123,13 @@ public class CollectionExerciseClient {
     inputDto.setSupplementaryDatasetEntity(null);
 
     try {
-      HttpResponse<String> createCollexResponse = Unirest.post("http://localhost:" + this.port + "/collectionexercises")
-          .basicAuth(this.username, this.password)
-          .header("accept", "application/json")
-          .header("Content-Type", "application/json")
-          .body(inputDto)
-          .asString();
+      HttpResponse<String> createCollexResponse =
+          Unirest.post("http://localhost:" + this.port + "/collectionexercises")
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/json")
+              .header("Content-Type", "application/json")
+              .body(inputDto)
+              .asString();
       int statusCode = createCollexResponse.getStatus();
       List<String> locations = createCollexResponse.getHeaders().get("Location");
       String location = locations != null && locations.size() > 0 ? locations.get(0) : null;
@@ -146,8 +146,7 @@ public class CollectionExerciseClient {
    *
    * @param collexId the uuid of the collection exercise
    * @return the full details of the collection exercise
-   * @throws CTPException thrown if an error occurred retrieving the collection
-   *                      exercise details
+   * @throws CTPException thrown if an error occurred retrieving the collection exercise details
    */
   CollectionExerciseDTO getCollectionExercise(final UUID collexId) throws CTPException {
     try {
@@ -166,13 +165,11 @@ public class CollectionExerciseClient {
   }
 
   /**
-   * Gets a collection exercise given the whole URI (e.g. as returned in a
-   * Location header)
+   * Gets a collection exercise given the whole URI (e.g. as returned in a Location header)
    *
    * @param uriStr the full URI of the collection exercise resource
    * @return a representation of the collection exercise
-   * @throws CTPException thrown if there was an error retrieving the collection
-   *                      exercise
+   * @throws CTPException thrown if there was an error retrieving the collection exercise
    */
   public CollectionExerciseDTO getCollectionExercise(final String uriStr) throws CTPException {
     try {
@@ -190,12 +187,11 @@ public class CollectionExerciseClient {
   /**
    * Calls the API to link a list of sample summaries to a collection exercise
    *
-   * @param collexId         the uuid of the collection exercise to link
+   * @param collexId the uuid of the collection exercise to link
    * @param sampleSummaryIds a list of the uuids of the sample summaries to link
    * @return the http status code of the operation
-   * @throws CTPException thrown if there was an error linking the sample
-   *                      summaries to the
-   *                      collection exercise
+   * @throws CTPException thrown if there was an error linking the sample summaries to the
+   *     collection exercise
    */
   private int linkSampleSummaries(final UUID collexId, final List<UUID> sampleSummaryIds)
       throws CTPException {
@@ -204,16 +200,17 @@ public class CollectionExerciseClient {
       for (UUID ssi : sampleSummaryIds) {
         arrayBuilder.add(ssi.toString());
       }
-      JsonObject jsonPayload = Json.createObjectBuilder().add("sampleSummaryIds", arrayBuilder).build();
+      JsonObject jsonPayload =
+          Json.createObjectBuilder().add("sampleSummaryIds", arrayBuilder).build();
 
-      HttpResponse<JsonNode> linkResponse = Unirest
-          .put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
-          .routeParam("id", collexId.toString())
-          .basicAuth(this.username, this.password)
-          .header("accept", "application/json")
-          .header("Content-Type", "application/json")
-          .body(jsonPayload.toString())
-          .asJson();
+      HttpResponse<JsonNode> linkResponse =
+          Unirest.put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+              .routeParam("id", collexId.toString())
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/json")
+              .header("Content-Type", "application/json")
+              .body(jsonPayload.toString())
+              .asJson();
 
       return linkResponse.getStatus();
     } catch (UnirestException e) {
@@ -224,11 +221,10 @@ public class CollectionExerciseClient {
   /**
    * Links a sample summary to a collection exercise
    *
-   * @param collexId        the uuid of the collection exercise to link
+   * @param collexId the uuid of the collection exercise to link
    * @param sampleSummaryId the uuid of the sample summary to link
-   * @throws CTPException thrown if there was an error linking the sample summary
-   *                      to the collection
-   *                      exercise
+   * @throws CTPException thrown if there was an error linking the sample summary to the collection
+   *     exercise
    * @see CollectionExerciseClient#linkSampleSummaries
    */
   void linkSampleSummary(final UUID collexId, final UUID sampleSummaryId) throws CTPException {
@@ -244,12 +240,13 @@ public class CollectionExerciseClient {
    */
   List<SampleLinkDTO> getSampleLinks(final UUID collexId) throws CTPException {
     try {
-      SampleLinkDTO[] linkArray = Unirest.get("http://localhost:" + this.port + "/collectionexercises/link/{id}")
-          .routeParam("id", collexId.toString())
-          .basicAuth(this.username, this.password)
-          .header("accept", "application/vnd.ons.sdc.samplelink.v1+json")
-          .asObject(SampleLinkDTO[].class)
-          .getBody();
+      SampleLinkDTO[] linkArray =
+          Unirest.get("http://localhost:" + this.port + "/collectionexercises/link/{id}")
+              .routeParam("id", collexId.toString())
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/vnd.ons.sdc.samplelink.v1+json")
+              .asObject(SampleLinkDTO[].class)
+              .getBody();
 
       return Arrays.asList(linkArray);
     } catch (UnirestException e) {
@@ -261,13 +258,14 @@ public class CollectionExerciseClient {
   public void createCollectionExerciseEvent(EventDTO event) {
     HttpResponse<String> response = null;
     try {
-      response = Unirest.post("http://localhost:" + this.port + "/collectionexercises/{id}/events")
-          .routeParam("id", event.getCollectionExerciseId().toString())
-          .basicAuth(this.username, this.password)
-          .header("accept", "application/json")
-          .header("Content-Type", "application/json")
-          .body(event)
-          .asString();
+      response =
+          Unirest.post("http://localhost:" + this.port + "/collectionexercises/{id}/events")
+              .routeParam("id", event.getCollectionExerciseId().toString())
+              .basicAuth(this.username, this.password)
+              .header("accept", "application/json")
+              .header("Content-Type", "application/json")
+              .body(event)
+              .asString();
     } catch (UnirestException e) {
       throw new RuntimeException(
           String.format(
@@ -291,7 +289,8 @@ public class CollectionExerciseClient {
     try {
       JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
       arrayBuilder.add(sampleSummaryId.toString());
-      JsonObject jsonPayload = Json.createObjectBuilder().add("sampleSummaryIds", arrayBuilder).build();
+      JsonObject jsonPayload =
+          Json.createObjectBuilder().add("sampleSummaryIds", arrayBuilder).build();
 
       Unirest.put("http://localhost:" + this.port + "/sample/summary-readiness")
           .basicAuth(this.username, this.password)

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseClient.java
@@ -5,6 +5,9 @@ import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -15,9 +18,6 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.springframework.http.HttpStatus;
 import uk.gov.ons.ctp.lib.common.UnirestInitialiser;
 import uk.gov.ons.ctp.response.collection.exercise.lib.common.error.CTPException;
@@ -196,10 +196,12 @@ public class CollectionExerciseClient {
   private int linkSampleSummaries(final UUID collexId, final List<UUID> sampleSummaryIds)
       throws CTPException {
     try {
-      JSONObject jsonPayload = new JSONObject();
-      JSONArray jsonSampleSummaryIds = new JSONArray();
-      sampleSummaryIds.forEach(ssi -> jsonSampleSummaryIds.put(ssi.toString()));
-      jsonPayload.put("sampleSummaryIds", jsonSampleSummaryIds);
+      JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+      for (UUID ssi : sampleSummaryIds) {
+        arrayBuilder.add(ssi.toString());
+      }
+      JsonObject jsonPayload =
+          Json.createObjectBuilder().add("sampleSummaryIds", arrayBuilder).build();
 
       HttpResponse<JsonNode> linkResponse =
           Unirest.put("http://localhost:" + this.port + "/collectionexercises/link/{id}")
@@ -211,8 +213,6 @@ public class CollectionExerciseClient {
               .asJson();
 
       return linkResponse.getStatus();
-    } catch (JSONException e) {
-      throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to create payload: %s", e);
     } catch (UnirestException e) {
       throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to serialize payload: %s", e);
     }
@@ -287,10 +287,10 @@ public class CollectionExerciseClient {
 
   private void sampleSummaryReady(final UUID sampleSummaryId) throws CTPException {
     try {
-      JSONObject jsonPayload = new JSONObject();
-      JSONArray jsonSampleSummaryId = new JSONArray();
-      jsonSampleSummaryId.put(sampleSummaryId);
-      jsonPayload.put("sampleSummaryId", jsonSampleSummaryId);
+      JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+      arrayBuilder.add(sampleSummaryId.toString());
+      JsonObject jsonPayload =
+          Json.createObjectBuilder().add("sampleSummaryIds", arrayBuilder).build();
 
       Unirest.put("http://localhost:" + this.port + "/sample/summary-readiness")
           .basicAuth(this.username, this.password)
@@ -299,8 +299,6 @@ public class CollectionExerciseClient {
           .body(jsonPayload)
           .asJson();
 
-    } catch (JSONException e) {
-      throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to create payload: %s", e);
     } catch (UnirestException e) {
       throw new CTPException(CTPException.Fault.SYSTEM_ERROR, "Failed to serialize payload: %s", e);
     }


### PR DESCRIPTION
# What and why?
org.json has vulnerabilities and hasn't been updated for years. jackson.json is up to date so this replaces it.

# How to test?
Run unit/integration tests

# Jira
RAS-924