### PR TITLE
making collection exercise load balancer configurable

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.36
+version: 13.0.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.36
+appVersion: 13.0.37
 

--- a/_infra/helm/collection-exercise/templates/loadbalancer.yml
+++ b/_infra/helm/collection-exercise/templates/loadbalancer.yml
@@ -1,3 +1,4 @@
+{{ if .Values.loadBalancer.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
       protocol: TCP
       port: 80
       targetPort: 8080
+{{ end }}

--- a/_infra/helm/collection-exercise/values.yaml
+++ b/_infra/helm/collection-exercise/values.yaml
@@ -76,3 +76,4 @@ gcp:
 
 loadBalancer:
   ipAddress: "10.110.128.12"
+  enabled: true


### PR DESCRIPTION
# What and why?
Allows us to disable the collection exercise load balancer
# How to test?
Helm install collection exercise after updating `values.yaml`
- `loadBalancer.enabled: false`
- `env: dev`
- `namespace: <your-namespace>`
- `image.tag: pr-343`
Make sure that there is no collection exercise load balancer service deployed when you run `kubectl get sercives`
# Jira
[RAS-1247](https://jira.ons.gov.uk/browse/RAS-1247)