### PR TITLE
Adding allowed state transition for ENDED when CI_SAMPLE_DELETED

### DIFF
--- a/diagrams/collection-exercise-new-states.puml
+++ b/diagrams/collection-exercise-new-states.puml
@@ -23,5 +23,5 @@ VALIDATED --> READY_FOR_LIVE : publish
 VALIDATED --> LIVE : go_live
 READY_FOR_LIVE --> LIVE : go_live
 LIVE --> ENDED : end_exercise
-
+ENDED --> ENDED : ci_sample_deleted
 @enduml

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/state/CollectionExerciseStateTransitionManagerFactory.java
@@ -123,6 +123,12 @@ public class CollectionExerciseStateTransitionManagerFactory
     transitionLive.put(CollectionExerciseEvent.END_EXERCISE, CollectionExerciseState.ENDED);
     transitions.put(CollectionExerciseState.LIVE, transitionLive);
 
+    // ENDED
+    Map<CollectionExerciseEvent, CollectionExerciseState> transitionForENDED = new HashMap<>();
+    transitionForENDED.put(
+        CollectionExerciseEvent.CI_SAMPLE_DELETED, CollectionExerciseState.ENDED);
+    transitions.put(CollectionExerciseState.ENDED, transitionForENDED);
+
     return new BasicStateTransitionManager<>(transitions);
   }
 


### PR DESCRIPTION
# What and why?

Allowing sample unlink to be processed once the CE has ENDED.
