### PR TITLE
RAS-1238 Update to docker compose from docker-compose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,11 @@ jobs:
         run: |
           gcloud auth configure-docker
 
+      - name: Chmod docker scripts
+        run: |
+          chmod +x docker-compose-down.sh
+          chmod +x docker-compose-up.sh
+
       - name: Run Tests
         run: |
           export LD_LIBRARY_PATH=/usr/local/lib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,10 +57,6 @@ jobs:
 
       - name: Run Tests
         run: |
-          ls -l
-          chmod +x docker-compose-down.sh
-          chmod +x docker-compose-up.sh
-          ls -l
           export LD_LIBRARY_PATH=/usr/local/lib
           mvn fmt:check
           mvn clean verify

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,13 +55,12 @@ jobs:
         run: |
           gcloud auth configure-docker
 
-      - name: Chmod docker scripts
-        run: |
-          chmod +x docker-compose-down.sh
-          chmod +x docker-compose-up.sh
-
       - name: Run Tests
         run: |
+          ls -l
+          chmod +x docker-compose-down.sh
+          chmod +x docker-compose-up.sh
+          ls -l
           export LD_LIBRARY_PATH=/usr/local/lib
           mvn fmt:check
           mvn clean verify

--- a/docker-compose-down.sh
+++ b/docker-compose-down.sh
@@ -1,0 +1,1 @@
+docker compose down

--- a/docker-compose-up.sh
+++ b/docker-compose-up.sh
@@ -1,0 +1,1 @@
+docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  postgres:
   container_name: postgres-it

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.codehaus.mojo/exec-maven-plugin -->
+        <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.4.0</version>
+        </dependency>
+
+
     </dependencies>
 
     <build>
@@ -372,39 +380,40 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.dkanejs.maven.plugins</groupId>
-                <artifactId>docker-compose-maven-plugin</artifactId>
-                <version>4.0.0</version>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
                 <executions>
                     <execution>
                         <id>pre-stop</id>
                         <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>down</goal>
+                            <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                            <executable>docker-compose-down.sh</executable>
                         </configuration>
                     </execution>
                     <execution>
                         <id>up</id>
                         <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>up</goal>
+                            <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-                            <detachedMode>true</detachedMode>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                            <executable>docker-compose-up.sh</executable>
                         </configuration>
                     </execution>
                     <execution>
                         <id>down</id>
                         <phase>post-integration-test</phase>
                         <goals>
-                            <goal>down</goal>
+                            <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                            <executable>docker-compose-down.sh</executable>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
# What and why?
This PR replaces our use of the `docker-compose-maven-plugin` as that is still using `docker-compose` that has been removed
# How to test?
Check the build
# Jira
[RAS-1238](https://jira.ons.gov.uk/browse/RAS-1238)