### PR TITLE
Revert "change debug to info"

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.25
+version: 13.0.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.25
+appVersion: 13.0.24
 

--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.24
+version: 13.0.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.24
+appVersion: 13.0.26
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/client/SampleSvcClient.java
@@ -87,7 +87,7 @@ public class SampleSvcClient {
       queryParams.add("state", SampleUnitDTO.SampleUnitState.FAILED.name());
     }
 
-    log.with("sampleSummaryId", sampleSummaryId).info("request sample units for sample summary");
+    log.with("sampleSummaryId", sampleSummaryId).debug("request sample units for sample summary");
     UriComponents uriComponents =
         restUtility.createUriComponents(
             appConfig.getSampleSvc().getRequestSampleUnitsForSampleSummaryPath(),

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -695,7 +695,7 @@ public class CollectionExerciseEndpoint {
   private CollectionExerciseDTO getCollectionExerciseDTO(
       final CollectionExercise collectionExercise) {
     log.with("collection_exercise_id", collectionExercise.getId())
-        .info("Populating data for requested collection exercise");
+        .debug("Populating data for requested collection exercise");
 
     CollectionExerciseDTO collectionExerciseDTO =
         ObjectConverter.collectionExerciseDTO(collectionExercise);


### PR DESCRIPTION
Reverts ONSdigital/rm-collection-exercise-service#326

This PR needed to be reverted because I only changed the debugging levels for the purpose of testing things out in preprod, but we don't want these logging statements showing up in prod.

To test, run acceptance tests and check the logs for the pod. They shouldn't show up (use CTRL+F and type the logging messages to check) becuase they've gone back to being debug messages.