### PR TITLE
Extend get ces for surveys

### DIFF
--- a/_infra/helm/collection-exercise/Chart.yaml
+++ b/_infra/helm/collection-exercise/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.46
+version: 13.0.47
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.46
+appVersion: 13.0.47
 

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/endpoint/CollectionExerciseEndpoint.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.validation.ConstraintViolation;
 import javax.validation.Valid;
 import javax.validation.Validation;
@@ -176,7 +177,7 @@ public class CollectionExerciseEndpoint {
   }
 
   /**
-   * Return collection exercises for each of the the surveys in the given list of survey ids. Return
+   * Return collection exercises for each of the surveys in the given list of survey ids. Return
    * data as a Json dictionary.
    *
    * @param surveyIds survey Ids for which to get collection exercises
@@ -186,10 +187,16 @@ public class CollectionExerciseEndpoint {
    */
   @RequestMapping(value = "/surveys", method = RequestMethod.GET, produces = "application/json")
   public ResponseEntity<HashMap> getCollectionExercisesForSurveys(
-      final @RequestParam List<UUID> surveyIds,
+      final @Nullable @RequestParam List<UUID> surveyIds,
       @RequestParam("liveOnly") Optional<Boolean> liveOnly) {
 
+    if (surveyIds == null) {
+      log.debug("No survey ids passed");
+      return ResponseEntity.noContent().build();
+    }
+
     HashMap<UUID, List<CollectionExercise>> surveyCollexMap;
+    HashMap<UUID, List<CollectionExerciseDTO>> surveyCollexMapWithEvents = new HashMap<>();
 
     if (liveOnly.isPresent() && liveOnly.get().booleanValue()) {
       surveyCollexMap =
@@ -199,7 +206,21 @@ public class CollectionExerciseEndpoint {
       surveyCollexMap = collectionExerciseService.findCollectionExercisesForSurveys(surveyIds);
     }
 
-    return ResponseEntity.ok(surveyCollexMap);
+    List<CollectionExerciseDTO> collectionExerciseSummaryDTOList;
+
+    for (Map.Entry<UUID, List<CollectionExercise>> current : surveyCollexMap.entrySet()) {
+      UUID surveyId = current.getKey();
+      List<CollectionExercise> collectionExerciseList = current.getValue();
+
+      collectionExerciseSummaryDTOList =
+          collectionExerciseList
+              .stream()
+              .map(this::getCollectionExerciseDTO)
+              .collect(Collectors.toList());
+      surveyCollexMapWithEvents.put(surveyId, collectionExerciseSummaryDTOList);
+    }
+
+    return ResponseEntity.ok(surveyCollexMapWithEvents);
   }
 
   /**


### PR DESCRIPTION
# This has the same changes as https://github.com/ONSdigital/rm-collection-exercise-service/pull/351 that was reverted because of a problem with https://github.com/ONSdigital/ras-frontstage/pull/1032

# What and why?
Swaps out the get collection exercises by survey id with get collection exercises by survey ids to reduce the number of calls to collection exercise from one per survey the respondent has, to just one for all the surveys the respondent has
# How to test?
- deploy this pr and https://github.com/ONSdigital/ras-frontstage/pull/1042 to your environment
- run acceptance tests
- set up another CE for QBS and one for a new survey
- log into frontstage and make sure the user interface looks the same on the todo and history pages
- go to the database and set the collection exercise state to ENDED
- make sure it doesn’t show up in the Todo or History pages in frontstage
# Jira
[RAS-1401](https://jira.ons.gov.uk/browse/RAS-1401)