### PR TITLE
RAS-917 SupplementaryDatasetService dataset call via existsByExerciseFK not required

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.34
+version: 13.0.35
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.34
+appVersion: 13.0.35
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SupplementaryDatasetService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/SupplementaryDatasetService.java
@@ -37,10 +37,12 @@ public class SupplementaryDatasetService {
           supplementaryDatasetDTO.getPeriodId());
     }
     try {
-      if (existsByExerciseFK(collectionExercise.getExercisePK())) {
-        log.info(
-            "Supplementary dataset with exerciseFk {} has been found.",
-            collectionExercise.getExercisePK());
+      if (collectionExercise.getSupplementaryDatasetEntity() != null) {
+        log.with("collectionExerciseId", collectionExercise.getId())
+            .with(
+                "supplementaryDatasetId",
+                collectionExercise.getSupplementaryDatasetEntity().getSupplementaryDatasetId())
+            .info("Linked supplementary dataset found");
         supplementaryDatasetRepository.deleteByExerciseFK(collectionExercise.getExercisePK());
         log.info("Supplementary dataset has been removed.");
       }
@@ -76,9 +78,5 @@ public class SupplementaryDatasetService {
 
   public SupplementaryDatasetEntity findSupplementaryDataset(int exercisePk) {
     return supplementaryDatasetRepository.findByExerciseFK(exercisePk);
-  }
-
-  public boolean existsByExerciseFK(int exercisePK) {
-    return supplementaryDatasetRepository.existsByExerciseFK(exercisePK);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/SupplementaryDatasetServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collection/exercise/service/SupplementaryDatasetServiceTest.java
@@ -47,13 +47,12 @@ public class SupplementaryDatasetServiceTest {
 
   @Test
   public void testDeleteAndSaveSupplementaryDataset() throws CTPException, JsonProcessingException {
+    SupplementaryDatasetEntity supplementaryDatasetEntity = createSupplementaryDatasetEntity();
+    collectionExercise.setSupplementaryDatasetEntity(supplementaryDatasetEntity);
+
     when(collectionExerciseService.findCollectionExercise(
             supplementaryDatasetDTO.getSurveyId(), supplementaryDatasetDTO.getPeriodId()))
         .thenReturn(collectionExercise);
-    when(supplementaryDatasetRepository.existsByExerciseFK(collectionExercise.getExercisePK()))
-        .thenReturn(true);
-
-    SupplementaryDatasetEntity supplementaryDatasetEntity = createSupplementaryDatasetEntity();
 
     supplementaryDatasetService.addSupplementaryDatasetEntity(supplementaryDatasetDTO);
 


### PR DESCRIPTION
**This PR contains verified commits that were created and reviewed on branch of PR #338**

# What and why?
Changes how we check if an SDS in already linked to a collection exercise since the collection exercise already has the liked sds in scope through the ORM instead of querying the database every time.
# How to test?
- Deploy to your env
- Run the acceptance tests
- publish a message to your sds topic
```
{
      "survey_id": "139",
      "period_id": "1912",
      "form_types": [
         "0001"
        ],
      "title": "Quarterly Business Survey | QBS | 139 | 1912",
      "sds_published_at": "2023-08-24T11:55:00Z",
      "total_reporting_units": 1,
      "schema_version": "v1.0.0",
      "sds_dataset_version": 2,
      "filename": "eccb61ad-4eb3-4714-8afd-8c8426960b43.json",
      "dataset_id": "eccb61ad-4eb3-4714-8afd-8c8426960b43"
}
```
- make sure that in the logs there is no linked collection exercise found and that there is no log saying that the sds has been removed
- check an sds entry has been added to the database
- publish the same message again (you can edit the sds id to make sure that the old one has been removed and a new one added)
- Make sure the above logs are now present and the new sds entry is in the database`
# Jira
[RAS-917](https://jira.ons.gov.uk/browse/RAS-917)
