### PR TITLE
RAS-1184 Seft-ci-ingestion cloud function: Introduce HTTP client to retrieve collex

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.35
+version: 13.0.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.35
+appVersion: 13.0.36
 

--- a/_infra/helm/collection-exercise/templates/loadbalancer.yml
+++ b/_infra/helm/collection-exercise/templates/loadbalancer.yml
@@ -4,11 +4,11 @@ metadata:
   name: collection-exercise-lb
   annotations:
     networking.gke.io/load-balancer-type: "Internal"
-    networking.gke.io/load-balancer-ip-addresses: "collection-exercise-ip"
+    networking.gke.io/load-balancer-ip-addresses: {{ .Values.loadBalancer.ipAddress }}
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Cluster
-  loadBalancerIP: "collection-exercise-ip"
+  loadBalancerIP: {{ .Values.loadBalancer.ipAddress }}
   selector:
     app: collection-exercise
   ports:

--- a/_infra/helm/collection-exercise/templates/loadbalancer.yml
+++ b/_infra/helm/collection-exercise/templates/loadbalancer.yml
@@ -4,11 +4,11 @@ metadata:
   name: collection-exercise-lb
   annotations:
     networking.gke.io/load-balancer-type: "Internal"
-    networking.gke.io/load-balancer-ip-addresses: "10.110.0.16"
+    networking.gke.io/load-balancer-ip-addresses: "10.110.128.16"
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Cluster
-  loadBalancerIP: "10.110.0.16"
+  loadBalancerIP: "10.110.128.16"
   selector:
     app: collection-exercise
   ports:

--- a/_infra/helm/collection-exercise/templates/loadbalancer.yml
+++ b/_infra/helm/collection-exercise/templates/loadbalancer.yml
@@ -4,11 +4,11 @@ metadata:
   name: collection-exercise-lb
   annotations:
     networking.gke.io/load-balancer-type: "Internal"
-    networking.gke.io/load-balancer-ip-addresses: "10.110.128.16"
+    networking.gke.io/load-balancer-ip-addresses: "collection-exercise-ip"
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Cluster
-  loadBalancerIP: "10.110.128.16"
+  loadBalancerIP: "collection-exercise-ip"
   selector:
     app: collection-exercise
   ports:

--- a/_infra/helm/collection-exercise/templates/loadbalancer.yml
+++ b/_infra/helm/collection-exercise/templates/loadbalancer.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: service
+metadata:
+  name: collection-exercise-lb
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
+    networking.gke.io/load-balancer-ip-addresses: "10.110.0.16"
+
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  loadBalancerIP: "10.110.0.16"
+  selector:
+    app: collection-exercise
+  ports:
+    - name: tcp-port
+      protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/_infra/helm/collection-exercise/templates/loadbalancer.yml
+++ b/_infra/helm/collection-exercise/templates/loadbalancer.yml
@@ -1,17 +1,16 @@
 apiVersion: v1
-kind: service
+kind: Service
 metadata:
   name: collection-exercise-lb
   annotations:
     networking.gke.io/load-balancer-type: "Internal"
     networking.gke.io/load-balancer-ip-addresses: "10.110.0.16"
-
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Cluster
   loadBalancerIP: "10.110.0.16"
   selector:
-    app: {{ .Chart.Name }}
+    app: collection-exercise
   ports:
     - name: tcp-port
       protocol: TCP

--- a/_infra/helm/collection-exercise/templates/loadbalancer.yml
+++ b/_infra/helm/collection-exercise/templates/loadbalancer.yml
@@ -11,7 +11,7 @@ spec:
   externalTrafficPolicy: Cluster
   loadBalancerIP: "10.110.0.16"
   selector:
-    app: collection-exercise
+    app: {{ .Chart.Name }}
   ports:
     - name: tcp-port
       protocol: TCP

--- a/_infra/helm/collection-exercise/templates/service.yaml
+++ b/_infra/helm/collection-exercise/templates/service.yaml
@@ -7,6 +7,7 @@ spec:
   ports:
   - port: {{ .Values.service.port }}
     targetPort: {{ .Values.container.port }}
+    nodePort: {{ .Values.nodePort.port }}
     protocol: TCP
   selector:
     app: {{ .Chart.Name }}

--- a/_infra/helm/collection-exercise/templates/service.yaml
+++ b/_infra/helm/collection-exercise/templates/service.yaml
@@ -3,11 +3,10 @@ kind: Service
 metadata:
   name: {{ .Chart.Name }}
 spec:
-  type: ClusterIp
+  type: ClusterIP
   ports:
   - port: {{ .Values.service.port }}
     targetPort: {{ .Values.container.port }}
-    nodePort: {{ .Values.nodePort.port }}
     protocol: TCP
   selector:
     app: {{ .Chart.Name }}

--- a/_infra/helm/collection-exercise/templates/service.yaml
+++ b/_infra/helm/collection-exercise/templates/service.yaml
@@ -3,8 +3,7 @@ kind: Service
 metadata:
   name: {{ .Chart.Name }}
 spec:
-  externalTrafficPolicy: Local
-  type: LoadBalancer
+  type: ClusterIP
   ports:
   - port: {{ .Values.service.port }}
     targetPort: {{ .Values.container.port }}

--- a/_infra/helm/collection-exercise/templates/service.yaml
+++ b/_infra/helm/collection-exercise/templates/service.yaml
@@ -3,7 +3,8 @@ kind: Service
 metadata:
   name: {{ .Chart.Name }}
 spec:
-  type: ClusterIP
+  externalTrafficPolicy: Local
+  type: LoadBalancer
   ports:
   - port: {{ .Values.service.port }}
     targetPort: {{ .Values.container.port }}

--- a/_infra/helm/collection-exercise/templates/service.yaml
+++ b/_infra/helm/collection-exercise/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Chart.Name }}
 spec:
-  type: ClusterIP
+  type: NodePort
   ports:
   - port: {{ .Values.service.port }}
     targetPort: {{ .Values.container.port }}

--- a/_infra/helm/collection-exercise/templates/service.yaml
+++ b/_infra/helm/collection-exercise/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Chart.Name }}
 spec:
-  type: NodePort
+  type: ClusterIp
   ports:
   - port: {{ .Values.service.port }}
     targetPort: {{ .Values.container.port }}

--- a/_infra/helm/collection-exercise/values.yaml
+++ b/_infra/helm/collection-exercise/values.yaml
@@ -73,3 +73,6 @@ gcp:
   collectionExerciseEventStatusUpdateSubscription: collection-exercise-event-update
   supplementaryDataServiceTopic: supplementary-data-service-topic
   supplementaryDataServiceSubscription: supplementary-data-service-subscription
+
+loadBalancer:
+  ipAddress: "10.110.128.12"

--- a/_infra/helm/collection-exercise/values.yaml
+++ b/_infra/helm/collection-exercise/values.yaml
@@ -26,8 +26,6 @@ container:
   port: 8080
 service:
   port: 8080
-nodePort:
-  port: 30009
 
 resources:
   application:

--- a/_infra/helm/collection-exercise/values.yaml
+++ b/_infra/helm/collection-exercise/values.yaml
@@ -26,6 +26,8 @@ container:
   port: 8080
 service:
   port: 8080
+nodePort:
+  port: 30009
 
 resources:
   application:


### PR DESCRIPTION
# What and why?
Changing collection exercise service to a NodePort instead of a ClusterIP to allow access from outside the kubernetes environment to give access to the cloud function
# How to test?
Follow test for https://github.com/ONSdigital/ras-rm-cloud-functions/pull/52
# Jira
https://jira.ons.gov.uk/browse/RAS-1184